### PR TITLE
[REG-1303] non-nullable, always synced RGEntity position and rotation

### DIFF
--- a/Editor/Scripts/RGBotReplayWindow.cs
+++ b/Editor/Scripts/RGBotReplayWindow.cs
@@ -873,7 +873,7 @@ namespace RegressionGames.Editor
                         // if still null
                         if (position == null && tickData.tickInfo?.state.position != null)
                             // targeting the bot's self
-                            position = tickData.tickInfo?.state.position.Value;
+                            position = tickData.tickInfo?.state.position;
                     }
 
                     if (position == null) position = Vector3.zero;

--- a/Editor/Scripts/RGTickInfoActionManager.cs
+++ b/Editor/Scripts/RGTickInfoActionManager.cs
@@ -50,7 +50,7 @@ namespace RegressionGames.Editor
                         var ti = replayData.tickInfo[i];
                         if (ti == null || ti.state.position == null) break;
 
-                        linePoints.Push(ti.state.position.Value);
+                        linePoints.Push(ti.state.position);
                     }
 
                     if (linePoints.Count > 0) return linePoints.ToArray();

--- a/Editor/Scripts/RGTickInfoActionManager.cs
+++ b/Editor/Scripts/RGTickInfoActionManager.cs
@@ -48,7 +48,7 @@ namespace RegressionGames.Editor
                     for (var i = tickNumber - 1; i >= 0; i--)
                     {
                         var ti = replayData.tickInfo[i];
-                        if (ti == null || ti.state.position == null) break;
+                        if (ti == null) break;
 
                         linePoints.Push(ti.state.position);
                     }

--- a/Runtime/Prefabs/RGOverlayCanvas.prefab
+++ b/Runtime/Prefabs/RGOverlayCanvas.prefab
@@ -2644,8 +2644,6 @@ MonoBehaviour:
   isPlayer: 0
   objectType: 
   isRuntimeObject: 0
-  syncPosition: 1
-  syncRotation: 1
 --- !u!1 &7045523072349830337
 GameObject:
   m_ObjectHideFlags: 0

--- a/Runtime/Scripts/RGBotConfigs/RGButtonState.cs
+++ b/Runtime/Scripts/RGBotConfigs/RGButtonState.cs
@@ -15,6 +15,9 @@ namespace RegressionGames.RGBotConfigs
             {
                 ["id"] = transform.GetInstanceID(),
                 ["type"] = objectType,
+                // TODO remove these fields when we have a better way of differentiating ui components from actors
+                ["position"] = Vector3.zero,
+                ["rotation"] = Vector3.zero
             };
             
             CanvasGroup cg = this.gameObject.GetComponentInParent<CanvasGroup>();

--- a/Runtime/Scripts/RGBotConfigs/RGEntity.cs
+++ b/Runtime/Scripts/RGBotConfigs/RGEntity.cs
@@ -14,10 +14,6 @@ namespace RegressionGames.RGBotConfigs
         // this is used in our toolkit to understand which things would need dynamic models
         [Tooltip("Is this object spawned during runtime, or a fixed object in the scene?")]
         public bool isRuntimeObject = false;
-
-        [Header("3D Positioning")] 
-        public bool syncPosition = true;
-        public bool syncRotation = true;
         
         // maps action names to RGAction components
         private Dictionary<string, RGAction> actionMap = new Dictionary<string, RGAction>();

--- a/Runtime/Scripts/RGBotConfigs/RGState.cs
+++ b/Runtime/Scripts/RGBotConfigs/RGState.cs
@@ -45,7 +45,7 @@ namespace RegressionGames.RGBotConfigs
                 ["type"] = rgEntity.objectType,
                 ["isPlayer"] = rgEntity.isPlayer,
                 ["isRuntimeObject"] = rgEntity.isRuntimeObject,
-				["state"] = theTransform.position;
+				["position"] = theTransform.position;
 				["rotation"] = theTransform.rotation;
             };
 

--- a/Runtime/Scripts/RGBotConfigs/RGState.cs
+++ b/Runtime/Scripts/RGBotConfigs/RGState.cs
@@ -45,8 +45,8 @@ namespace RegressionGames.RGBotConfigs
                 ["type"] = rgEntity.objectType,
                 ["isPlayer"] = rgEntity.isPlayer,
                 ["isRuntimeObject"] = rgEntity.isRuntimeObject,
-				["position"] = theTransform.position;
-				["rotation"] = theTransform.rotation;
+				["position"] = theTransform.position,
+				["rotation"] = theTransform.rotation,
             };
 
             var dict = GetState();

--- a/Runtime/Scripts/RGBotConfigs/RGState.cs
+++ b/Runtime/Scripts/RGBotConfigs/RGState.cs
@@ -45,10 +45,9 @@ namespace RegressionGames.RGBotConfigs
                 ["type"] = rgEntity.objectType,
                 ["isPlayer"] = rgEntity.isPlayer,
                 ["isRuntimeObject"] = rgEntity.isRuntimeObject,
+				["state"] = theTransform.position;
+				["rotation"] = theTransform.rotation;
             };
-
-            if (rgEntity.syncPosition) state["position"] = theTransform.position;
-            if (rgEntity.syncRotation) state["rotation"] = theTransform.rotation;
 
             var dict = GetState();
             foreach (var entry in dict)

--- a/Runtime/Scripts/RGBotLocalRuntime/RG.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RG.cs
@@ -61,12 +61,15 @@ namespace RegressionGames.RGBotLocalRuntime
         /**
          * <summary>Used to find the closest Entity to the given position.</summary>
          * <param name="objectType">{string | null} Search for entities of a specific type</param>
-         * <param name="position">{Vector3} Position to search from</param>
+         * <param name="position">
+         *     {Vector3 | null} Position to search from.  If not passed, attempts to use the client's bot
+         *     position in index 0.
+         * </param>
          * <param name="filterFunction">{Func&lt;RGStateEntity, bool&gt; | null} Function to filter entities.</param>
          * <returns>{RGStateEntity} The closest Entity matching the search criteria, or null if none match.</returns>
          */
         [CanBeNull]
-        public RGStateEntity FindNearestEntity(Vector3 position, string objectType = null,
+        public RGStateEntity FindNearestEntity(string objectType = null, Vector3? position = null,
             Func<RGStateEntity, bool> filterFunction = null)
         {
             var result = FindEntities(objectType);
@@ -77,11 +80,13 @@ namespace RegressionGames.RGBotLocalRuntime
 
             if (result.Count > 1)
             {
+                var pos = position ?? GetMyPlayers()[0].position;
+                
                 // sort by distance
                 result.Sort((e1, e2) =>
                 {
-                    var val = MathFunctions.DistanceSq(position, e1.position) -
-                              MathFunctions.DistanceSq(position, e1.position);
+                    var val = MathFunctions.DistanceSq(pos, e1.position) -
+                              MathFunctions.DistanceSq(pos, e1.position);
                     if (val < 0)
                         return -1;
                     if (val > 0) return 1;

--- a/Runtime/Scripts/RGBotLocalRuntime/RG.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RG.cs
@@ -61,15 +61,12 @@ namespace RegressionGames.RGBotLocalRuntime
         /**
          * <summary>Used to find the closest Entity to the given position.</summary>
          * <param name="objectType">{string | null} Search for entities of a specific type</param>
-         * <param name="position">
-         *     {Vector3 | null} Position to search from.  If not passed, attempts to use the client's bot
-         *     position in index 0.
-         * </param>
+         * <param name="position">{Vector3} Position to search from</param>
          * <param name="filterFunction">{Func&lt;RGStateEntity, bool&gt; | null} Function to filter entities.</param>
          * <returns>{RGStateEntity} The closest Entity matching the search criteria, or null if none match.</returns>
          */
         [CanBeNull]
-        public RGStateEntity FindNearestEntity(string objectType = null, Vector3? position = null,
+        public RGStateEntity FindNearestEntity(Vector3 position, string objectType = null,
             Func<RGStateEntity, bool> filterFunction = null)
         {
             var result = FindEntities(objectType);
@@ -81,12 +78,10 @@ namespace RegressionGames.RGBotLocalRuntime
             if (result.Count > 1)
             {
                 // sort by distance
-                var pos = position ?? GetMyPlayers()[0].position ?? Vector3.zero;
-
                 result.Sort((e1, e2) =>
                 {
-                    var val = MathFunctions.DistanceSq(pos, e1.position ?? Vector3.zero) -
-                              MathFunctions.DistanceSq(pos, e1.position ?? Vector3.zero);
+                    var val = MathFunctions.DistanceSq(position, e1.position) -
+                              MathFunctions.DistanceSq(position, e1.position);
                     if (val < 0)
                         return -1;
                     if (val > 0) return 1;

--- a/Runtime/Scripts/RGBotLocalRuntime/SampleBot/RGSampleBot.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/SampleBot/RGSampleBot.cs
@@ -38,21 +38,17 @@ namespace RegressionGames.RGBotLocalRuntime.SampleBot
                 {
                     var target = entities[new Random().Next(entities.Count)];
 
-                    // ensure target is not UI component
-                    if (target.ContainsKey("position"))
+                    var targetPosition = (Vector3)target["position"];
+                    //TODO (REG-1302): If Actions were strongly typed we wouldn't need to build this weird map...
+                    var action = new RGActionRequest("PerformSkill", new Dictionary<string, object>()
                     {
-                        var targetPosition = (Vector3)target["position"];
-                        //TODO (REG-1302): If Actions were strongly typed we wouldn't need to build this weird map...
-                        var action = new RGActionRequest("PerformSkill", new Dictionary<string, object>()
-                        {
-                            { "skillId",  skillId},
-                            { "targetId", target["id"] },
-                            { "xPosition", targetPosition.x },
-                            { "yPosition", targetPosition.y },
-                            { "zPosition", targetPosition.z },
-                        });
-                        rgObject.PerformAction(action);   
-                    }
+                        { "skillId", new Random().Next(2) },
+                        { "targetId", target["id"] },
+                        { "xPosition", targetPosition.x },
+                        { "yPosition", targetPosition.y },
+                        { "zPosition", targetPosition.z }
+                    });
+                    rgObject.PerformAction(action);
                 }
                 else
                 {

--- a/Runtime/Scripts/RGBotLocalRuntime/SampleBot/RGSampleBot.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/SampleBot/RGSampleBot.cs
@@ -38,15 +38,14 @@ namespace RegressionGames.RGBotLocalRuntime.SampleBot
                 {
                     var target = entities[new Random().Next(entities.Count)];
 
-                    var targetPosition = target.position ?? Vector3.zero;
                     //TODO (REG-1302): If Actions were strongly typed we wouldn't need to build this weird map...
                     var action = new RGActionRequest("PerformSkill", new Dictionary<string, object>
                     {
                         { "skillId", new Random().Next(2) },
                         { "targetId", target["id"] },
-                        { "xPosition", targetPosition.x },
-                        { "yPosition", targetPosition.y },
-                        { "zPosition", targetPosition.z }
+                        { "xPosition", target.position.x },
+                        { "yPosition", target.position.y },
+                        { "zPosition", target.position.z }
                     });
                     rgObject.PerformAction(action);
                 }

--- a/Runtime/Scripts/RGBotLocalRuntime/SampleBot/RGSampleBot.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/SampleBot/RGSampleBot.cs
@@ -38,16 +38,21 @@ namespace RegressionGames.RGBotLocalRuntime.SampleBot
                 {
                     var target = entities[new Random().Next(entities.Count)];
 
-                    //TODO (REG-1302): If Actions were strongly typed we wouldn't need to build this weird map...
-                    var action = new RGActionRequest("PerformSkill", new Dictionary<string, object>
+                    // ensure target is not UI component
+                    if (target.ContainsKey("position"))
                     {
-                        { "skillId", new Random().Next(2) },
-                        { "targetId", target["id"] },
-                        { "xPosition", target.position.x },
-                        { "yPosition", target.position.y },
-                        { "zPosition", target.position.z }
-                    });
-                    rgObject.PerformAction(action);
+                        var targetPosition = (Vector3)target["position"];
+                        //TODO (REG-1302): If Actions were strongly typed we wouldn't need to build this weird map...
+                        var action = new RGActionRequest("PerformSkill", new Dictionary<string, object>()
+                        {
+                            { "skillId",  skillId},
+                            { "targetId", target["id"] },
+                            { "xPosition", targetPosition.x },
+                            { "yPosition", targetPosition.y },
+                            { "zPosition", targetPosition.z },
+                        });
+                        rgObject.PerformAction(action);   
+                    }
                 }
                 else
                 {

--- a/Runtime/Scripts/RGBotLocalRuntime/Template/BotEntryPoint.cs.template
+++ b/Runtime/Scripts/RGBotLocalRuntime/Template/BotEntryPoint.cs.template
@@ -40,20 +40,16 @@ namespace <TEMPLATE_NAMESPACE>
                 {
                     var target = entities[new System.Random().Next(entities.Count)];
 
-                    // ensure target is not UI component
-                    if (target.ContainsKey("position"))
+                    var targetPosition = (Vector3)target["position"];
+                    var action = new RGActionRequest("PerformSkill", new Dictionary<string, object>()
                     {
-                        var targetPosition = (Vector3)target["position"];
-                        var action = new RGActionRequest("PerformSkill", new Dictionary<string, object>()
-                        {
-                            { "skillId",  skillId},
-                            { "targetId", target["id"] },
-                            { "xPosition", targetPosition.x },
-                            { "yPosition", targetPosition.y },
-                            { "zPosition", targetPosition.z },
-                        });
-                        rgObject.PerformAction(action);   
-                    }
+                        { "skillId", new Random().Next(2) },
+                        { "targetId", target["id"] },
+                        { "xPosition", targetPosition.x },
+                        { "yPosition", targetPosition.y },
+                        { "zPosition", targetPosition.z },
+                    });
+                    rgObject.PerformAction(action);
                 }
                 else
                 {

--- a/Runtime/Scripts/RGBotLocalRuntime/Template/BotEntryPoint.cs.template
+++ b/Runtime/Scripts/RGBotLocalRuntime/Template/BotEntryPoint.cs.template
@@ -40,16 +40,20 @@ namespace <TEMPLATE_NAMESPACE>
                 {
                     var target = entities[new System.Random().Next(entities.Count)];
 
-                    var targetPosition = target.position ?? Vector3.zero;
-                    var action = new RGActionRequest("PerformSkill", new Dictionary<string, object>()
+                    // ensure target is not UI component
+                    if (target.ContainsKey("position"))
                     {
-                        { "skillId", new System.Random().Next(2) },
-                        { "targetId", target["id"] },
-                        { "xPosition", targetPosition.x },
-                        { "yPosition", targetPosition.y },
-                        { "zPosition", targetPosition.z },
-                    });
-                    rgObject.PerformAction(action);
+                        var targetPosition = (Vector3)target["position"];
+                        var action = new RGActionRequest("PerformSkill", new Dictionary<string, object>()
+                        {
+                            { "skillId",  skillId},
+                            { "targetId", target["id"] },
+                            { "xPosition", targetPosition.x },
+                            { "yPosition", targetPosition.y },
+                            { "zPosition", targetPosition.z },
+                        });
+                        rgObject.PerformAction(action);   
+                    }
                 }
                 else
                 {

--- a/Runtime/Scripts/StateActionTypes/RGStateEntity.cs
+++ b/Runtime/Scripts/StateActionTypes/RGStateEntity.cs
@@ -21,9 +21,8 @@ namespace RegressionGames.StateActionTypes
 
         public bool isRuntimeObject => (bool)this.GetValueOrDefault("isRuntimeObject", false);
 
-        // TODO (REG-1303): These should be non-nullable and we should remove the option NOT to sync position and rotation
-        public Vector3? position => (Vector3?)this.GetValueOrDefault("position", null);
-        public Quaternion? rotation => (Quaternion?)this.GetValueOrDefault("rotation", null);
+        public Vector3 position => (Vector3)this.GetValueOrDefault("position");
+        public Quaternion rotation => (Quaternion)this.GetValueOrDefault("rotation");
 
         public long? clientId => (long?)this.GetValueOrDefault("clientId", null);
 

--- a/SampleBots/BossRoom/AbilityBot_0/BotEntryPoint.cs
+++ b/SampleBots/BossRoom/AbilityBot_0/BotEntryPoint.cs
@@ -43,20 +43,16 @@ namespace AbilityBot_0
                         skillId = 1;
                     }
 
-                    // ensure target is not UI component
-                    if (target.ContainsKey("position"))
+                    var targetPosition = (Vector3)target["position"];
+                    var action = new RGActionRequest("PerformSkill", new Dictionary<string, object>()
                     {
-                        var targetPosition = (Vector3)target["position"];
-                        var action = new RGActionRequest("PerformSkill", new Dictionary<string, object>()
-                        {
-                            { "skillId",  skillId},
-                            { "targetId", target["id"] },
-                            { "xPosition", targetPosition.x },
-                            { "yPosition", targetPosition.y },
-                            { "zPosition", targetPosition.z },
-                        });
-                        rgObject.PerformAction(action);   
-                    }
+                        { "skillId",  skillId},
+                        { "targetId", target["id"] },
+                        { "xPosition", targetPosition.x },
+                        { "yPosition", targetPosition.y },
+                        { "zPosition", targetPosition.z },
+                    });
+                    rgObject.PerformAction(action);
                 }
                 else
                 {

--- a/SampleBots/BossRoom/AbilityBot_0/BotEntryPoint.cs
+++ b/SampleBots/BossRoom/AbilityBot_0/BotEntryPoint.cs
@@ -43,16 +43,20 @@ namespace AbilityBot_0
                         skillId = 1;
                     }
 
-                    var targetPosition = target.position ?? Vector3.zero;
-                    var action = new RGActionRequest("PerformSkill", new Dictionary<string, object>()
+                    // ensure target is not UI component
+                    if (target.ContainsKey("position"))
                     {
-                        { "skillId",  skillId},
-                        { "targetId", target["id"] },
-                        { "xPosition", targetPosition.x },
-                        { "yPosition", targetPosition.y },
-                        { "zPosition", targetPosition.z },
-                    });
-                    rgObject.PerformAction(action);
+                        var targetPosition = (Vector3)target["position"];
+                        var action = new RGActionRequest("PerformSkill", new Dictionary<string, object>()
+                        {
+                            { "skillId",  skillId},
+                            { "targetId", target["id"] },
+                            { "xPosition", targetPosition.x },
+                            { "yPosition", targetPosition.y },
+                            { "zPosition", targetPosition.z },
+                        });
+                        rgObject.PerformAction(action);   
+                    }
                 }
                 else
                 {

--- a/SampleBots/BossRoom/MenuAbilityBot_1/BotEntryPoint.cs
+++ b/SampleBots/BossRoom/MenuAbilityBot_1/BotEntryPoint.cs
@@ -160,20 +160,16 @@ namespace MenuAbilityBot_1
                             {
                                 var target = entities[new Random().Next(entities.Count)];
 
-                                // ensure target is not UI component
-                                if (target.ContainsKey("position"))
+                                var targetPosition = (Vector3)target["position"];
+                                var action = new RGActionRequest("PerformSkill", new Dictionary<string, object>()
                                 {
-                                    var targetPosition = (Vector3)target["position"];
-                                    var action = new RGActionRequest("PerformSkill", new Dictionary<string, object>()
-                                    {
-                                        { "skillId",  skillId},
-                                        { "targetId", target["id"] },
-                                        { "xPosition", targetPosition.x },
-                                        { "yPosition", targetPosition.y },
-                                        { "zPosition", targetPosition.z },
-                                    });
-                                    rgObject.PerformAction(action);   
-                                }
+                                    { "skillId", new Random().Next(2) },
+                                    { "targetId", target["id"] },
+                                    { "xPosition", targetPosition.x },
+                                    { "yPosition", targetPosition.y },
+                                    { "zPosition", targetPosition.z }
+                                });
+                                rgObject.PerformAction(action);
                             }
                             else
                             {

--- a/SampleBots/BossRoom/MenuAbilityBot_1/BotEntryPoint.cs
+++ b/SampleBots/BossRoom/MenuAbilityBot_1/BotEntryPoint.cs
@@ -160,16 +160,20 @@ namespace MenuAbilityBot_1
                             {
                                 var target = entities[new Random().Next(entities.Count)];
 
-                                var targetPosition = target.position ?? Vector3.zero;
-                                var action = new RGActionRequest("PerformSkill", new Dictionary<string, object>
+                                // ensure target is not UI component
+                                if (target.ContainsKey("position"))
                                 {
-                                    { "skillId", new Random().Next(2) },
-                                    { "targetId", target["id"] },
-                                    { "xPosition", targetPosition.x },
-                                    { "yPosition", targetPosition.y },
-                                    { "zPosition", targetPosition.z }
-                                });
-                                rgObject.PerformAction(action);
+                                    var targetPosition = (Vector3)target["position"];
+                                    var action = new RGActionRequest("PerformSkill", new Dictionary<string, object>()
+                                    {
+                                        { "skillId",  skillId},
+                                        { "targetId", target["id"] },
+                                        { "xPosition", targetPosition.x },
+                                        { "yPosition", targetPosition.y },
+                                        { "zPosition", targetPosition.z },
+                                    });
+                                    rgObject.PerformAction(action);   
+                                }
                             }
                             else
                             {


### PR DESCRIPTION
## Summary

- RGEntities now have mandatory, non-nullable `positions` and `rotations`. They will always be synced
- Added a check to ensure that skills aren't used on UI components. They are found the same as enemies or allies in BossRoom, but lack a `position`

## Validation

To test this I created a remote bot that logs the position of all player characters in a game of BossRoom. I tested the game using the remote bot and a local bot. In the remote bot logs we can see the Vector3 position of the player characters update:

https://www.loom.com/share/7c6e22fbc0b94af6b46965b572b0a4be

## Remote Bot Logging Code (If you are curious)

```
const state = rg.getState().gameState;
const res = Object.keys(state)
    .filter(key => state[key].isPlayer)
    .map(key => `${state[key].position.x}, ${state[key].position.y}, ${state[key].position.z}`);
```