### PR TITLE
[REG-1333] - Add namespace to generated state files

### DIFF
--- a/Editor/Scripts/CodeGenerators/GenerateRGStateClasses.cs
+++ b/Editor/Scripts/CodeGenerators/GenerateRGStateClasses.cs
@@ -18,14 +18,30 @@ namespace RegressionGames
 
             foreach (var rgStateInfo in rgStateInfos)
             {
+                List<UsingDirectiveSyntax> usings = new()
+                {
+                    SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("System")),
+                    SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("System.Collections.Generic")),
+                    SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("RegressionGames")),
+                    SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("RegressionGames.RGBotConfigs")),
+                    SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("RegressionGames.StateActionTypes")),
+                    SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("UnityEngine"))
+                };
+
+                if (!string.IsNullOrEmpty(rgStateInfo.Namespace))
+                {
+                    usings.Add(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(rgStateInfo.Namespace)));
+                }
+                
                 var className = $"{rgStateInfo.Object}_RGState";
                 var componentType = rgStateInfo.Object;
 
                 // Create a new compilation unit
                 var compilationUnit = SyntaxFactory.CompilationUnit()
-                    .AddUsings(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("System")),
-                        SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("System.Collections.Generic")));
-
+                    .AddUsings(
+                        usings.ToArray()
+                    );
+                
                 // Create a new class declaration with the desired name
                 var classDeclaration = SyntaxFactory.ClassDeclaration(className)
                     .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))

--- a/Editor/Scripts/CodeGenerators/RGActionCodeGenerator.cs
+++ b/Editor/Scripts/CodeGenerators/RGActionCodeGenerator.cs
@@ -171,11 +171,11 @@ namespace RegressionGames
 
                 foreach (var classDeclaration in classDeclarations)
                 {
-                    string className = classDeclaration.Identifier.ValueText;
-                    List<RGStateInfo> stateList = new List<RGStateInfo>();
-
                     string nameSpace = classDeclaration.Ancestors().OfType<NamespaceDeclarationSyntax>().FirstOrDefault()?.Name.ToString();
 
+                    string className = classDeclaration.Identifier.ValueText;
+                    List<RGStateInfo> stateList = new List<RGStateInfo>();
+                    
                     var membersWithRGState = classDeclaration.Members
                         .Where(m => m.AttributeLists.Any(a => a.Attributes.Any(attr => attr.Name.ToString() == "RGState")));
 

--- a/Editor/Scripts/CodeGenerators/RGActionCodeGenerator.cs
+++ b/Editor/Scripts/CodeGenerators/RGActionCodeGenerator.cs
@@ -164,6 +164,8 @@ namespace RegressionGames
                     string className = classDeclaration.Identifier.ValueText;
                     List<RGStateInfo> stateList = new List<RGStateInfo>();
 
+                    string nameSpace = classDeclaration.Ancestors().OfType<NamespaceDeclarationSyntax>().FirstOrDefault()?.Name.ToString();
+
                     var membersWithRGState = classDeclaration.Members
                         .Where(m => m.AttributeLists.Any(a => a.Attributes.Any(attr => attr.Name.ToString() == "RGState")));
 
@@ -241,6 +243,7 @@ namespace RegressionGames
                     {
                         rgStateInfoList.Add(new RGStatesInfo
                         {
+                            Namespace = nameSpace,
                             Object = className,
                             State = stateList
                         });

--- a/Editor/Scripts/CodeGenerators/RGActionCodeGenerator.cs
+++ b/Editor/Scripts/CodeGenerators/RGActionCodeGenerator.cs
@@ -82,9 +82,7 @@ namespace RegressionGames
 
                 foreach (var method in botActionMethods)
                 {
-                    var namespaceAncestors = method.Ancestors().OfType<NamespaceDeclarationSyntax>().ToArray();
-                    var namespaceAncestor = namespaceAncestors.Length > 0 ? namespaceAncestors[0] : null; 
-                    string nameSpace = namespaceAncestor?.Name.ToString();
+                    string nameSpace = method.Ancestors().OfType<NamespaceDeclarationSyntax>().FirstOrDefault()?.Name.ToString();
                     string className = method.Ancestors().OfType<ClassDeclarationSyntax>().First().Identifier.ValueText;
                     string methodName = method.Identifier.ValueText;
 

--- a/Editor/Scripts/RGStatesInfo.cs
+++ b/Editor/Scripts/RGStatesInfo.cs
@@ -12,6 +12,7 @@ namespace RegressionGames
     [Serializable]
     public class RGStatesInfo
     {
+        public string Namespace;
         public string Object;
         public List<RGStateInfo> State;
     }


### PR DESCRIPTION
Fixes compile errors after `Regression Games -> Generate Scripts` 

**To Test**
Add `[RGAction]` and `[RGState]` attributes to a class with a custom namespace

```
using UnityEngine;
using RegressionGames;

namespace TestNamespace
{
  public class Test : MonoBehaviour
  {
     [RGState]
     public int testState = 5;
     
     [RGAction]
     public void TestAction()
     {
       Debug.Log("Test Action");
     }
     
     private void Start(){}
  }
}
```

Generate scripts. `Regression Games->Generate Scripts`. Generated files should include `using TestNamespace;`