### PR TITLE
Fix for unneeded path fixing in Windows

### DIFF
--- a/Runtime/Scripts/RGBotLocalRuntime/RGBotAssetsManager.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RGBotAssetsManager.cs
@@ -58,7 +58,13 @@ namespace RegressionGames.RGBotLocalRuntime
             foreach (var botGuid in botGuids)
             {
                 var botAssetPath = AssetDatabase.GUIDToAssetPath(botGuid);
-                var botDirectory = botAssetPath.Substring(0, botAssetPath.LastIndexOf(Path.DirectorySeparatorChar));
+                var botDirectory = botAssetPath;
+                var lastIndex = botAssetPath.LastIndexOf(Path.DirectorySeparatorChar);
+                
+                if (lastIndex != -1) 
+                {
+                    botDirectory = botAssetPath.Substring(0, lastIndex);        
+                }
 
                 try
                 {


### PR DESCRIPTION
In Windows, there was an error (described in the linear ticket for this task). I _believe_ this is because in windows, there is no trailing slash included in the path, so there is an out of bounds error when trimming the path because of a -1 index.

However, I have no access to a Windows computer rn, so I cannot confirm that this works. However, I did the next best thing and had GPT review this error, and it came to the same conclusion and reasoning, so I'm pretty confident this should work... https://chat.openai.com/share/1b7c364c-9a91-4ac1-ba2e-f14e1560d2ef

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
