### PR TITLE
[REG-1415] Upload bot when there's no bot code

### DIFF
--- a/Editor/Scripts/BotManagement/RGBotSynchronizer.cs
+++ b/Editor/Scripts/BotManagement/RGBotSynchronizer.cs
@@ -264,6 +264,12 @@ namespace RegressionGames.Editor.BotManagement
         {
             bool ShouldUpload(RGBotCodeDetails rgBotCodeDetails)
             {
+                if (rgBotCodeDetails == null)
+                {
+                    // No code on the server? Definitely upload.
+                    return true;
+                }
+
                 // Server-owned code should always be downloaded.
                 if (remoteBot.CodeIsServerOwned)
                 {
@@ -306,16 +312,8 @@ namespace RegressionGames.Editor.BotManagement
                 () => { }
             );
 
-            if (botCodeDetails is null)
-            {
-                // Unlikely unless the server is having a problem, but we should handle it.
-                // Just don't sync this bot
-                RGDebug.LogWarning($"Server reported no code for bot {remoteBot.id}. Skipping sync.");
-                return false;
-            }
-
-            // If the checksums match, we're done
-            if (localMd5 == botCodeDetails.md5)
+            // If the checksums match, no sync is required at all
+            if (botCodeDetails != null && localMd5 == botCodeDetails.md5)
             {
                 RGDebug.LogDebug(
                     $"RG Bot Id: {remoteBot.id} is up to date; local md5: {localMd5} == remote md5: {botCodeDetails.md5}");


### PR DESCRIPTION
Oof, missed a case when testing #96. If there's no bot on the server, we create a record. But then, when we go to fetch the server-side code details to check if we should upload, we find there is no code and assume that means we shouldn't upload. This was a misunderstanding on my part, assuming that meant there would be nothing to sync, but that's not the case 🤦🏻‍♀️ .

The fix here is simple: if there's no code on the server, we must upload!

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [x] The code is extensible and backward compatible
- [x] New public interfaces are extensible and open to backward compatibility in the future
- [x] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [x] Non-critical or potentially modifiable arguments are optional
- [x] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [x] The code is easy to read
- [x] Unit tests are added for expected and edge cases
- [x] Integration tests are added for expected and edge cases
- [x] Functions and classes are documented
- [x] Migrations for both up and down operations are completed
- [x] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [x] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [x] Style changes and other non-blocking changes are marked as non-blocking from reviewers
