### PR TITLE
[REG-1308] Update characterConfig to Map and RG api enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ crashlytics-build.properties
 mono_crash*.json
 
 **/.DS_Store
+.DS_Store

--- a/Runtime/Scripts/Attributes/RGStateAttribute.cs
+++ b/Runtime/Scripts/Attributes/RGStateAttribute.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace RegressionGames
 {
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Delegate, Inherited = false, AllowMultiple = false)]
     public class RGStateAttribute : Attribute
     {
         public string StateName { get; }

--- a/Runtime/Scripts/RGBotLocalRuntime/SampleBot/RGSampleBot.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/SampleBot/RGSampleBot.cs
@@ -8,7 +8,6 @@ namespace RegressionGames.RGBotLocalRuntime.SampleBot
 {
     public class RGSampleBot : RGUserBot
     {
-
         protected override bool GetIsSpawnable()
         {
             return true;
@@ -22,8 +21,11 @@ namespace RegressionGames.RGBotLocalRuntime.SampleBot
         public override void ConfigureBot(RG rgObject)
         {
             var classIndex = new Random().Next(4);
-            var classes = new string[] {"Mage", "Rogue", "Tank", "Archer"};
-            rgObject.CharacterConfig = $"{{\"characterType\": \"{classes[classIndex]}\"}}";
+            var classes = new[] { "Mage", "Rogue", "Tank", "Archer" };
+            rgObject.CharacterConfig = new Dictionary<string, object>
+            {
+                { "characterType", $"{classes[classIndex]}" }
+            };
         }
 
         public override void ProcessTick(RG rgObject)
@@ -38,13 +40,13 @@ namespace RegressionGames.RGBotLocalRuntime.SampleBot
 
                     var targetPosition = target.position ?? Vector3.zero;
                     //TODO (REG-1302): If Actions were strongly typed we wouldn't need to build this weird map...
-                    var action = new RGActionRequest("PerformSkill", new Dictionary<string, object>()
+                    var action = new RGActionRequest("PerformSkill", new Dictionary<string, object>
                     {
                         { "skillId", new Random().Next(2) },
                         { "targetId", target["id"] },
                         { "xPosition", targetPosition.x },
                         { "yPosition", targetPosition.y },
-                        { "zPosition", targetPosition.z },
+                        { "zPosition", targetPosition.z }
                     });
                     rgObject.PerformAction(action);
                 }

--- a/Runtime/Scripts/RGBotLocalRuntime/Template/BotEntryPoint.cs.template
+++ b/Runtime/Scripts/RGBotLocalRuntime/Template/BotEntryPoint.cs.template
@@ -24,7 +24,10 @@ namespace <TEMPLATE_NAMESPACE>
         {
             var classIndex = new System.Random().Next(4);
             var classes = new string[] {"Mage", "Rogue", "Tank", "Archer"};
-            rgObject.CharacterConfig = $"{{\"characterType\": \"{classes[classIndex]}\"}}";
+            rgObject.CharacterConfig = new Dictionary<string, object>
+            {
+                { "characterType", $"{classes[classIndex]}" }
+            };
         }
 
         public override void ProcessTick(RG rgObject)

--- a/Runtime/Scripts/RGBotServerListener.cs
+++ b/Runtime/Scripts/RGBotServerListener.cs
@@ -617,7 +617,7 @@ namespace RegressionGames
                     {
                         botName += clientIdStringSuffix;
                     }
-                    string characterConfig = handshakeMessage.characterConfig;
+                    Dictionary<string, object> characterConfig = handshakeMessage.characterConfig;
 
                     // save the token the client gave us for talking to them
                     clientConnectionMap[clientId].Token = handshakeMessage.rgToken;

--- a/Runtime/Scripts/RGServiceManager.cs
+++ b/Runtime/Scripts/RGServiceManager.cs
@@ -203,6 +203,10 @@ namespace RegressionGames
                     }
                 );
             }
+            else
+            {
+                onFailure();
+            }
         }
 
         public async Task GetExternalConnectionInformationForBotInstance(long botInstanceId, Action<RGBotInstanceExternalConnectionInfo> onSuccess, Action onFailure)
@@ -222,6 +226,10 @@ namespace RegressionGames
                     },
                     onFailure: async (f) => { onFailure.Invoke(); }
                 );
+            }
+            else
+            {
+                onFailure();
             }
         }
 
@@ -244,6 +252,10 @@ namespace RegressionGames
                     },
                     onFailure: async (f) => { onFailure.Invoke(); }
                 );
+            }    
+            else
+            {
+                onFailure();
             }
         }
 
@@ -266,6 +278,10 @@ namespace RegressionGames
                     onFailure: async (f) => { onFailure.Invoke(); }
                 );
             }
+            else
+            {
+                onFailure();
+            }
         }
 
         public async Task StopBotInstance(long botInstanceId, Action onSuccess, Action onFailure)
@@ -283,6 +299,10 @@ namespace RegressionGames
                         onFailure.Invoke();
                     }
                 );
+            }
+            else
+            {
+                onFailure();
             }
         }
 

--- a/Runtime/Scripts/StateActionTypes/RGStateEntity.cs
+++ b/Runtime/Scripts/StateActionTypes/RGStateEntity.cs
@@ -14,10 +14,22 @@ namespace RegressionGames.StateActionTypes
         public int id => (int)this.GetValueOrDefault("id", 0);
         public string type => (string)this.GetValueOrDefault("type", null);
         public bool isPlayer => (bool)this.GetValueOrDefault("isPlayer", false);
+
         public bool isRuntimeObject => (bool)this.GetValueOrDefault("isRuntimeObject", false);
+
         // TODO (REG-1303): These should be non-nullable and we should remove the option NOT to sync position and rotation
         public Vector3? position => (Vector3?)this.GetValueOrDefault("position", null);
         public Quaternion? rotation => (Quaternion?)this.GetValueOrDefault("rotation", null);
         public long? clientId => (long?)this.GetValueOrDefault("clientId", null);
+
+        public object GetField(string fieldName)
+        {
+            if (TryGetValue(fieldName, out var result))
+            {
+                return result;
+            }
+
+            return null;
+        }
     }
 }

--- a/Runtime/Scripts/Types/BotInformation.cs
+++ b/Runtime/Scripts/Types/BotInformation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace RegressionGames.Types
@@ -6,11 +7,14 @@ namespace RegressionGames.Types
     [Serializable]
     public class BotInformation
     {
+        // ReSharper disable InconsistentNaming
         public long clientId;
         public string botName;
-        public string characterConfig;
 
-        public BotInformation(long clientId, string botName, string characterConfig)
+        public Dictionary<string, object> characterConfig;
+        // ReSharper enable InconsistentNaming
+
+        public BotInformation(long clientId, string botName, Dictionary<string, object> characterConfig)
         {
             this.clientId = clientId;
             this.botName = botName;
@@ -19,12 +23,12 @@ namespace RegressionGames.Types
 
         /**
          * <summary>
-         * Parses the JSON from characterConfig into the serialized data type
-         * passed into the generic of this function.
+         *     Parses the JSON from characterConfig into the serialized data type
+         *     passed into the generic of this function.
          * </summary>
          * <returns>An object of type T deserialized from the JSON string</returns>
          * <example>
-         * <code>
+         *     <code>
          * [Serializable]
          * public class BotCharacterConfig
          * {
@@ -37,19 +41,19 @@ namespace RegressionGames.Types
          */
         public T ParseCharacterConfig<T>()
         {
-            return JsonConvert.DeserializeObject<T>(characterConfig);
+            return JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(characterConfig));
         }
 
         /**
          * <summary>
-         * Updates the bots character config - this is useful for overriding or adding new
-         * information defined and set by your Unity code. For example, when seating a bot, you may
-         * discover that the requested character type is no longer available, and you need to let
-         * the bot know. The generic type you pass in must be [Serializable].
+         *     Updates the bots character config - this is useful for overriding or adding new
+         *     information defined and set by your Unity code. For example, when seating a bot, you may
+         *     discover that the requested character type is no longer available, and you need to let
+         *     the bot know. The generic type you pass in must be [Serializable].
          * </summary>
          * <param name="newConfig">The new config to save and send to the bot</param>
          * <example>
-         * <code>
+         *     <code>
          * [Serializable]
          * public class BotCharacterConfig
          * {
@@ -63,8 +67,8 @@ namespace RegressionGames.Types
          */
         public void UpdateCharacterConfig<T>(T newConfig)
         {
-            characterConfig = JsonConvert.SerializeObject(newConfig);
+            characterConfig =
+                JsonConvert.DeserializeObject<Dictionary<string, object>>(JsonConvert.SerializeObject(newConfig));
         }
-        
     }
 }

--- a/Runtime/Scripts/Types/RGBotUnityState.cs
+++ b/Runtime/Scripts/Types/RGBotUnityState.cs
@@ -1,33 +1,35 @@
-using System;
-
 namespace RegressionGames.Types
 {
     public class RGUnityBotState
     {
-        private RGUnityBotState(string value) { _value = value; }
-
         private readonly string _value;
-        
-        public static RGUnityBotState STARTING   { get { return new RGUnityBotState("STARTING"); } }
-        public static RGUnityBotState CONNECTING   { get { return new RGUnityBotState("CONNECTING"); } }
-        public static RGUnityBotState CONNECTED    { get { return new RGUnityBotState("CONNECTED"); } }
-        public static RGUnityBotState RUNNING    { get { return new RGUnityBotState("RUNNING"); } }
-        public static RGUnityBotState TEARING_DOWN    { get { return new RGUnityBotState("TEARING_DOWN"); } }
-        public static RGUnityBotState STOPPED    { get { return new RGUnityBotState("STOPPED"); } }
-        public static RGUnityBotState UNKNOWN { get { return new RGUnityBotState("UNKNOWN"); } }
+
+        private RGUnityBotState(string value)
+        {
+            _value = value;
+        }
+
+        public static RGUnityBotState STARTING => new("STARTING");
+        public static RGUnityBotState CONNECTING => new("CONNECTING");
+        public static RGUnityBotState CONNECTED => new("CONNECTED");
+        public static RGUnityBotState RUNNING => new("RUNNING");
+        public static RGUnityBotState TEARING_DOWN => new("TEARING_DOWN");
+        public static RGUnityBotState STOPPED => new("STOPPED");
+        public static RGUnityBotState UNKNOWN => new("UNKNOWN");
 
         public override string ToString()
         {
             return _value;
         }
 
-        public override bool Equals(Object state)
+        public override bool Equals(object state)
         {
             var botState = state as RGUnityBotState;
             if (botState == null)
             {
                 return false;
             }
+
             return _value.Equals(botState._value);
         }
 

--- a/Runtime/Scripts/Types/RGClientHandshake.cs
+++ b/Runtime/Scripts/Types/RGClientHandshake.cs
@@ -1,21 +1,24 @@
 using System;
+using System.Collections.Generic;
 
 namespace RegressionGames.Types
 {
     [Serializable]
     public class RGClientHandshake
     {
+        // ReSharper disable InconsistentNaming
         public string unityToken;
         public string rgToken;
         public string botName;
-        public string characterConfig;
+        public Dictionary<string, object> characterConfig;
         public bool spawnable;
+
         /**
             One of ...
             MANAGED - Server disconnects/ends bot on match/game-scene teardown
             PERSISTENT - Bot is responsible for disconnecting / ending itself
          */
         public string lifecycle;
+        // ReSharper enable InconsistentNaming
     }
 }
-

--- a/Runtime/Scripts/Types/RGServerHandshake.cs
+++ b/Runtime/Scripts/Types/RGServerHandshake.cs
@@ -1,17 +1,22 @@
 using System;
+using System.Collections.Generic;
 
 namespace RegressionGames.Types
 {
     [Serializable]
     public class RGServerHandshake
     {
+        // ReSharper disable InconsistentNaming
         public string token;
+
         // we echo this back in all cases... it is most useful to the client when randomly assigned
         // OR in bot scripts that support many types to know which type to reconnect with
-        public string characterConfig;
-        public string error;
+        public Dictionary<string, object> characterConfig;
 
-        public RGServerHandshake( string token, string characterConfig, string error)
+        public string error;
+        // ReSharper enable InconsistentNaming
+
+        public RGServerHandshake(string token, Dictionary<string, object> characterConfig, string error)
         {
             this.token = token;
             this.characterConfig = characterConfig;
@@ -19,4 +24,3 @@ namespace RegressionGames.Types
         }
     }
 }
-


### PR DESCRIPTION
- Changes characterConfig from a plain string to a `Dictionary<string, object>` to make writing local bots somewhat sane
  - Handles/Compensates for existing remote bots sending poorly formatted JSON strings for backward compatibility
- Exposes `SceneName` as a field on `RG` accessor object
- Adds Filter Function support to `FindNearestEntity` for parity with javascript version
- Adds a `object GetField(string fieldName)` method onto `RGStateEntity` to simplify coding patterns for getting fields from state entities

See also https://github.com/Regression-Games/RegressionDocs/pull/36
See also https://github.com/Regression-Games/RGBossRoom/pull/34