### PR TITLE
[REG-1107] Make RGSettings threadsafe and performant but still reactive

### DIFF
--- a/Editor/Scripts/RGSettingsUIRegistrar.cs
+++ b/Editor/Scripts/RGSettingsUIRegistrar.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using RegressionGames;
 using RegressionGames.Types;
 using UnityEditor;
 using UnityEngine;
@@ -42,14 +41,14 @@ namespace RegressionGames.Editor
                     SerializedProperty passwordField = settings.FindProperty("password");
                     passwordField.stringValue = EditorGUILayout.PasswordField("RG Password", passwordField.stringValue);
 
-                    SerializedProperty logLevel = settings.FindProperty("logLevel");
-                    logLevel.enumValueIndex = (int)(DebugLogLevel)EditorGUILayout.EnumPopup("Log Level", (DebugLogLevel)logLevel.enumValueIndex);
-                    
                     SerializedProperty useSystemSettings = settings.FindProperty("useSystemSettings");
                     useSystemSettings.boolValue =
                         EditorGUILayout.Toggle("Use Global Settings ?", useSystemSettings.boolValue);
                     EditorGUI.BeginDisabledGroup(useSystemSettings.boolValue != true);
                     EditorGUI.BeginChangeCheck();
+                    
+                    SerializedProperty logLevel = settings.FindProperty("logLevel");
+                    logLevel.enumValueIndex = (int)(DebugLogLevel)EditorGUILayout.EnumPopup("Log Level", (DebugLogLevel)logLevel.enumValueIndex);
                     SerializedProperty numBotsProp = settings.FindProperty("numBots");
                     numBotsProp.intValue = EditorGUILayout.IntSlider("Number Of Bots", numBotsProp.intValue, 0, 7, new GUILayoutOption[] { });
 
@@ -126,6 +125,7 @@ namespace RegressionGames.Editor
                             priorUser = null;
                         }
                         AssetDatabase.SaveAssets();
+                        RGSettings.OptionsUpdated();
                         RGSettingsDynamicEnabler[] objects = GameObject.FindObjectsOfType<RGSettingsDynamicEnabler>(true);
                         foreach (RGSettingsDynamicEnabler rgSettingsDynamicEnabler in objects)
                         {

--- a/Runtime/Scripts/RGAgentTypes.meta
+++ b/Runtime/Scripts/RGAgentTypes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a64d04bf90664f53b95eeb95346eb83
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/RGSettings.cs
+++ b/Runtime/Scripts/RGSettings.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEditor;
 using UnityEngine;
 
@@ -16,23 +17,60 @@ namespace RegressionGames
         [SerializeField] private string password;
         [SerializeField] private int[] botsSelected;
         [SerializeField] private DebugLogLevel logLevel;
+
+        /*
+         * This is setup to be safely callable on the non-main thread.
+         * Options will update as soon as called on main thread once marked dirty.
+         */
+        private static RGSettings _settings = null;
+        private static bool dirty = true;
         
         public static RGSettings GetOrCreateSettings()
         {
-            RGSettings settings = AssetDatabase.LoadAssetAtPath<RGSettings>(SETTINGS_PATH);
-            if (settings == null)
+            if (_settings == null || dirty)
             {
-                settings = CreateInstance<RGSettings>();
-                settings.useSystemSettings = false;
-                settings.enableOverlay = true;
-                settings.numBots = 0;
-                settings.email = "rgunitydev@rgunity.com";
-                settings.password = "Password1";
-                settings.botsSelected = new int[0];
-                AssetDatabase.CreateAsset(settings, SETTINGS_PATH);
+                try
+                {
+                    _settings = AssetDatabase.LoadAssetAtPath<RGSettings>(SETTINGS_PATH);
+                    dirty = false;
+                }
+                catch (Exception ex)
+                {
+                    // if not called on main thread this will exception
+                }
+            }
+
+            if (_settings == null)
+            {
+                _settings = CreateInstance<RGSettings>();
+                _settings.useSystemSettings = false;
+                _settings.enableOverlay = true;
+                _settings.numBots = 0;
+                _settings.email = "rgunitydev@rgunity.com";
+                _settings.password = "Password1";
+                _settings.botsSelected = new int[0];
+                AssetDatabase.CreateAsset(_settings, SETTINGS_PATH);
                 AssetDatabase.SaveAssets();
             }
-            return settings;
+            
+            return _settings;
+        }
+
+        public static void OptionsUpdated()
+        {
+            //mark dirty
+            dirty = true;
+            try
+            {
+                // try to update and mark clean, but if failed
+                // will keep trying to update until clean
+                _settings = AssetDatabase.LoadAssetAtPath<RGSettings>(SETTINGS_PATH);
+                dirty = false;
+            }
+            catch (Exception ex)
+            {
+                // if not called on main thread this will exception
+            }
         }
 
         public static SerializedObject GetSerializedSettings()


### PR DESCRIPTION
For those having connection issues with the current state of the RGUnityBots integration, the problem is some Unhandled exceptions happening from calls made in the new logging system.

Specifically.. LoadAssetAtPath inside RGSettings.GetOrCreateSettings is now getting called from a location not running on the main thread.  It also exposed something I missed in code review, which is that we are now calling this on every log statement, thus causing an asset load from disk on every log statement (bad performance 👎)

This PR will make the RGSettings still be live reactive to editor settings changes, while being safe on the main thread, and avoiding reading from disk on every call.

This PR also moves the log settings inside the watched properties so that log settings changes are reactive nearly immediately.