### PR TITLE
[REG-1423] Fix issues where editor libraries were preventing project builds

### DIFF
--- a/Editor/Scripts/BotManagement/RGBotSynchronizer.cs
+++ b/Editor/Scripts/BotManagement/RGBotSynchronizer.cs
@@ -1,17 +1,16 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 using RegressionGames.RGBotLocalRuntime;
 using RegressionGames.Types;
 using UnityEngine;
 using CompressionLevel = System.IO.Compression.CompressionLevel;
-using File = UnityEngine.Windows.File;
 #if UNITY_EDITOR
-using System;
-using System.IO.Compression;
-using System.Security.Cryptography;
-using System.Threading.Tasks;
 using UnityEditor;
 using UnityEditor.Compilation;
 #endif
@@ -332,7 +331,7 @@ namespace RegressionGames.Editor.BotManagement
         static string CalculateMD5(string filename)
         {
             using var md5 = MD5.Create();
-            using var stream = System.IO.File.OpenRead(filename);
+            using var stream = File.OpenRead(filename);
             
             var hash = md5.ComputeHash(stream);
             return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
@@ -469,6 +468,6 @@ namespace RegressionGames.Editor.BotManagement
 
             return result;
         }
-    }
 #endif
+    }
 }

--- a/Editor/Scripts/CodeGenerators/CodeGeneratorUtils.cs
+++ b/Editor/Scripts/CodeGenerators/CodeGeneratorUtils.cs
@@ -1,9 +1,11 @@
 using System.Text.RegularExpressions;
+#if UNITY_EDITOR
 using UnityEditor;
-using UnityEngine;
+#endif
 
 namespace RegressionGames
 {
+#if UNITY_EDITOR
     public class CodeGeneratorUtils
     {
         public static readonly string HeaderComment = $"/*\r\n* This file has been automatically generated. Do not modify.\r\n*/\r\n\r\n";
@@ -21,4 +23,5 @@ namespace RegressionGames
             return Regex.Replace("RG" + PlayerSettings.productName.Replace(" ", "_"), "[^0-9a-zA-Z_]", "_");
         }
     }
+#endif
 }

--- a/Editor/Scripts/CodeGenerators/GenerateRGActionClasses.cs
+++ b/Editor/Scripts/CodeGenerators/GenerateRGActionClasses.cs
@@ -1,15 +1,17 @@
-
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using UnityEngine;
+#if UNITY_EDITOR
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using UnityEditor;
-using UnityEngine;
+#endif
 
 namespace RegressionGames.Editor.CodeGenerators
 {
+#if UNITY_EDITOR
     // Dev Note: Not perfect, but mega time saver for generating this gook: https://roslynquoter.azurewebsites.net/
     public static class GenerateRGActionClasses
     {
@@ -422,4 +424,5 @@ namespace RegressionGames.Editor.CodeGenerators
         }
 
     }
+#endif
 }

--- a/Editor/Scripts/CodeGenerators/GenerateRGActionMapClass.cs
+++ b/Editor/Scripts/CodeGenerators/GenerateRGActionMapClass.cs
@@ -1,14 +1,17 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using UnityEngine;
+#if UNITY_EDITOR
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using UnityEditor;
-using UnityEngine;
+#endif
 
 namespace RegressionGames.Editor.CodeGenerators
 {
+#if UNITY_EDITOR    
     // Dev Note: Not perfect, but mega time saver for generating this gook: https://roslynquoter.azurewebsites.net/
     public static class GenerateRGActionMapClass
     {
@@ -121,4 +124,5 @@ namespace RegressionGames.Editor.CodeGenerators
         }
 
     }
+#endif
 }

--- a/Editor/Scripts/CodeGenerators/GenerateRGSerializationClass.cs
+++ b/Editor/Scripts/CodeGenerators/GenerateRGSerializationClass.cs
@@ -1,13 +1,16 @@
 using System.Collections.Generic;
 using System.IO;
+using UnityEngine;
+#if UNITY_EDITOR
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using UnityEditor;
-using UnityEngine;
+#endif
 
 namespace RegressionGames.Editor.CodeGenerators
 {
+#if UNITY_EDITOR
     // Dev Note: Not perfect, but mega time saver for generating this gook: https://roslynquoter.azurewebsites.net/
     public static class GenerateRGSerializationClass
     {
@@ -111,4 +114,5 @@ namespace RegressionGames.Editor.CodeGenerators
             return result;
         }
     }
+#endif
 }

--- a/Editor/Scripts/CodeGenerators/GenerateRGStateClasses.cs
+++ b/Editor/Scripts/CodeGenerators/GenerateRGStateClasses.cs
@@ -1,15 +1,18 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using UnityEngine;
+#if UNITY_EDITOR
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using UnityEditor;
-using UnityEngine;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+#endif
 
 namespace RegressionGames.Editor.CodeGenerators
 {
+#if UNITY_EDITOR
     // Dev Note: Not perfect, but mega time saver for generating this gook: https://roslynquoter.azurewebsites.net/
     public static class GenerateRGStateClasses
     {
@@ -415,4 +418,5 @@ namespace RegressionGames.Editor.CodeGenerators
         }
 
     }
+#endif
 }

--- a/Editor/Scripts/CodeGenerators/RGCodeGenerator.cs
+++ b/Editor/Scripts/CodeGenerators/RGCodeGenerator.cs
@@ -4,20 +4,19 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Threading;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Newtonsoft.Json;
 using RegressionGames.RGBotConfigs;
-
-#if UNITY_EDITOR
-using UnityEditor;
-using UnityEditor.SceneManagement;
-#endif
-
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Object = UnityEngine.Object;
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEditor.PackageManager;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+#endif
 
 namespace RegressionGames.Editor.CodeGenerators
 {
@@ -450,7 +449,7 @@ namespace RegressionGames.Editor.CodeGenerators
             var csFiles = Directory.GetFiles(Application.dataPath, "*.cs", SearchOption.AllDirectories).ToHashSet();
             
             // look through all packages that are part of this project
-            var listRequest = UnityEditor.PackageManager.Client.List(true, false);
+            var listRequest = Client.List(true, false);
 
             while (!listRequest.IsCompleted)
             {
@@ -896,6 +895,7 @@ namespace RegressionGames.Editor.CodeGenerators
             string filePath = Path.Combine(folderPath, $"{fileName}.json");
             File.WriteAllText(filePath, json);
         }
+#endif
     }
 
     static class EnumerableExtensions
@@ -913,5 +913,4 @@ namespace RegressionGames.Editor.CodeGenerators
             }
         }
     }
-#endif
 }

--- a/Editor/Scripts/Startup/RegressionPackagePopup.cs
+++ b/Editor/Scripts/Startup/RegressionPackagePopup.cs
@@ -1,18 +1,20 @@
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using RegressionGames;
-using RegressionGames.Editor;
-using RegressionGames.RGBotLocalRuntime;
 using UnityEngine;
+using UnityEngine.Rendering;
+#if UNITY_EDITOR
+using RegressionGames.Editor;
 using UnityEditor;
-using UnityEditor.PackageManager;
 using UnityEditor.PackageManager.Requests;
 using UnityEditor.SceneManagement;
-using UnityEngine.Rendering;
-using RegressionGames.Editor.CodeGenerators;
+#endif
 
+#if UNITY_EDITOR
 public class RegressionPackagePopup : EditorWindow
 {
+
     private const string RGUnityCheck = "rgunitycheck";
     private const string RGWindowCheck = "rgwindowcheck";
     private const string RGGuestCheck = "rgguest";
@@ -55,7 +57,7 @@ public class RegressionPackagePopup : EditorWindow
         if (window == null)
         {
             Rect windowRect = new Rect(100, 100, 600, 600);
-            window = (RegressionPackagePopup)EditorWindow.GetWindowWithRect(typeof(RegressionPackagePopup), windowRect, true, "Welcome to Regression Games!");
+            window = (RegressionPackagePopup)GetWindowWithRect(typeof(RegressionPackagePopup), windowRect, true, "Welcome to Regression Games!");
         }
         else
         {
@@ -392,7 +394,7 @@ public class RegressionPackagePopup : EditorWindow
                 string scenePath = Path.Combine(destinationPath, "Demo", "Scenes", "Playground.unity").Replace("\\", "/");
                 EditorSceneManager.OpenScene(scenePath);
             }
-            catch (System.Exception e)
+            catch (Exception e)
             {
                 RGDebug.LogError("Failed to import sample: " + e.Message);
             }
@@ -463,4 +465,6 @@ public class RegressionPackagePopup : EditorWindow
             window.Repaint();
         }
     }
+
 }
+#endif

--- a/Runtime/Scripts/BehaviorTree/Decorators.cs
+++ b/Runtime/Scripts/BehaviorTree/Decorators.cs
@@ -1,5 +1,4 @@
 using System;
-using Codice.CM.Common;
 using RegressionGames.RGBotLocalRuntime;
 
 namespace RegressionGames.BehaviorTree

--- a/Runtime/Scripts/BehaviorTree/SequenceNode.cs
+++ b/Runtime/Scripts/BehaviorTree/SequenceNode.cs
@@ -1,8 +1,4 @@
-using System.Linq;
-using JetBrains.Annotations;
-using RegressionGames;
 using RegressionGames.RGBotLocalRuntime;
-using TreeEditor;
 
 namespace RegressionGames.BehaviorTree
 {

--- a/Runtime/Scripts/RGBotLocalRuntime/RGBotAssetsManager.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RGBotAssetsManager.cs
@@ -73,7 +73,7 @@ namespace RegressionGames.RGBotLocalRuntime
                 }
             }
 #else
-            //TODO: can't use asset database in real runtime
+            //TODO (REG-1424): can't use asset database in real runtime
 #endif
         }
     }

--- a/Runtime/Scripts/RGBotLocalRuntime/RGBotAssetsManager.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RGBotAssetsManager.cs
@@ -52,6 +52,7 @@ namespace RegressionGames.RGBotLocalRuntime
         {
             _botAssets.Clear();
             
+#if UNITY_EDITOR
             // Load up the listing of available local bots
             string[] botGuids = AssetDatabase.FindAssets("BotRecord", new string[] {"Assets"});
             foreach (var botGuid in botGuids)
@@ -71,6 +72,9 @@ namespace RegressionGames.RGBotLocalRuntime
                     RGDebug.LogWarning($"Bot at path `{botDirectory}` could not be loaded: {ex}");
                 }
             }
+#else
+            //TODO: can't use asset database in real runtime
+#endif
         }
     }
 }

--- a/Runtime/Scripts/RGBotLocalRuntime/RGBotRuntimeManager.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RGBotRuntimeManager.cs
@@ -47,7 +47,7 @@ namespace RegressionGames.RGBotLocalRuntime
             var botInstance = new RGBotInstance
             {
                 // without a live connection to RG, we can't get a DB unique instance Id.. make this a negative random long for now
-                id = RGSettings.GetOrCreateSettings().GetNextBotInstanceId(),
+                id = RGRuntimeProperties.GetNextBotInstanceId(),
                 bot = null, // filled in below
                 lobby = null,
                 createdDate = DateTimeOffset.Now

--- a/Runtime/Scripts/RGRuntimeProperties.cs
+++ b/Runtime/Scripts/RGRuntimeProperties.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+namespace RegressionGames
+{
+    public class RGRuntimeProperties
+    {
+
+        
+        public const string NEXT_BOT_INSTANCE_ID = "RGNextBotInstanceId";
+
+        public static long GetNextBotInstanceId()
+        {
+            var systemId = RGSettings.GetSystemId();
+            var nextId = PlayerPrefs.GetInt(NEXT_BOT_INSTANCE_ID, 0) + 1;
+
+            PlayerPrefs.SetInt(NEXT_BOT_INSTANCE_ID, nextId);
+            
+            // this is so that 'to a human' these ids look sequential
+            if (systemId < 0)
+            {
+                systemId -= nextId;
+            }
+            else
+            {
+                systemId += nextId;
+            }
+            return systemId;
+        }
+    }
+    
+}

--- a/Runtime/Scripts/RGRuntimeProperties.cs.meta
+++ b/Runtime/Scripts/RGRuntimeProperties.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 968d355628d1496d9678a7ca84bef0ee
+timeCreated: 1699973720

--- a/Runtime/Scripts/RGSettings.cs
+++ b/Runtime/Scripts/RGSettings.cs
@@ -102,7 +102,7 @@ namespace RegressionGames
         }
 #endif
 
-        private long GetSystemId()
+        public static long GetSystemId()
         {
             // a machine unique system id shifted into the left side of the long as a human would see it
             return SystemInfo.deviceUniqueIdentifier.GetHashCode() * 1_000_000_000L;
@@ -112,24 +112,9 @@ namespace RegressionGames
         {
             var systemId = GetSystemId();
             var nextId = nextBotId++;
+#if UNITY_EDITOR
             AssetDatabase.SaveAssets();
-            // this is so that 'to a human' these ids look sequential
-            if (systemId < 0)
-            {
-                systemId -= nextId;
-            }
-            else
-            {
-                systemId += nextId;
-            }
-            return systemId;
-        }
-        
-        public long GetNextBotInstanceId()
-        {
-            var systemId = GetSystemId();
-            var nextId = nextBotInstanceId++;
-            AssetDatabase.SaveAssets();
+#endif
             // this is so that 'to a human' these ids look sequential
             if (systemId < 0)
             {

--- a/Runtime/Scripts/RGUtils.cs
+++ b/Runtime/Scripts/RGUtils.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace RegressionGames
 {


### PR DESCRIPTION
- Add `#if UNITY_EDITOR` to files as needed to properly exclude Editor libraries from production builds
  - Unbreaks the ability for users to actually build their projects
  
- We still can't run our bots in their production builds, but we'll fix that as a follow up task as it gets more complicated