### PR TITLE
DRAFT: [REG-1359] Fixes to support C# Agent Builder bots

### DIFF
--- a/Runtime/Scripts/BehaviorTree/SelectorNode.cs
+++ b/Runtime/Scripts/BehaviorTree/SelectorNode.cs
@@ -5,6 +5,7 @@ namespace RegressionGames.BehaviorTree
     /// <summary>
     /// Represents a node that will run each of its children in sequence.
     /// If any child returns <see cref="NodeStatus.Success"/> or <see cref="NodeStatus.Running"/>, this node will return that result and stop executing children.
+    /// If no children return <see cref="NodeStatus.Success"/> or <see cref="NodeStatus.Running"/>, then this node will return Failure.
     /// </summary>
     public class SelectorNode : ContainerNode
     {
@@ -19,7 +20,7 @@ namespace RegressionGames.BehaviorTree
                 }
             }
 
-            return NodeStatus.Success;
+            return NodeStatus.Failure;
         }
 
         public SelectorNode(string name) : base(name)

--- a/Runtime/Scripts/RGBotLocalRuntime/RG.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RG.cs
@@ -102,7 +102,7 @@ namespace RegressionGames.RGBotLocalRuntime
                 result.Sort((e1, e2) =>
                 {
                     var val = MathFunctions.DistanceSq(pos, e1.position) -
-                              MathFunctions.DistanceSq(pos, e1.position);
+                              MathFunctions.DistanceSq(pos, e2.position);
                     if (val < 0)
                         return -1;
                     if (val > 0) return 1;
@@ -259,15 +259,16 @@ namespace RegressionGames.RGBotLocalRuntime
             return result;
         }
         
+        public static class MathFunctions 
+        {
+            /**
+             * <returns>{double} The square distance between two positions</returns>
+             */
+            public static double DistanceSq (Vector3 position1, Vector3 position2) {
+                return Math.Pow(position2.x - position1.x, 2) + Math.Pow(position2.y - position1.y, 2) + Math.Pow(position2.z - position1.z, 2);
+            }
+        }
+        
     }
     
-    internal static class MathFunctions 
-    {
-        /**
-         * <returns>{double} The square distance between two positions</returns>
-         */
-        public static double DistanceSq (Vector3 position1, Vector3 position2) {
-            return Math.Pow(position2.x - position1.x, 2) + Math.Pow(position2.y - position1.y, 2) + Math.Pow(position2.z - position1.z, 2);
-        }
-    }
 }


### PR DESCRIPTION
* Selector node must return `Failure` if all of its children failed
* Fix distance comparison in `FindNearestEntity`
* `MathFunctions` is now accessible through the `RG` class. This lets us call `DistanceSq` from Agent Builder