### PR TITLE
[REG-1304] Move generated scripts under RegressionGames asset path

### DIFF
--- a/Editor/Scripts/CodeGenerators/GenerateRGActionClasses.cs
+++ b/Editor/Scripts/CodeGenerators/GenerateRGActionClasses.cs
@@ -56,9 +56,9 @@ namespace RegressionGames
                 string formattedCode = compilationUnit.NormalizeWhitespace().ToFullString();
                 string headerComment = "/*\n* This file has been automatically generated. Do not modify.\n*/\n\n";
 
-                // Save to 'Assets/RGScripts/RGActions,RGSerialization.cs'
+                // Save to 'Assets/RegressionGames/Runtime/GeneratedScripts/RGActions,RGSerialization.cs'
                 string fileName = $"RGAction_{botAction.ActionName.Replace(" ", "_")}.cs";
-                string subfolderName = Path.Combine("RGScripts", "RGActions");
+                string subfolderName = Path.Combine("RegressionGames", "Runtime", "GeneratedScripts", "RGActions");
                 string filePath = Path.Combine(Application.dataPath, subfolderName, fileName);
                 string fileContents = headerComment + formattedCode;
 

--- a/Editor/Scripts/CodeGenerators/GenerateRGActionMapClass.cs
+++ b/Editor/Scripts/CodeGenerators/GenerateRGActionMapClass.cs
@@ -33,10 +33,9 @@ namespace RegressionGames
             string formattedCode = compilationUnit.NormalizeWhitespace().ToFullString();
             string headerComment = "/*\n* This file has been automatically generated. Do not modify.\n*/\n\n";
 
-            // Save to 'Assets/RGScripts/RGActionMap.cs'
-            string subfolderName = "RGScripts";
+            // Save to 'Assets/RegressionGames/Runtime/GeneratedScripts/RGActionMap.cs'
             string fileName = "RGActionMap.cs";
-            string filePath = Path.Combine(Application.dataPath, subfolderName, fileName);
+            string filePath = Path.Combine(Application.dataPath, "RegressionGames", "Runtime", "GeneratedScripts", fileName);
             string fileContents = headerComment + formattedCode;
             Directory.CreateDirectory(Path.GetDirectoryName(filePath));
             File.WriteAllText(filePath, fileContents);            

--- a/Editor/Scripts/CodeGenerators/GenerateRGSerializationClass.cs
+++ b/Editor/Scripts/CodeGenerators/GenerateRGSerializationClass.cs
@@ -31,10 +31,9 @@ namespace RegressionGames
 
             string headerComment = "/*\n* This file has been automatically generated. Do not modify.\n*/\n\n";
 
-            // Save to 'Assets/RGScripts/RGSerialization.cs'
-            string subfolderName = "RGScripts";
+            // Save to 'Assets/RegressionGames/Runtime/GeneratedScripts/RGSerialization.cs'
             string fileName = "RGSerialization.cs";
-            string filePath = Path.Combine(Application.dataPath, subfolderName, fileName);
+            string filePath = Path.Combine(Application.dataPath, "RegressionGames", "Runtime", "GeneratedScripts", fileName);
             string fileContents = headerComment + formattedCode;
             Directory.CreateDirectory(Path.GetDirectoryName(filePath));
             File.WriteAllText(filePath, fileContents);

--- a/Editor/Scripts/CodeGenerators/GenerateRGStateClasses.cs
+++ b/Editor/Scripts/CodeGenerators/GenerateRGStateClasses.cs
@@ -61,8 +61,8 @@ namespace RegressionGames
                 // Write the code to a .cs file
                 string headerComment = "/*\n* This file has been automatically generated. Do not modify.\n*/\n\n";
 
-                // Save to 'Assets/RGScripts/RGStates/{name}.cs'
-                string subfolderName = Path.Combine("RGScripts", "RGStates");
+                // Save to 'Assets/RegressionGames/Runtime/GeneratedScripts/RGStates/{name}.cs'
+                string subfolderName = Path.Combine("RegressionGames", "Runtime", "GeneratedScripts", "RGStates");
                 string fileName = $"{className}.cs";
                 string filePath = Path.Combine(Application.dataPath, subfolderName, fileName);
                 string fileContents = headerComment + formattedCode;

--- a/Editor/Scripts/CodeGenerators/RGActionCodeGenerator.cs
+++ b/Editor/Scripts/CodeGenerators/RGActionCodeGenerator.cs
@@ -16,6 +16,7 @@ namespace RegressionGames
         [MenuItem("Regression Games/Generate Scripts")]
         private static void GenerateRGScripts()
         {
+            //TODO: Someone/Anyone... remove this delete RGScripts directory code after November 1st, 2023... This is temporary to help devs migrate easily
             // remove old 'RGScripts' folder that is no longer used
             string dataPath = Application.dataPath;
             string directoryToDelete = Path.Combine(dataPath, "RGScripts").Replace("\\", "/");

--- a/Editor/Scripts/CodeGenerators/RGActionCodeGenerator.cs
+++ b/Editor/Scripts/CodeGenerators/RGActionCodeGenerator.cs
@@ -16,6 +16,17 @@ namespace RegressionGames
         [MenuItem("Regression Games/Generate Scripts")]
         private static void GenerateRGScripts()
         {
+            // remove old 'RGScripts' folder that is no longer used
+            string dataPath = Application.dataPath;
+            string directoryToDelete = Path.Combine(dataPath, "RGScripts").Replace("\\", "/");
+
+            if (Directory.Exists(directoryToDelete))
+            {
+                Directory.Delete(directoryToDelete, true);
+                File.Delete(directoryToDelete + ".meta");
+                AssetDatabase.Refresh();
+            }
+
             // find and extract RGAction data
             string actionJson = SearchForBotActionMethods();
             
@@ -101,7 +112,7 @@ namespace RegressionGames
             
             // remove previous RGActions
             string dataPath = Application.dataPath;
-            string directoryToDelete = Path.Combine(dataPath, "RGScripts/RGActions").Replace("\\", "/");
+            string directoryToDelete = Path.Combine(dataPath, "RegressionGames/Runtime/GeneratedScripts/RGActions").Replace("\\", "/");
 
             if (Directory.Exists(directoryToDelete))
             {
@@ -233,7 +244,7 @@ namespace RegressionGames
             
             // remove previous RGStates
             string dataPath = Application.dataPath;
-            string directoryToDelete = Path.Combine(dataPath, "RGScripts/RGStates").Replace("\\", "/");
+            string directoryToDelete = Path.Combine(dataPath, "RegressionGames/Runtime/GeneratedScripts/RGStates").Replace("\\", "/");
             
             if (Directory.Exists(directoryToDelete))
             {
@@ -248,7 +259,7 @@ namespace RegressionGames
 
         private static void WriteToJson(string fileName, string json)
         {
-            string folderPath = Path.Combine(Directory.GetParent(Application.dataPath).FullName, "RegressionGames");
+            string folderPath = Path.Combine(Directory.GetParent(Application.dataPath).FullName, "RegressionGamesZipTemp");
 
             if (!Directory.Exists(folderPath))
             {
@@ -262,17 +273,24 @@ namespace RegressionGames
         private static void ZipJson()
         {
             string parentPath = Directory.GetParent(Application.dataPath).FullName;
-            string folderPath = Path.Combine(parentPath, "RegressionGames");
+            string folderPath = Path.Combine(parentPath, "RegressionGamesZipTemp");
 
             if (Directory.Exists(folderPath))
             {
                 string zipPath = Path.Combine(parentPath, "RegressionGames.zip");
+                // delete existing zip if exists
+                if (File.Exists(zipPath))
+                {
+                    File.Delete(zipPath);
+                }
                 ZipFile.CreateFromDirectory(folderPath, zipPath);
+                RGDebug.LogInfo($"Successfully Generated {zipPath}");
                 Directory.Delete(folderPath, true);
+                RGDebug.LogDebug($"Successfully removed temporary zip directory {folderPath}");
             }
             else
             {
-                Debug.LogWarning("The 'RegressionGames' folder does not exist.");
+                Debug.LogWarning("The 'RegressionGamesZipTemp' folder does not exist.");
             }
         }
         


### PR DESCRIPTION
- Moves generated scripts from `Assets/RGScripts` to `Assets/RegressionGames/Runtime/GeneratedScripts`
  - Handles removing the old folder to avoid classname conflicts
- Fixes an issue where generating scripts more than once would fail to generate the zip
- Updated path for the temp zip folder to avoid confusion with the `RegressionGames` folder in `Assets`

See also https://github.com/Regression-Games/RegressionDocs/pull/37