### PR TITLE
[REG-1209] - Set canvas to relative screen size, not constant size

### DIFF
--- a/Runtime/Prefabs/RGOverlayCanvas.prefab
+++ b/Runtime/Prefabs/RGOverlayCanvas.prefab
@@ -2533,12 +2533,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 800, y: 600}
   m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
+  m_MatchWidthOrHeight: 0.5
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96


### PR DESCRIPTION
Changes:
* Canvas scaler on overlay now has default setting of "Scale with screen size" instead of "Constant Pixels", which can remove the need for devs to adjust it when first adding it to scene