### PR TITLE
[REG-1205] Log error for instant bot queueing

### DIFF
--- a/Runtime/Scripts/RGOverlayMenu.cs
+++ b/Runtime/Scripts/RGOverlayMenu.cs
@@ -28,8 +28,8 @@ namespace RegressionGames
         public TMP_Dropdown nextBotDropdown;
         
         private static List<RGBotInstance> activeBots = new List<RGBotInstance>();
-
-        private List<long> invalidBotIds = new List<long>();
+        
+        private ConcurrentBag<long> invalidBotIds = new ConcurrentBag<long>();
 
         private int lastCount = -1;
 

--- a/Runtime/Scripts/RGOverlayMenu.cs
+++ b/Runtime/Scripts/RGOverlayMenu.cs
@@ -29,6 +29,8 @@ namespace RegressionGames
         
         private static List<RGBotInstance> activeBots = new List<RGBotInstance>();
 
+        private List<long> invalidBotIds = new List<long>();
+
         private int lastCount = -1;
 
         private static RGOverlayMenu _this = null;
@@ -205,6 +207,7 @@ namespace RegressionGames
                                 },
                                 () =>
                                 {
+                                    invalidBotIds.Add(bot.id);
                                     if (Interlocked.Increment(ref count) >= bots.Length)
                                     {
                                         // we hit the last async result.. do the update processing
@@ -226,6 +229,13 @@ namespace RegressionGames
 
         private void ProcessBotUpdateList(ConcurrentBag<RGBotInstance> instances)
         {
+            // Log if we have any invalid bot ids
+            if (invalidBotIds.Count > 0)
+            {
+                string botIds = string.Join(", ", invalidBotIds);
+                RGDebug.LogWarning($"Failed to get running bot instances for bots: [{botIds}]");
+            }
+            invalidBotIds.Clear();
             List<RGBotInstance> botInstances = instances.Distinct().ToList();
             // sort by id ascending, since the ids are DB ids, this should keep them in creation order
             botInstances.Sort((a, b) => (int)(b.id - a.id));

--- a/Runtime/Scripts/RGOverlayMenu.cs
+++ b/Runtime/Scripts/RGOverlayMenu.cs
@@ -200,7 +200,7 @@ namespace RegressionGames
                                     if (Interlocked.Increment(ref count) >= bots.Length)
                                     {
                                         // we hit the last async result.. do the update processing
-                                        processBotUpdateList(instances);
+                                        ProcessBotUpdateList(instances);
                                     }
                                 },
                                 () =>
@@ -208,7 +208,7 @@ namespace RegressionGames
                                     if (Interlocked.Increment(ref count) >= bots.Length)
                                     {
                                         // we hit the last async result.. do the update processing
-                                        processBotUpdateList(instances);
+                                        ProcessBotUpdateList(instances);
                                     }
                                 }
                             );
@@ -216,7 +216,7 @@ namespace RegressionGames
                         else if (Interlocked.Increment(ref count) >= bots.Length)
                         {
                             // we hit the last async result.. do the update processing
-                            processBotUpdateList(instances);
+                            ProcessBotUpdateList(instances);
                         }
                     }
                     nextBotDropdown.options = dropOptions;
@@ -224,7 +224,7 @@ namespace RegressionGames
                 () => { });
         }
 
-        private void processBotUpdateList(ConcurrentBag<RGBotInstance> instances)
+        private void ProcessBotUpdateList(ConcurrentBag<RGBotInstance> instances)
         {
             List<RGBotInstance> botInstances = instances.Distinct().ToList();
             // sort by id ascending, since the ids are DB ids, this should keep them in creation order

--- a/Runtime/Scripts/RGServiceManager.cs
+++ b/Runtime/Scripts/RGServiceManager.cs
@@ -244,7 +244,7 @@ namespace RegressionGames
                 },
                 onFailure: async (f) =>
                 {
-                    RGDebug.LogWarning($"Failed to stop bot instance: {f}");
+                    RGDebug.LogWarning($"Failed to stop bot instance {botInstanceId}: {f}");
                     onFailure.Invoke();
                 }
             );

--- a/Runtime/Scripts/RGServiceManager.cs
+++ b/Runtime/Scripts/RGServiceManager.cs
@@ -150,6 +150,7 @@ namespace RegressionGames
                 },
                 onFailure: async (f) =>
                 {
+                    RGDebug.LogWarning($"Failed retrieving bots for current user: {f}");
                     onFailure.Invoke();
                 }
             );
@@ -172,7 +173,11 @@ namespace RegressionGames
                         RGDebug.LogDebug($"RG Bot Instance external connection info: {connInfo}");
                         onSuccess.Invoke(connInfo);
                     },
-                    onFailure: async (f) => { onFailure.Invoke(); }
+                    onFailure: async (f) =>
+                    {
+                        RGDebug.LogWarning($"Failed retrieving external connection information: {f}");
+                        onFailure.Invoke();
+                    }
                 );
             }
             catch (Exception ex)
@@ -198,6 +203,7 @@ namespace RegressionGames
                 },
                 onFailure: async (f) =>
                 {
+                    RGDebug.LogWarning($"Failed to queue instance bot: {f}");
                     onFailure.Invoke();
                 }
             );
@@ -220,6 +226,7 @@ namespace RegressionGames
                 },
                 onFailure: async (f) =>
                 {
+                    RGDebug.LogWarning($"Failed to get running instance for bot: {f}");
                     onFailure.Invoke();
                 }
             );
@@ -240,6 +247,7 @@ namespace RegressionGames
                 },
                 onFailure: async (f) =>
                 {
+                    RGDebug.LogWarning($"Failed to stop bot instance: {f}");
                     onFailure.Invoke();
                 }
             );

--- a/Runtime/Scripts/RGServiceManager.cs
+++ b/Runtime/Scripts/RGServiceManager.cs
@@ -203,7 +203,6 @@ namespace RegressionGames
                 },
                 onFailure: async (f) =>
                 {
-                    RGDebug.LogWarning($"Failed to queue instance bot: {f}");
                     onFailure.Invoke();
                 }
             );
@@ -226,7 +225,6 @@ namespace RegressionGames
                 },
                 onFailure: async (f) =>
                 {
-                    RGDebug.LogWarning($"Failed to get running instance for bot: {f}");
                     onFailure.Invoke();
                 }
             );

--- a/Runtime/Scripts/RGServiceManager.cs
+++ b/Runtime/Scripts/RGServiceManager.cs
@@ -175,7 +175,6 @@ namespace RegressionGames
                     },
                     onFailure: async (f) =>
                     {
-                        RGDebug.LogWarning($"Failed retrieving external connection information: {f}");
                         onFailure.Invoke();
                     }
                 );


### PR DESCRIPTION
Looking at the comments here:
https://linear.app/regression-games/issue/REG-1205/log-error-for-instant-bot-queueing

It's possible no further information is available, except to determine which service has failed. Is the value added by the warning messages worth the extra inspector logs? 