### PR TITLE
[REG-1183] Cleanup RGCertOnlyPublicKey to not log off main thread

### DIFF
--- a/Runtime/Scripts/RGCertificateHolder.cs
+++ b/Runtime/Scripts/RGCertificateHolder.cs
@@ -3,29 +3,39 @@
 using System.Security.Cryptography.X509Certificates;
 using UnityEngine.Networking;
 using System.IO;
+using JetBrains.Annotations;
 
 namespace RegressionGames
 {
     // tls/ssl seems to not be working correctly on some versions, so use this instead for now.
     class RGCertOnlyPublicKey : CertificateHandler
     {
-        private readonly static X509Certificate2 RG_CERT;
+        private X509Certificate2 RG_CERT;
 
-        static RGCertOnlyPublicKey()
+        [CanBeNull] private static RGCertOnlyPublicKey _this = null;
+        
+        public static RGCertOnlyPublicKey GetInstance()
         {
-            if (RG_CERT == null) {
-                var certFile = Path.GetFullPath("Packages/gg.regression.unity.bots/Runtime/Resources/regression_cert.cer");
-                RGDebug.LogVerbose("RG Cert loaded"+certFile);
-                RG_CERT = new X509Certificate2(certFile);
+            if (_this == null)
+            {
+                _this = new RGCertOnlyPublicKey();
             }
+
+            return _this;
+        }
+
+        private RGCertOnlyPublicKey()
+        {
+            var certFile = Path.GetFullPath("Packages/gg.regression.unity.bots/Runtime/Resources/regression_cert.cer");
+            RG_CERT = new X509Certificate2(certFile);
         }
 
         protected override bool ValidateCertificate(byte[] certificateData)
         {
             X509Certificate2 certificate = new X509Certificate2(certificateData);
-            string pk = certificate.GetPublicKeyString();
-            RGDebug.LogVerbose("Comparing Cert: " + certificate.ToString());
-            return pk.Equals(RG_CERT.GetPublicKeyString());
+            string pk = RG_CERT.GetPublicKeyString();
+            string ck = certificate.GetPublicKeyString();
+            return pk.Equals(ck);
         }
     }
 }

--- a/Runtime/Scripts/RGServiceManager.cs
+++ b/Runtime/Scripts/RGServiceManager.cs
@@ -304,7 +304,7 @@ namespace RegressionGames
 
             if (webRequest.uri.Scheme.Equals(Uri.UriSchemeHttps))
             {
-                webRequest.certificateHandler = new RGCertOnlyPublicKey();
+                webRequest.certificateHandler = RGCertOnlyPublicKey.GetInstance();
             }
         }
 


### PR DESCRIPTION
- Fixes a bug where we were logging off the main thread and causing certs to fail to load sometimes