### PR TITLE
[REG-1373] Populate state and action json from all scenes

### DIFF
--- a/Editor/Scripts/CodeGenerators/RGCodeGenerator.cs
+++ b/Editor/Scripts/CodeGenerators/RGCodeGenerator.cs
@@ -153,11 +153,8 @@ namespace RegressionGames.Editor.CodeGenerators
                             "Cancel"
                         ))
                     {
-                        foreach (var dirtyScene in dirtyScenes)
-                        {
-                            EditorSceneManager.SaveScenes(dirtyScenes.ToArray());
-                            ExtractGameContextHelper();
-                        }
+                        EditorSceneManager.SaveScenes(dirtyScenes.ToArray());
+                        ExtractGameContextHelper();
                     }
                 }
                 else

--- a/Editor/Scripts/CodeGenerators/RGCodeGenerator.cs
+++ b/Editor/Scripts/CodeGenerators/RGCodeGenerator.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using RegressionGames.RGBotConfigs;
-using RegressionGames.StateActionTypes;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;

--- a/Editor/Scripts/CodeGenerators/RGCodeGenerator.cs
+++ b/Editor/Scripts/CodeGenerators/RGCodeGenerator.cs
@@ -138,8 +138,10 @@ namespace RegressionGames.Editor.CodeGenerators
         private static void ExtractGameContext()
         {
             if (EditorUtility.DisplayDialog(
-                    "Extract Game Context",
-                    "Warning: This operation will load and unload every scene in your project's build configuration while gathering data.  This operation can take a long time to complete depending on the size of your project.",
+                    "Extract Game Context\r\nWarning",
+                    "This operation will load and unload every scene in your project's build configuration while gathering data." +
+                    "\r\n\r\nOnly Scenes that are enabled in your build configuration will be evaluated." +
+                    "\r\n\r\nThis operation can take a long time to complete depending on the size of your project.",
                     "Continue",
                     "Cancel"))
             {

--- a/Editor/Scripts/CodeGenerators/RGCodeGenerator.cs
+++ b/Editor/Scripts/CodeGenerators/RGCodeGenerator.cs
@@ -139,7 +139,7 @@ namespace RegressionGames.Editor.CodeGenerators
         {
             if (EditorUtility.DisplayDialog(
                     "Extract Game Context\r\nWarning",
-                    "This operation will load and unload every scene in your project's build configuration while gathering data." +
+                    "This operation will load and unload every Scene in your project's build configuration while gathering data." +
                     "\r\n\r\nOnly Scenes that are enabled in your build configuration will be evaluated." +
                     "\r\n\r\nThis operation can take a long time to complete depending on the size of your project.",
                     "Continue",


### PR DESCRIPTION
- Handles looking up objectTypes from all scenes, not just the current active ones
  - Includes logic for restoring their editor scenes back to the same open/active scenes they started with, including keeping scenes original loaded/unloaded states.
- Includes prompting to warn about this as well as handle unsaved scene changes.

![image](https://github.com/Regression-Games/RGUnityBots/assets/112959031/f301b611-6b1e-468e-817b-95882bd39ad5)

![Screenshot 2023-11-07 at 11 16 06 AM](https://github.com/Regression-Games/RGUnityBots/assets/112959031/cf81d7b0-6ce3-406d-a84e-1af35fbe2380)
