### PR TITLE
[REG-1273] Harden network connectivity and re-connects

### DIFF
--- a/Runtime/Scripts/RGBotSpawnManager.cs
+++ b/Runtime/Scripts/RGBotSpawnManager.cs
@@ -280,7 +280,15 @@ namespace RegressionGames
             {
                 // First, allow the developer to configure any frontend/backend for a player about to spawn,
                 // such as character selection.
-                SeatBot(botToSpawn);
+                try
+                {
+                    SeatBot(botToSpawn);
+                }
+                catch (Exception ex)
+                {
+                    RGDebug.LogError($"Error seating bot - {ex}");
+                }
+
                 RGBotServerListener rgBotServerListener = RGBotServerListener.GetInstance();
                 if (rgBotServerListener != null)
                 {

--- a/Runtime/Scripts/RGBotSpawnManager.cs
+++ b/Runtime/Scripts/RGBotSpawnManager.cs
@@ -280,14 +280,8 @@ namespace RegressionGames
             {
                 // First, allow the developer to configure any frontend/backend for a player about to spawn,
                 // such as character selection.
-                try
-                {
-                    SeatBot(botToSpawn);
-                }
-                catch (Exception ex)
-                {
-                    RGDebug.LogError($"Error seating bot - {ex}");
-                }
+
+                SeatBot(botToSpawn);
 
                 RGBotServerListener rgBotServerListener = RGBotServerListener.GetInstance();
                 if (rgBotServerListener != null)


### PR DESCRIPTION
Not Perfect, but should reconnect remote bots automatically in most scenarios.

- Thread safety / concurrency fixes around network connection management
  - Resolves an issue where sometimes we wouldn't re-connect as necessary due to a concurrency issue setting/reading a variable
- Changes to better detect most socket state failures before read and write
- Added socket read/write timeouts to make failures detect properly
- Fixed socket read code to address issues handling transient errors / empty buffer during read attempts
  