### PR TITLE
[REG-1294] Extract object type and adds to JSON files

### DIFF
--- a/Runtime/Scripts/RGBotConfigs/RGEntity.cs
+++ b/Runtime/Scripts/RGBotConfigs/RGEntity.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace RegressionGames.RGBotConfigs
@@ -50,6 +53,35 @@ namespace RegressionGames.RGBotConfigs
                 return action;
             }
             return null;
+        }
+
+        /*
+         * RGEntity holds an 'ObjectType' that is provided by the developer. We map this object type
+         * to its actions and states
+         */
+        public Dictionary<Type, string> MapObjectType(Dictionary<Type, string> objectTypeMap)
+        {
+            Dictionary<Type, string> cloneDict = new Dictionary<Type, string>(objectTypeMap);
+            KeyValuePair<Type, string>[] keyValuePairs = objectTypeMap.ToArray();
+
+            for(int i= 0; i < keyValuePairs.Length; i++)
+            {
+                Type componentType = keyValuePairs[i].Key;
+                
+                // skip previously assigned object types
+                if (!string.IsNullOrEmpty(keyValuePairs[i].Value))
+                {
+                    continue;
+                }
+                
+                // map object type to components with 'objectName'
+                var component = gameObject.GetComponent(componentType);
+                if (component != null)
+                {
+                    cloneDict[componentType] = objectType;
+                }
+            }
+            return cloneDict;
         }
     }
 }


### PR DESCRIPTION
Changes:
1. Add 'Extract Data' to menu bar. This pulls all developer-written object-types, maps them to their actions and states, and then writes and zips JSON
2. RGEntity now has a 'MapObjectType' method. It takes in a dictionary of objects (i.e. PlayerController), checks for the existence of the component, and adds its 'Object Type' to the map if it exists.

Notes:
* RGEntities with the same actions or states, but different Object Types aren't supported. The code skips already mapped object types, so there's no way to tell which of the different object types would show up in the JSON
* `RGEntity` tests the existence of a given component with `GetComponent`. This won't work for components with different namespaces. That fix is covered by [REG-1333](https://linear.app/regression-games/issue/REG-1333/generated-code-should-use-the-namespace-of-the-components-it-relies-on)