### PR TITLE
[REG-1376] Behavior Tree Bots and supporting components

### DIFF
--- a/Runtime/Scripts/BehaviorTree.meta
+++ b/Runtime/Scripts/BehaviorTree.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 17b1a012127740f99f2774e004e19f96
+timeCreated: 1698353257

--- a/Runtime/Scripts/BehaviorTree/ActionNode.cs
+++ b/Runtime/Scripts/BehaviorTree/ActionNode.cs
@@ -1,0 +1,12 @@
+namespace RegressionGames.BehaviorTree
+{
+    /// <summary>
+    /// Represents a node that runs custom user code to instruct the bot to perform an action.
+    /// </summary>
+    public abstract class ActionNode : BehaviorTreeNode
+    {
+        protected ActionNode(string name) : base(name)
+        {
+        }
+    }
+}

--- a/Runtime/Scripts/BehaviorTree/ActionNode.cs.meta
+++ b/Runtime/Scripts/BehaviorTree/ActionNode.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e63e9fe714554241b2bd9245e0f616e9
+timeCreated: 1698353401

--- a/Runtime/Scripts/BehaviorTree/BehaviorTreeNode.cs
+++ b/Runtime/Scripts/BehaviorTree/BehaviorTreeNode.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using RegressionGames.RGBotLocalRuntime;
+
+namespace RegressionGames.BehaviorTree
+{
+    /// <summary>
+    /// Base class to represent a nodes in a Behavior Tree.
+    /// </summary>
+    public abstract class BehaviorTreeNode
+    {
+        /// <summary>
+        /// A reference to the tree this node is a part of.
+        /// </summary>
+        protected BehaviorTreeNode Parent { get; private set; }
+        
+        /// <summary>The name of the node.</summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Initializes the node with a name.
+        /// </summary>
+        /// <param name="name">The name of the node</param>
+        protected BehaviorTreeNode(string name)
+        {
+            Name = name;
+        }
+        
+        /// <summary>
+        /// Executes the node, given the provided <see cref="RG"/> object as context.
+        /// </summary>
+        /// <param name="rgObject">The <see cref="RG"/> context object.</param>
+        /// <returns>A <see cref="NodeStatus"/> indicating the result of executing the node.</returns>
+        public abstract NodeStatus Execute(RG rgObject);
+
+        /// <summary>
+        /// Sets a data value with the specified key and value.
+        /// This value will be available to all nodes in the tree via <see cref="GetData{T}"/>.
+        /// </summary>
+        /// <param name="key">The key to store the data under.</param>
+        /// <param name="value">The value to store.</param>
+        protected void SetData(string key, object value)
+            => GetRoot().Data[key] = value;
+
+        /// <summary>
+        /// Gets a data value with the specified key and expected type.
+        /// </summary>
+        /// <param name="key">The key to retrieve data from.</param>
+        /// <typeparam name="T">The expected type of the value.</typeparam>
+        /// <returns>The value at the provided key, cast to <typeparamref name="T"/>, or the default value for <typeparamref name="T"/> if no value is stored at that key.</returns>
+        protected T GetData<T>(string key)
+            => GetRoot().Data.TryGetValue(key, out var v) ? (T)v : default;
+
+        /// <summary>
+        /// Clears the data value at the specified key.
+        /// </summary>
+        /// <param name="key"></param>
+        protected void ClearData(string key)
+            => GetRoot().Data.Remove(key);
+
+        internal void SetParent(BehaviorTreeNode parent) 
+            => Parent = parent;
+
+        protected RootNode GetRoot()
+        {
+            // Walk up 'parent' links until we hit a null parent or a RootNode.
+            var current = this;
+            while (current is not null and not RootNode)
+            {
+                current = current.Parent;
+            }
+
+            if (current is not RootNode root)
+            {
+                // We broke from the loop without finding a root node
+                throw new InvalidOperationException("Could not find root node.");
+            }
+
+            return root;
+        }
+    }
+    
+    /// <summary>
+    /// Base class for any <see cref="BehaviorTreeNode"/> with child nodes.
+    /// </summary>
+    public abstract class ContainerNode: BehaviorTreeNode
+    {
+        private List<BehaviorTreeNode> _children = new();
+
+        /// <summary>
+        /// The children of this node.
+        /// </summary>
+        public IReadOnlyList<BehaviorTreeNode> Children => _children;
+
+        /// <summary>
+        /// Adds a child to this node.
+        /// </summary>
+        /// <param name="node">The <see cref="BehaviorTreeNode"/> to add as a child.</param>
+        public void AddChild(BehaviorTreeNode node)
+        {
+            _children.Add(node);
+            node.SetParent(this);
+        }
+
+        protected ContainerNode(string name) : base(name)
+        {
+        }
+    }
+}

--- a/Runtime/Scripts/BehaviorTree/BehaviorTreeNode.cs
+++ b/Runtime/Scripts/BehaviorTree/BehaviorTreeNode.cs
@@ -13,9 +13,12 @@ namespace RegressionGames.BehaviorTree
         /// A reference to the tree this node is a part of.
         /// </summary>
         protected BehaviorTreeNode Parent { get; private set; }
-        
+
         /// <summary>The name of the node.</summary>
-        public string Name { get; }
+        public readonly string Name;
+        
+        /// <summary>The path from the root to this node.</summary>
+        public string Path => Parent is null ? Name : $"{Parent.Path}/{Name}";
 
         /// <summary>
         /// Initializes the node with a name.
@@ -25,13 +28,26 @@ namespace RegressionGames.BehaviorTree
         {
             Name = name;
         }
+
+        /// <summary>
+        /// Executes the node, given the provided <see cref="RG"/> object as context.
+        /// </summary>
+        /// <param name="rgObject">The <see cref="RG"/> context object.</param>
+        /// <returns>A <see cref="NodeStatus"/> indicating the result of executing the node.</returns>
+        public NodeStatus Invoke(RG rgObject)
+        {
+            // We use a public wrapper to call the protected Execute method so that we can log the result.
+            var result = Execute(rgObject);
+            RGDebug.LogVerbose($"Behavior Tree Node '{Path}' completed with result '{result}'");
+            return result;
+        }
         
         /// <summary>
         /// Executes the node, given the provided <see cref="RG"/> object as context.
         /// </summary>
         /// <param name="rgObject">The <see cref="RG"/> context object.</param>
         /// <returns>A <see cref="NodeStatus"/> indicating the result of executing the node.</returns>
-        public abstract NodeStatus Execute(RG rgObject);
+        protected abstract NodeStatus Execute(RG rgObject);
 
         /// <summary>
         /// Sets a data value with the specified key and value.

--- a/Runtime/Scripts/BehaviorTree/BehaviorTreeNode.cs.meta
+++ b/Runtime/Scripts/BehaviorTree/BehaviorTreeNode.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0544a963f2504081b060e548a09c3bca
+timeCreated: 1698353278

--- a/Runtime/Scripts/BehaviorTree/ConditionNode.cs
+++ b/Runtime/Scripts/BehaviorTree/ConditionNode.cs
@@ -1,0 +1,12 @@
+namespace RegressionGames.BehaviorTree
+{
+    /// <summary>
+    /// Represents a node that runs custom user code to determine if a condition is met.
+    /// </summary>
+    public abstract class ConditionNode : BehaviorTreeNode
+    {
+        protected ConditionNode(string name) : base(name)
+        {
+        }
+    }
+}

--- a/Runtime/Scripts/BehaviorTree/ConditionNode.cs.meta
+++ b/Runtime/Scripts/BehaviorTree/ConditionNode.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4547cb618d154cdcaffb2c236adedbde
+timeCreated: 1698353407

--- a/Runtime/Scripts/BehaviorTree/Decorators.cs
+++ b/Runtime/Scripts/BehaviorTree/Decorators.cs
@@ -1,0 +1,56 @@
+using System;
+using RegressionGames.RGBotLocalRuntime;
+
+namespace RegressionGames.BehaviorTree
+{
+    /// <summary>
+    /// A node that always returns <see cref="NodeStatus.Success"/> when executed.
+    /// </summary>
+    public class AlwaysSucceed: BehaviorTreeNode
+    {
+        public AlwaysSucceed() : base("Always Succeed")
+        {
+        }
+
+        public override NodeStatus Execute(RG rgObject) => NodeStatus.Success;
+    }
+    
+    /// <summary>
+    /// A node that always returns <see cref="NodeStatus.Failure"/> when executed.
+    /// </summary>
+    public class AlwaysFail: BehaviorTreeNode
+    {
+        public AlwaysFail() : base("Always Fail")
+        {
+        }
+
+        public override NodeStatus Execute(RG rgObject) => NodeStatus.Failure;
+    }
+    
+    /// <summary>
+    /// A node that inverts the result of it's child node.
+    /// </summary>
+    /// <remarks>
+    /// If the child node returns <see cref="NodeStatus.Running"/>, this node returns <see cref="NodeStatus.Running"/>.
+    /// If the child node returns <see cref="NodeStatus.Failure"/>, this node returns <see cref="NodeStatus.Success"/>.
+    /// If the child node returns <see cref="NodeStatus.Success"/>, this node returns <see cref="NodeStatus.Failure"/>.
+    /// </remarks>
+    public class Invert: BehaviorTreeNode
+    {
+        private readonly BehaviorTreeNode _child;
+
+        public Invert(BehaviorTreeNode child) : base("Invert")
+        {
+            _child = child;
+        }
+
+        public override NodeStatus Execute(RG rgObject) =>
+            _child.Execute(rgObject) switch
+            {
+                NodeStatus.Success => NodeStatus.Failure,
+                NodeStatus.Failure => NodeStatus.Success,
+                NodeStatus.Running => NodeStatus.Running,
+                var other => throw new InvalidOperationException($"Unexpected node status: {other}"),
+            };
+    }
+}

--- a/Runtime/Scripts/BehaviorTree/Decorators.cs.meta
+++ b/Runtime/Scripts/BehaviorTree/Decorators.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ae2d6b6ee1a0410f9b31eb3e7abfa8e8
+timeCreated: 1698353460

--- a/Runtime/Scripts/BehaviorTree/NodeStatus.cs
+++ b/Runtime/Scripts/BehaviorTree/NodeStatus.cs
@@ -1,0 +1,20 @@
+namespace RegressionGames.BehaviorTree
+{
+    public enum NodeStatus
+    {
+        /// <summary>
+        /// The node has completed successfully.
+        /// </summary>
+        Success,
+        
+        /// <summary>
+        /// The node failed to execute.
+        /// </summary>
+        Failure,
+        
+        /// <summary>
+        /// The node is still running.
+        /// </summary>
+        Running,
+    }
+}

--- a/Runtime/Scripts/BehaviorTree/NodeStatus.cs.meta
+++ b/Runtime/Scripts/BehaviorTree/NodeStatus.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 96ff1b7503a74cbe87d36fd4aacd9986
+timeCreated: 1698353275

--- a/Runtime/Scripts/BehaviorTree/RGBehaviorTreeBot.cs
+++ b/Runtime/Scripts/BehaviorTree/RGBehaviorTreeBot.cs
@@ -14,8 +14,7 @@ namespace RegressionGames.BehaviorTree
 
         public override void ProcessTick(RG rgObject)
         {
-            var result = _rootNode.Execute(rgObject);
-            RGDebug.LogVerbose($"Behavior tree completed with status: {result}");
+            _ = _rootNode.Invoke(rgObject);
         }
 
         protected abstract RootNode BuildBehaviorTree();

--- a/Runtime/Scripts/BehaviorTree/RGBehaviorTreeBot.cs
+++ b/Runtime/Scripts/BehaviorTree/RGBehaviorTreeBot.cs
@@ -1,0 +1,23 @@
+using RegressionGames.RGBotLocalRuntime;
+
+namespace RegressionGames.BehaviorTree
+{
+    public abstract class RGBehaviorTreeBot: RGUserBot
+    {
+        private BehaviorTreeNode _rootNode;
+
+        internal override void Init(long botId, string botName)
+        {
+            base.Init(botId, botName);
+            _rootNode = BuildBehaviorTree();
+        }
+
+        public override void ProcessTick(RG rgObject)
+        {
+            var result = _rootNode.Execute(rgObject);
+            RGDebug.LogVerbose($"Behavior tree completed with status: {result}");
+        }
+
+        protected abstract RootNode BuildBehaviorTree();
+    }
+}

--- a/Runtime/Scripts/BehaviorTree/RGBehaviorTreeBot.cs.meta
+++ b/Runtime/Scripts/BehaviorTree/RGBehaviorTreeBot.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 387c5e6fb1724b9fb2735db8618ea905
+timeCreated: 1698083462

--- a/Runtime/Scripts/BehaviorTree/RootNode.cs
+++ b/Runtime/Scripts/BehaviorTree/RootNode.cs
@@ -6,7 +6,7 @@ namespace RegressionGames.BehaviorTree
 {
     /// <summary>
     /// Represents the root node of a behavior tree.
-    /// The root node carries the data dictionary that is shared between all nodes in the tree.
+    /// The root node carries a data dictionary that is shared between all nodes in the tree.
     /// </summary>
     public class RootNode : ContainerNode
     {
@@ -16,10 +16,10 @@ namespace RegressionGames.BehaviorTree
         {
         }
 
-        public override NodeStatus Execute(RG rgObject)
+        protected override NodeStatus Execute(RG rgObject)
         {
             return Children.Count > 0 
-                ? Children.First().Execute(rgObject) 
+                ? Children.First().Invoke(rgObject) 
                 : NodeStatus.Failure;
         }
     }

--- a/Runtime/Scripts/BehaviorTree/RootNode.cs
+++ b/Runtime/Scripts/BehaviorTree/RootNode.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Linq;
+using RegressionGames.RGBotLocalRuntime;
+
+namespace RegressionGames.BehaviorTree
+{
+    /// <summary>
+    /// Represents the root node of a behavior tree.
+    /// The root node carries the data dictionary that is shared between all nodes in the tree.
+    /// </summary>
+    public class RootNode : ContainerNode
+    {
+        internal readonly Dictionary<string, object> Data = new();
+
+        public RootNode() : base("Root Node")
+        {
+        }
+
+        public override NodeStatus Execute(RG rgObject)
+        {
+            return Children.Count > 0 
+                ? Children.First().Execute(rgObject) 
+                : NodeStatus.Failure;
+        }
+    }
+}

--- a/Runtime/Scripts/BehaviorTree/RootNode.cs.meta
+++ b/Runtime/Scripts/BehaviorTree/RootNode.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6ca5c20953294e7fb858bc9951aa58b8
+timeCreated: 1698353298

--- a/Runtime/Scripts/BehaviorTree/SelectorNode.cs
+++ b/Runtime/Scripts/BehaviorTree/SelectorNode.cs
@@ -3,16 +3,16 @@ using RegressionGames.RGBotLocalRuntime;
 namespace RegressionGames.BehaviorTree
 {
     /// <summary>
-    /// Represents a node that will run each of it's children in sequence.
+    /// Represents a node that will run each of its children in sequence.
     /// If any child returns <see cref="NodeStatus.Success"/> or <see cref="NodeStatus.Running"/>, this node will return that result and stop executing children.
     /// </summary>
     public class SelectorNode : ContainerNode
     {
-        public override NodeStatus Execute(RG rgObject)
+        protected override NodeStatus Execute(RG rgObject)
         {
             foreach(var child in Children)
             {
-                var result = child.Execute(rgObject);
+                var result = child.Invoke(rgObject);
                 if (result == NodeStatus.Success || result == NodeStatus.Running)
                 {
                     return result;

--- a/Runtime/Scripts/BehaviorTree/SelectorNode.cs
+++ b/Runtime/Scripts/BehaviorTree/SelectorNode.cs
@@ -1,0 +1,29 @@
+using RegressionGames.RGBotLocalRuntime;
+
+namespace RegressionGames.BehaviorTree
+{
+    /// <summary>
+    /// Represents a node that will run each of it's children in sequence.
+    /// If any child returns <see cref="NodeStatus.Success"/> or <see cref="NodeStatus.Running"/>, this node will return that result and stop executing children.
+    /// </summary>
+    public class SelectorNode : ContainerNode
+    {
+        public override NodeStatus Execute(RG rgObject)
+        {
+            foreach(var child in Children)
+            {
+                var result = child.Execute(rgObject);
+                if (result == NodeStatus.Success || result == NodeStatus.Running)
+                {
+                    return result;
+                }
+            }
+
+            return NodeStatus.Success;
+        }
+
+        public SelectorNode(string name) : base(name)
+        {
+        }
+    }
+}

--- a/Runtime/Scripts/BehaviorTree/SelectorNode.cs.meta
+++ b/Runtime/Scripts/BehaviorTree/SelectorNode.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: de945e2ffe9047de9cdc7b4a5b89851c
+timeCreated: 1698353355

--- a/Runtime/Scripts/BehaviorTree/SequenceNode.cs
+++ b/Runtime/Scripts/BehaviorTree/SequenceNode.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+using JetBrains.Annotations;
+using RegressionGames;
+using RegressionGames.RGBotLocalRuntime;
+using TreeEditor;
+
+namespace RegressionGames.BehaviorTree
+{
+    /// <summary>
+    /// Represents a node that will run all of it's children in sequence.
+    /// If any child returns <see cref="NodeStatus.Failure"/>, this node will fail and stop executing children.
+    /// </summary>
+    public class SequenceNode : ContainerNode
+    {
+        public override NodeStatus Execute(RG rgObject)
+        {
+            foreach(var child in Children)
+            {
+                var result = child.Execute(rgObject);
+                if (result != NodeStatus.Success)
+                {
+                    return result;
+                }
+            }
+
+            return NodeStatus.Success;
+        }
+
+        public SequenceNode(string name) : base(name)
+        {
+        }
+    }
+}

--- a/Runtime/Scripts/BehaviorTree/SequenceNode.cs
+++ b/Runtime/Scripts/BehaviorTree/SequenceNode.cs
@@ -7,16 +7,16 @@ using TreeEditor;
 namespace RegressionGames.BehaviorTree
 {
     /// <summary>
-    /// Represents a node that will run all of it's children in sequence.
+    /// Represents a node that will run all of its children in sequence.
     /// If any child returns <see cref="NodeStatus.Failure"/>, this node will fail and stop executing children.
     /// </summary>
     public class SequenceNode : ContainerNode
     {
-        public override NodeStatus Execute(RG rgObject)
+        protected override NodeStatus Execute(RG rgObject)
         {
             foreach(var child in Children)
             {
-                var result = child.Execute(rgObject);
+                var result = child.Invoke(rgObject);
                 if (result != NodeStatus.Success)
                 {
                     return result;

--- a/Runtime/Scripts/BehaviorTree/SequenceNode.cs.meta
+++ b/Runtime/Scripts/BehaviorTree/SequenceNode.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5e140fb157be497ebb9a5caf4993f66c
+timeCreated: 1698083462

--- a/Runtime/Scripts/RGBotLocalRuntime/RG.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RG.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using Newtonsoft.Json;
 using RegressionGames.StateActionTypes;
 using UnityEngine;
 
@@ -203,7 +204,7 @@ namespace RegressionGames.RGBotLocalRuntime
         
         /**
          * <summary>Queue an action to perform.  Multiple actions can be queued per tick</summary>
-         * <param name="rgAction">{RGActionRequest} action request to queue</param>
+         * <param name="rgAction"><see cref="RGActionRequest"/> action request to queue</param>
          */
         public void PerformAction(RGActionRequest rgAction)
         {
@@ -212,13 +213,21 @@ namespace RegressionGames.RGBotLocalRuntime
         
         /**
          * <summary>Record a validation result.  Multiple validation results can be recorded per tick</summary>
-         * <param name="rgValidation">{RGValidationResult} validation result to queue</param>
+         * <param name="rgValidation"><see cref="RGValidationResult"/> validation result to queue</param>
          */
         public void RecordValidation(RGValidationResult rgValidation)
         {
             _validationResults.Enqueue(rgValidation);
         }
-        
+
+        /**
+         * <summary>Sets the <see cref="CharacterConfig"/> field by parsing the provided JSON string.</summary>
+         * <param name="characterConfigJson">A JSON string representing the character config.</param>
+         */
+        public void SetCharacterConfigFromJson(string characterConfigJson)
+        {
+            this.CharacterConfig = JsonConvert.DeserializeObject<Dictionary<string, object>>(characterConfigJson);
+        }
         
         internal void SetCharacterConfig(Dictionary<string, object> characterConfig)
         {

--- a/Runtime/Scripts/RGBotLocalRuntime/RGUserBot.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RGUserBot.cs
@@ -24,7 +24,7 @@ namespace RegressionGames.RGBotLocalRuntime
          */
         public RGGizmos RGGizmos => _rgGizmos;
 
-        public void Init(long botId, string botName)
+        internal virtual void Init(long botId, string botName)
         {
             _botId = botId;
             _botName = botName;


### PR DESCRIPTION
This adds a new namespace: `RegressionGames.BehaviorTree`. Inside this namespace are types to support Behavior Tree-based bots in the Unity SDK. This includes bots generated by Agent Builder, but also allows users to integrate behavior trees into their own bots if they'd like to use a hybrid approach.
 
A Behavior Tree-based bot inherits from `RGBehaviorTreeBot` **instead** of `RGUserBot`. Then, instead of overriding `ProcessTick`, they override `BuildBehaviorTree` to construct their behavior tree and return the root node.

As part of this change, I've made `RGUserBot.Init` `internal`. I don't think there's reason for a user script to call it, so it probably shouldn't be public, but I can revert that if we know user scripts need to call it. It's also `virtual` now, which allows `RGBehaviorTreeBot` to use it to call the user-provided `BuildBehaviorTree` method. That avoids the weird `ConfigureBotCore` behavior I had in [the earlier sketch](https://github.com/Regression-Games/RGBossRoom/pull/38).

----

I think it's preferable to put these types in the Unity SDK rather than generate them with the Agent Builder bot (which is what we do in TypeScript). If we generate them alongside the bot, we create a few issues:

* Lots of code duplication when there are multiple local bots in a single game.
* Code completion will be polluted with multiple copies of the Behavior Tree types (since most IDEs now are extra helpful and suggest types in namespaces not currently imported)
* We have no ability to make bug-fixes and improvements to Behavior Tree logic

That does mean that if we add new node types to the Agent Builder, we will have to consider the version of our SDK that the bot is targeting. However, we'll need to do that anyway for the code _inside_ of each node, so it's not really more complication than we're already signing ourselves up for.