### PR TITLE
[REG-1302] Adds typed `RGActionRequest`s to generated code

### DIFF
--- a/Editor/Scripts/CodeGenerators/GenerateRGActionClasses.cs
+++ b/Editor/Scripts/CodeGenerators/GenerateRGActionClasses.cs
@@ -19,6 +19,7 @@ namespace RegressionGames
             // Iterate through BotActions
             foreach (var botAction in actionsInfo.BotActions)
             {
+                
                 // Create a new compilation unit
                 CompilationUnitSyntax compilationUnit = SyntaxFactory.CompilationUnit()
                     .AddUsings(
@@ -26,7 +27,10 @@ namespace RegressionGames
                         SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("System.Collections.Generic")),
                         SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("RegressionGames")),
                         SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("RegressionGames.RGBotConfigs")),
+                        SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("RegressionGames.StateActionTypes")),
+                        SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(botAction.Namespace)),
                         SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("UnityEngine"))
+                        
                     )
                     .AddMembers(
                         // Namespace
@@ -34,21 +38,32 @@ namespace RegressionGames
                         .AddMembers(
                             // Class declaration
                             SyntaxFactory.ClassDeclaration($"RGAction_{botAction.ActionName.Replace(" ", "_")}")
-                            .AddModifiers(
-                                SyntaxFactory.Token(SyntaxKind.PublicKeyword)
-                                // Only add one of the "class" keywords here
-                            )
-                            .AddBaseListTypes(
-                                SyntaxFactory.SimpleBaseType(SyntaxFactory.ParseTypeName("RGAction"))
-                            )
-                            .AddMembers(
-                                // Start method
-                                GenerateStartMethod(botAction),
-                                // GetActionName method
-                                GenerateGetActionNameMethod(botAction),
-                                // StartAction method
-                                GenerateStartActionMethod(botAction)
-                            )
+                                .AddModifiers(
+                                    SyntaxFactory.Token(SyntaxKind.PublicKeyword)
+                                    // Only add one of the "class" keywords here
+                                )
+                                .AddBaseListTypes(
+                                    SyntaxFactory.SimpleBaseType(SyntaxFactory.ParseTypeName("RGAction"))
+                                )
+                                .AddMembers(
+                                    // Start method
+                                    GenerateStartMethod(botAction),
+                                    // GetActionName method
+                                    GenerateGetActionNameMethod(botAction),
+                                    // StartAction method
+                                    GenerateStartActionMethod(botAction)
+                                ),
+                            SyntaxFactory.ClassDeclaration($"RGActionRequest_{botAction.ActionName.Replace(" ", "_")}")
+                                .AddModifiers(
+                                    SyntaxFactory.Token(SyntaxKind.PublicKeyword)
+                                    // Only add one of the "class" keywords here
+                                )
+                                .AddBaseListTypes(
+                                    SyntaxFactory.SimpleBaseType(SyntaxFactory.ParseTypeName("RGActionRequest"))
+                                ).AddMembers(
+                                    // Action Request method
+                                    GenerateActionRequestConstructor(botAction)
+                                )
                         )
                     );
 
@@ -306,6 +321,43 @@ namespace RegressionGames
             .WithBody(methodBody);
 
             return startActionMethod;
+        }
+        
+        private static MemberDeclarationSyntax GenerateActionRequestConstructor(RGActionInfo action)
+        {
+            var methodParameters = new List<ParameterSyntax>();
+            var parameterParsingStatements = new List<StatementSyntax>();
+            
+            foreach (var rgParameterInfo in action.Parameters)
+            {
+                methodParameters.Add(SyntaxFactory.Parameter(SyntaxFactory.Identifier(rgParameterInfo.Name))
+                    .WithType(SyntaxFactory.ParseTypeName(rgParameterInfo.Type)));
+            }
+
+            parameterParsingStatements.Add(SyntaxFactory.ParseStatement($"action = \"{action.ActionName}\";"));
+
+            var inputString = "Input = new () {";
+            foreach (var rgParameterInfo in action.Parameters)
+            {
+                inputString += $"\r\n {{ \"{rgParameterInfo.Name}\", {rgParameterInfo.Name} }},";
+            }
+
+            inputString += "\r\n};";
+            
+            parameterParsingStatements.Add(
+                SyntaxFactory.ParseStatement(inputString)
+            );
+
+            var methodBody = SyntaxFactory.Block(parameterParsingStatements);
+
+            var constructor = SyntaxFactory.ConstructorDeclaration(
+                $"RGActionRequest_{action.ActionName}"
+            )
+            .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
+            .AddParameterListParameters(methodParameters.ToArray())
+            .WithBody(methodBody);
+
+            return constructor;
         }
 
     }

--- a/Editor/Scripts/CodeGenerators/GenerateRGActionMapClass.cs
+++ b/Editor/Scripts/CodeGenerators/GenerateRGActionMapClass.cs
@@ -16,14 +16,23 @@ namespace RegressionGames
             // Parse JSON and extract parameter types
             List<RGActionInfo> botActions = ParseJson(jsonData);
 
+            List<UsingDirectiveSyntax> usings = new() {SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("UnityEngine"))};
+            foreach (var rgActionInfo in botActions)
+            {
+                usings.Add(
+                    SyntaxFactory.UsingDirective(SyntaxFactory.ParseName($"{rgActionInfo.Namespace}"))
+                );
+            }
+
             // Create a namespace and class declaration
             NamespaceDeclarationSyntax namespaceDeclaration = SyntaxFactory
                 .NamespaceDeclaration(SyntaxFactory.ParseName("RegressionGames"))
                 .AddUsings(
-                    SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("UnityEngine"))
+                    usings.ToArray()
                 )
                 .AddMembers(GenerateClass(botActions));
-
+            
+            
             // Create a compilation unit and add the namespace declaration
             CompilationUnitSyntax compilationUnit = SyntaxFactory.CompilationUnit()
                 .AddUsings(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("System")))

--- a/Editor/Scripts/CodeGenerators/RGActionCodeGenerator.cs
+++ b/Editor/Scripts/CodeGenerators/RGActionCodeGenerator.cs
@@ -60,6 +60,7 @@ namespace RegressionGames
 
                 foreach (var method in botActionMethods)
                 {
+                    string nameSpace = method.Ancestors().OfType<NamespaceDeclarationSyntax>().First().Name.ToString();
                     string className = method.Ancestors().OfType<ClassDeclarationSyntax>().First().Identifier.ValueText;
                     string methodName = method.Identifier.ValueText;
 
@@ -88,6 +89,7 @@ namespace RegressionGames
 
                     botActionList.Add(new RGActionInfo
                     {
+                        Namespace = nameSpace,
                         Object = className,
                         MethodName = methodName,
                         ActionName = actionName,

--- a/Editor/Scripts/RGActionInfo.cs
+++ b/Editor/Scripts/RGActionInfo.cs
@@ -6,6 +6,8 @@ namespace RegressionGames
     [Serializable]
     public class RGActionInfo
     {
+        // the namespace of the class that contains the [RGAction] attribute tags
+        public string Namespace;
         // the name of the component class that contains the [RGAction] attribute tags
         public string Object;
         // the name of the method tagged with [RGAction]

--- a/Runtime/Scripts/RGBotConfigs/RGClickButtonAction.cs
+++ b/Runtime/Scripts/RGBotConfigs/RGClickButtonAction.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using RegressionGames.StateActionTypes;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
@@ -48,6 +49,15 @@ namespace RegressionGames.RGBotConfigs
                     buttonsToClick.Enqueue(target.gameObject.GetComponent<Button>());
                 }
             }
+        }
+    }
+
+    public class RGActionRequest_ClickButton : RGActionRequest
+    {
+        public RGActionRequest_ClickButton(int targetId)
+        {
+            action = "ClickButton";
+            Input = new() { { "targetId", targetId } };
         }
     }
 }


### PR DESCRIPTION
- Generates new classes extending RGActionRequest for each action to provide typed action requests when coding in C#
- Fixes the issue with namespaces for actions in the action map and in the generated action class
- Sample
```csharp
    public class RGActionRequest_PerformAttack : RGActionRequest
    {
        public RGActionRequest_PerformAttack(bool isEnabled, string actionName, int attackNumber, float damageAmount)
        {
            action = "PerformAttack";
            Input = new ()
            {{"isEnabled", isEnabled}, {"actionName", actionName}, {"attackNumber", attackNumber}, {"damageAmount", damageAmount}, };
        }
    }
```

See also https://github.com/Regression-Games/RegressionDocs/pull/38