### PR TITLE
[REG-1397] Make SetCharacterConfigFromJson public so user bots can call it

### DIFF
--- a/Runtime/Scripts/RGBotLocalRuntime/RG.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RG.cs
@@ -12,11 +12,11 @@ namespace RegressionGames.RGBotLocalRuntime
     public class RG
     {
         public bool Completed { get; private set; } = false;
-        
-        private RGTickInfoData _tickInfo; 
-        
+
+        private RGTickInfoData _tickInfo;
+
         private readonly ConcurrentQueue<RGActionRequest> _actionQueue = new();
-        
+
         private readonly ConcurrentQueue<RGValidationResult> _validationResults = new();
 
         public Dictionary<string, object> CharacterConfig = new();
@@ -97,7 +97,7 @@ namespace RegressionGames.RGBotLocalRuntime
             if (result.Count > 1)
             {
                 var pos = position ?? GetMyPlayers()[0].position;
-                
+
                 // sort by distance
                 result.Sort((e1, e2) =>
                 {
@@ -141,7 +141,7 @@ namespace RegressionGames.RGBotLocalRuntime
             {
                 return new List<IRGStateEntity>();
             }
-            
+
             // filter down to objectType Matches
             var result = gameState.Values.Where(value =>
             {
@@ -170,7 +170,7 @@ namespace RegressionGames.RGBotLocalRuntime
 
             // filter down to isPlayer
             var result = gameState.Values.Where(value => value.isPlayer);
-            
+
             // filter down to clientId Matches
             if (clientId != null)
             {
@@ -195,13 +195,13 @@ namespace RegressionGames.RGBotLocalRuntime
                 {
                     return attributeValue.Equals(expectedValue);
                 }
-                
+
                 return true;
             }
 
             return false;
         }
-        
+
         /**
          * <summary>Queue an action to perform.  Multiple actions can be queued per tick</summary>
          * <param name="rgAction"><see cref="RGActionRequest"/> action request to queue</param>
@@ -210,7 +210,7 @@ namespace RegressionGames.RGBotLocalRuntime
         {
             _actionQueue.Enqueue(rgAction);
         }
-        
+
         /**
          * <summary>Record a validation result.  Multiple validation results can be recorded per tick</summary>
          * <param name="rgValidation"><see cref="RGValidationResult"/> validation result to queue</param>
@@ -219,26 +219,28 @@ namespace RegressionGames.RGBotLocalRuntime
         {
             _validationResults.Enqueue(rgValidation);
         }
-        
+
         internal void SetCharacterConfig(Dictionary<string, object> characterConfig)
         {
             this.CharacterConfig = characterConfig;
         }
-        
+
         /**
          * <summary>Sets the <see cref="CharacterConfig"/> field by parsing the provided JSON string.</summary>
          * <param name="characterConfigJson">A JSON string representing the character config.</param>
          */
-        internal void SetCharacterConfigFromJson(string characterConfigJson)
+        // NOTE: This is called by the generated BotEntryPoint class in Agent Builder Bots.
+        // Avoid changing the signature, name, or accessibility of this method!
+        public void SetCharacterConfigFromJson(string characterConfigJson)
         {
             this.CharacterConfig = JsonConvert.DeserializeObject<Dictionary<string, object>>(characterConfigJson);
         }
-        
+
         internal void SetTickInfo(RGTickInfoData tickInfo)
         {
             this._tickInfo = tickInfo;
         }
-        
+
         internal List<RGActionRequest> FlushActions()
         {
             List<RGActionRequest> result = new();
@@ -258,8 +260,8 @@ namespace RegressionGames.RGBotLocalRuntime
             }
             return result;
         }
-        
-        public static class MathFunctions 
+
+        public static class MathFunctions
         {
             /**
              * <returns>{double} The square distance between two positions</returns>
@@ -268,7 +270,7 @@ namespace RegressionGames.RGBotLocalRuntime
                 return Math.Pow(position2.x - position1.x, 2) + Math.Pow(position2.y - position1.y, 2) + Math.Pow(position2.z - position1.z, 2);
             }
         }
-        
+
     }
-    
+
 }

--- a/Runtime/Scripts/RGBotLocalRuntime/RG.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RG.cs
@@ -220,11 +220,6 @@ namespace RegressionGames.RGBotLocalRuntime
             _validationResults.Enqueue(rgValidation);
         }
 
-        internal void SetCharacterConfig(Dictionary<string, object> characterConfig)
-        {
-            this.CharacterConfig = characterConfig;
-        }
-
         /**
          * <summary>Sets the <see cref="CharacterConfig"/> field by parsing the provided JSON string.</summary>
          * <param name="characterConfigJson">A JSON string representing the character config.</param>

--- a/Runtime/Scripts/RGBotLocalRuntime/RGBotRunner.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RGBotRunner.cs
@@ -58,10 +58,10 @@ namespace RegressionGames.RGBotLocalRuntime
         {
             if (handshake.characterConfig != null)
             {
-                _rgObject.SetCharacterConfig(handshake.characterConfig);
+                _rgObject.CharacterConfig = handshake.characterConfig;
             }
         }
-        
+
         public void QueueTickInfo(RGTickInfoData tickInfo)
         {
             if (_running)
@@ -71,12 +71,12 @@ namespace RegressionGames.RGBotLocalRuntime
                 _tickInfoQueue.Enqueue(tickInfo);
             }
         }
-        
+
         private void RunBotLoop()
         {
             // configure bot from user code
             _userBotCode.ConfigureBot(_rgObject);
-            
+
             // before we get into the loop, handle handshakes and such
             RGClientHandshake handshakeMessage = new RGClientHandshake();
             handshakeMessage.unityToken = RGServiceManager.RG_UNITY_AUTH_TOKEN;
@@ -85,10 +85,10 @@ namespace RegressionGames.RGBotLocalRuntime
             handshakeMessage.characterConfig = _rgObject.CharacterConfig;
             handshakeMessage.lifecycle = _userBotCode.lifecycle.ToString();
             handshakeMessage.botName = BotInstance.bot.name;
-                
+
             // do the 'handshake'  In remote bots they send a message to cause this, but we'll call it directly just after starting
             RGBotServerListener.GetInstance().HandleClientHandshakeMessage(BotInstance.id, handshakeMessage);
-            
+
             while (_running)
             {
                 if (_rgObject.Completed)
@@ -158,7 +158,7 @@ namespace RegressionGames.RGBotLocalRuntime
                 RGBotServerListener.GetInstance().SetUnityBotState(BotInstance.id, RGUnityBotState.STOPPED);
             }
         }
-        
+
         public void OnDrawGizmos()
         {
             if (_running)


### PR DESCRIPTION
I thought I made `RG.SetCharacterConfigFromJson` a `public` method but I guess not 😩 . Anyway, it needs to be public so that user bots can call it. Our generated Agent Builder code includes a call to `SetCharacterConfigFromJson`:

```csharp
    public class BotEntryPoint : RGBehaviorTreeBot
    {
        protected override bool GetIsSpawnable() => true;
        protected override RGBotLifecycle GetBotLifecycle() => RGBotLifecycle.MANAGED;

        private const string CharacterConfig = @"{}";

        public override void ConfigureBot(RG rgObject)
        {
            rgObject.SetCharacterConfigFromJson(CharacterConfig);
        }

        protected override RootNode BuildBehaviorTree()
        {
            var rootNode = new RootNode();
            rootNode.AddChild(new SequenceNode());

            return rootNode;
        }
    }
```

Also, Rider went ahead and cleaned up some trailing spaces 🤣 . If you turn "Ignore Whitespace" on in the files view, you'll see the only real change.