### PR TITLE
[REG-1461] Fix bot creation and loading on Windows

### DIFF
--- a/Editor/Scripts/BotManagement/RGBotSynchronizer.cs
+++ b/Editor/Scripts/BotManagement/RGBotSynchronizer.cs
@@ -433,7 +433,8 @@ namespace RegressionGames.Editor.BotManagement
         private void CreateNewBotAssets(string folderName, string botName, long botId)
         {
             RGDebug.LogInfo($"Creating new Regression Games Unity bot at path {folderName}");
-            var botFolderShortName = folderName.Substring(folderName.LastIndexOf(Path.DirectorySeparatorChar)+1);
+            // unity assets always use '/' regardless of Operating System
+            var botFolderShortName = folderName.Substring(folderName.LastIndexOf('/')+1);
 
             // create `Bot` record asset
             CreateBotAssetFile(folderName, botName, botId, null);

--- a/Runtime/Scripts/RGBotLocalRuntime/RGBotAssetsManager.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RGBotAssetsManager.cs
@@ -58,13 +58,8 @@ namespace RegressionGames.RGBotLocalRuntime
             foreach (var botGuid in botGuids)
             {
                 var botAssetPath = AssetDatabase.GUIDToAssetPath(botGuid);
-                var botDirectory = botAssetPath;
-                var lastIndex = botAssetPath.LastIndexOf(Path.DirectorySeparatorChar);
-                
-                if (lastIndex != -1) 
-                {
-                    botDirectory = botAssetPath.Substring(0, lastIndex);        
-                }
+                // unity assets always use '/' regardless of Operating System
+                var botDirectory = botAssetPath.Substring(0, botAssetPath.LastIndexOf('/'));
 
                 try
                 {

--- a/Runtime/Scripts/RGBotLocalRuntime/RGBotRuntimeManager.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RGBotRuntimeManager.cs
@@ -68,8 +68,9 @@ namespace RegressionGames.RGBotLocalRuntime
                     ? $"_n{-1 * botAssetRecord.BotAsset.Bot.id}"
                     : $"_{botAssetRecord.BotAsset.Bot.id}";
                 var botNameSpace = botAssetRecord.BotAsset.Bot.name + botIdKey;
+                // unity assets always use '/' regardless of Operating System
                 var botFolderNamespace =
-                    botAssetRecord.Path.Substring(botAssetRecord.Path.LastIndexOf(Path.DirectorySeparatorChar) + 1);
+                    botAssetRecord.Path.Substring(botAssetRecord.Path.LastIndexOf('/') + 1);
                 try
                 {
                     userBotCode = (RGUserBot)ScriptableObject.CreateInstance($"{botNameSpace}.BotEntryPoint");


### PR DESCRIPTION
- Fixes namespace generation bug introduced in (https://github.com/Regression-Games/RGUnityBots/pull/100)
- Fixes asset pathing for both Windows and Mac for bot creation and loading