### PR TITLE
[REG-1401] Update bot namespace loading patterns

### DIFF
--- a/Runtime/Scripts/RGBotLocalRuntime/RGBotRuntimeManager.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RGBotRuntimeManager.cs
@@ -66,10 +66,9 @@ namespace RegressionGames.RGBotLocalRuntime
             var botAssetRecord = RGBotAssetsManager.GetInstance().GetBotAssetRecord(botId);
             if (botAssetRecord != null)
             {
-                var botFolderNamespace =
-                    botAssetRecord.Path.Substring(botAssetRecord.Path.LastIndexOf(Path.DirectorySeparatorChar) + 1);
+                var botNameSpace = botAssetRecord.BotAsset.Bot.name + "_" + botAssetRecord.BotAsset.Bot.id; 
                 
-                RGUserBot userBotCode = (RGUserBot) ScriptableObject.CreateInstance($"{botFolderNamespace}.BotEntryPoint");
+                RGUserBot userBotCode = (RGUserBot) ScriptableObject.CreateInstance($"{botNameSpace}.BotEntryPoint");
                 userBotCode.Init(botId, botAssetRecord.BotAsset.Bot.name);
                 
                 botInstance.bot = botAssetRecord.BotAsset.Bot;


### PR DESCRIPTION
- Updates expected bot namespace pattern to be independent of directory path when possible
  - This isn't perfectly clean, but handles both synced and locally created but unsynced bot cases as best as currently possible.
    - We may have to consider mucking with the user's bot code namespace values when syncing bots as their ids change to avoid them having to do weird work.  I don't like this suggestion, but haven't come up with another way to ensure their namespace is correct 100% of the time.  Basically we'd need to lookup the namespace for their `BotEntryPoint.cs`.  If that namespace didn't comply, then we'd need to change it, as well as any other files that had that exact same namespace.  We can't change ALL files as they may have a complex bot with multiple namespaces.
- See also (https://github.com/Regression-Games/RegressionClient/pull/336)
- See also (https://github.com/Regression-Games/RegressionGames/pull/426)
- See also (https://github.com/Regression-Games/RegressionDocs/pull/45)