### PR TITLE
[REG-1474] Expose the tick number to local bots

### DIFF
--- a/Runtime/Scripts/RGBotLocalRuntime/RG.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RG.cs
@@ -32,6 +32,11 @@ namespace RegressionGames.RGBotLocalRuntime
          * <summary>{string} The current game scene name.</summary>
          */
         public string SceneName => _tickInfo.sceneName;
+        
+        /**
+         * <summary>{long} The current tick since the start of the first bot that was run this session.</summary>
+         */
+        public long Tick => _tickInfo.tick;
 
         /**
          * <summary>Mark this bot complete and ready for teardown.</summary>


### PR DESCRIPTION
Exposes the tick number as a property that can be accessed from the rgObject argument in local bots. Useful for scenarios where you want your bots to wait for a certain amount of time.

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [x] The code is extensible and backward compatible
- [x] New public interfaces are extensible and open to backward compatibility in the future
- [x] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [x] Non-critical or potentially modifiable arguments are optional
- [x] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [x] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [x] Functions and classes are documented
- [x] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
