### PR TITLE
[REG-1433] Fix issue with enum serialization

### DIFF
--- a/Editor/Scripts/CodeGenerators/GenerateRGActionClasses.cs
+++ b/Editor/Scripts/CodeGenerators/GenerateRGActionClasses.cs
@@ -37,8 +37,10 @@ namespace RegressionGames.Editor.CodeGenerators
                         usings.Add(botAction.Namespace);
                     }
 
+                    var projectNamespace = CodeGeneratorUtils.GetNamespaceForProject();
+                    
                     botAction.GeneratedClassName =
-                        $"RegressionGames.RGAction_{CodeGeneratorUtils.SanitizeActionName(botAction.ActionName)}";
+                        $"{projectNamespace}.RGAction_{CodeGeneratorUtils.SanitizeActionName(botAction.ActionName)}";
 
                     // Create a new compilation unit
                     CompilationUnitSyntax compilationUnit = SyntaxFactory.CompilationUnit()
@@ -47,7 +49,7 @@ namespace RegressionGames.Editor.CodeGenerators
                         )
                         .AddMembers(
                             // Namespace
-                            SyntaxFactory.NamespaceDeclaration(SyntaxFactory.ParseName(CodeGeneratorUtils.GetNamespaceForProject()))
+                            SyntaxFactory.NamespaceDeclaration(SyntaxFactory.ParseName(projectNamespace))
                                 .AddMembers(
                                     // Class declaration
                                     SyntaxFactory

--- a/Runtime/Scripts/DataCollection/RGDataCollection.cs
+++ b/Runtime/Scripts/DataCollection/RGDataCollection.cs
@@ -122,6 +122,11 @@ namespace RegressionGames.DataCollection
         {
             try
             {
+                
+                // Sometimes a client will update the replay data even after the run is finished - copy the replay
+                // data so this doesn't affect our for loops.
+                var replayDatas = _clientIdToReplayData[clientId].ToArray();
+                
                 RGDebug.LogVerbose($"DataCollection[{clientId}] - Starting to save bot instance history");
 
                 var bot = _clientIdToBots[clientId];
@@ -161,8 +166,8 @@ namespace RegressionGames.DataCollection
 
                 // Save text files for each replay tick, zip it up, and then upload
                 RGDebug.LogVerbose(
-                    $"DataCollection[{clientId}] - Zipping the replay data (total of {_clientIdToReplayData[clientId].Count} files)...");
-                foreach (var replayData in _clientIdToReplayData[clientId])
+                    $"DataCollection[{clientId}] - Zipping the replay data (total of {replayDatas.Length} files)...");
+                foreach (var replayData in replayDatas)
                 {
                     var filePath =
                         GetSessionDirectory($"replayData/{clientId}/rgbot_replay_data_{replayData.tickInfo.tick}.txt");
@@ -181,7 +186,7 @@ namespace RegressionGames.DataCollection
 
                 // Save all of the validation data (i.e. the validation summary and validations file overall)
                 RGDebug.LogVerbose($"DataCollection[{clientId}] - Uploading validation data...");
-                var validations = _clientIdToReplayData[clientId]
+                var validations = replayDatas
                     .Where(rd => rd.validationResults?.Length > 0)
                     .SelectMany(rd => rd.validationResults)
                     .ToArray();

--- a/Runtime/Scripts/RGServiceManager.cs
+++ b/Runtime/Scripts/RGServiceManager.cs
@@ -495,7 +495,7 @@ namespace RegressionGames
                 List<string> jsonLines = new List<string>();
                 foreach (var validation in request)
                 {
-                    string jsonString = JsonUtility.ToJson(validation);
+                    string jsonString = JsonConvert.SerializeObject(validation);
                     jsonLines.Add(jsonString);
                 }
 

--- a/Runtime/Scripts/StateActionTypes/RGValidationResult.cs
+++ b/Runtime/Scripts/StateActionTypes/RGValidationResult.cs
@@ -1,5 +1,7 @@
 using System;
 using JetBrains.Annotations;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace RegressionGames.StateActionTypes
 {
@@ -8,6 +10,7 @@ namespace RegressionGames.StateActionTypes
     {
         
         public string name;
+        [JsonConverter(typeof(StringEnumConverter))]
         public RGValidationResultType result;
         public string icon;
         public string id;


### PR DESCRIPTION
Fixes an issue with enum serialization for validations. Before they would be sent as integers, but the frontend expected strings. This has been updated to use strings now.

Also adds a quick fix for a threading issue I saw.

UPDATE: Also adds a quick fix for action classes where the namespace would be incorrect.

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [x] The code is extensible and backward compatible
- [x] New public interfaces are extensible and open to backward compatibility in the future
- [x] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [x] Non-critical or potentially modifiable arguments are optional
- [x] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [x] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [x] Functions and classes are documented
- [x] Migrations for both up and down operations are completed
- [x] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [x] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [x] Style changes and other non-blocking changes are marked as non-blocking from reviewers
