### PR TITLE
[REG-1475] Support raw key presses in bots

### DIFF
--- a/Runtime/Scripts/DebugUtils/BillboardText.cs
+++ b/Runtime/Scripts/DebugUtils/BillboardText.cs
@@ -6,7 +6,7 @@ public class BillboardText : MonoBehaviour
 {
     private TextMeshProUGUI _text;
     public string content = "";
-    public float yOffset = 2f;
+    public Vector3 offset = new Vector3(0f, 2f, 0f);
     public GameObject target;
     
     void Awake()
@@ -25,7 +25,7 @@ public class BillboardText : MonoBehaviour
         }
         
         // Now update our position to be the same as the target
-        transform.position = target.transform.position + new Vector3(0, yOffset, 0);
+        transform.position = target.transform.position + offset;
         
         // Then rotate to face the camera
         Transform camTransform = Camera.main != null ? Camera.main.transform : null;

--- a/Runtime/Scripts/DebugUtils/RGGizmos.cs
+++ b/Runtime/Scripts/DebugUtils/RGGizmos.cs
@@ -7,24 +7,24 @@ using Object = UnityEngine.Object;
 
 namespace RegressionGames.DebugUtils
 {
-    
+
     /**
      * A set of debug utilities for drawing gizmos and text on top of entities in your scene.
      */
     // ReSharper disable once InconsistentNaming
     public class RGGizmos
     {
-        
+
         const string BillboardTextAsset = "AgentBillboardText";
-        
+
         private readonly ConcurrentDictionary<string, (int, Vector3, Color)> _linesFromEntityToPosition = new();
         private readonly ConcurrentDictionary<string, (int, int, Color)> _linesFromEntityToEntity = new();
         private readonly ConcurrentDictionary<string, (Vector3, Vector3, Color)> _linesFromPositionToPosition = new();
         private readonly ConcurrentDictionary<string, (Vector3, Color, float, bool)> _spheresAtPosition = new();
         private readonly ConcurrentDictionary<string, (int, Color, float, bool)> _spheresAtEntity = new();
-        private readonly ConcurrentDictionary<int, (string, float)> _billboardsToDraw = new();
+        private readonly ConcurrentDictionary<int, (string, Vector3)> _billboardsToDraw = new();
         private readonly ConcurrentDictionary<int, GameObject> _drawnBillboards = new();
-        
+
         // Billboard text objects
         private readonly GameObject _billboardAsset;
 
@@ -69,7 +69,7 @@ namespace RegressionGames.DebugUtils
          * <seealso cref="DestroyLine"/>
          * <seealso cref="DestroyAllLines"/>
          */
-        public void CreateLine(Vector3 startPosition, int endEntityId, Color color, string name) => 
+        public void CreateLine(Vector3 startPosition, int endEntityId, Color color, string name) =>
             CreateLine(endEntityId, startPosition, color, name);
 
         /**
@@ -90,7 +90,7 @@ namespace RegressionGames.DebugUtils
          * <seealso cref="DestroyLine"/>
          * <seealso cref="DestroyAllLines"/>
          */
-        public void CreateLine(int startEntityId, int endEntityId, Color color, string name) => 
+        public void CreateLine(int startEntityId, int endEntityId, Color color, string name) =>
             _linesFromEntityToEntity[name] = (startEntityId, endEntityId, color);
 
         /**
@@ -111,7 +111,7 @@ namespace RegressionGames.DebugUtils
          * <seealso cref="DestroyLine"/>
          * <seealso cref="DestroyAllLines"/>
          */
-        public void CreateLine(Vector3 startPosition, Vector3 endPosition, Color color, string name) => 
+        public void CreateLine(Vector3 startPosition, Vector3 endPosition, Color color, string name) =>
             _linesFromPositionToPosition[name] = (startPosition, endPosition, color);
 
         /**
@@ -149,7 +149,7 @@ namespace RegressionGames.DebugUtils
             _linesFromEntityToEntity.Clear();
             _linesFromPositionToPosition.Clear();
         }
-        
+
         /**
          * <summary>
          * Creates a sphere at the given position. The sphere will persist until removed using
@@ -169,7 +169,7 @@ namespace RegressionGames.DebugUtils
          * <seealso cref="DestroySphere"/>
          * <seealso cref="DestroyAllSpheres"/>
          */
-        public void CreateSphere(Vector3 position, Color color, float size, bool isWireframe, string name) => 
+        public void CreateSphere(Vector3 position, Color color, float size, bool isWireframe, string name) =>
             _spheresAtPosition[name] = (position, color, size, isWireframe);
 
         /**
@@ -191,7 +191,7 @@ namespace RegressionGames.DebugUtils
          * <seealso cref="DestroySphere"/>
          * <seealso cref="DestroyAllSpheres"/>
          */
-        public void CreateSphere(int entityId, Color color, float size, bool isWireframe, string name) => 
+        public void CreateSphere(int entityId, Color color, float size, bool isWireframe, string name) =>
             _spheresAtEntity[name] = (entityId, color, size, isWireframe);
 
         /**
@@ -227,7 +227,7 @@ namespace RegressionGames.DebugUtils
             _spheresAtPosition.Clear();
             _spheresAtEntity.Clear();
         }
-        
+
         /**
          * <summary>
          * Creates a text billboard on an entity with the given id. The text will persist until removed using
@@ -241,7 +241,7 @@ namespace RegressionGames.DebugUtils
          * </remarks>
          * <param name="entityId">The entity of the id to place this text billboard.</param>
          * <param name="content">The content of the text billboard.</param>
-         * <param name="yOffset">The y offset of the text billboard (defaults to 2.0).</param>
+         * <param name="offset">The Vector3 offset of the text billboard (defaults to 0f,2.0f,0f).</param>
          * <example>
          * <code>
          * // Create a text billboard on an entity with id 1 with the content "Hello World!".
@@ -251,8 +251,10 @@ namespace RegressionGames.DebugUtils
          * <seealso cref="DestroyText"/>
          * <seealso cref="DestroyAllTexts"/>
          */
-        public void CreateText(int entityId, string content, float yOffset = 2.0f) => 
-            _billboardsToDraw[entityId] = (content, yOffset);
+        public void CreateText(int entityId, string content, Vector3? offset = null)
+        {
+            _billboardsToDraw[entityId] = (content, offset ?? new Vector3(0f, 2f, 0f));
+        }
 
         /**
          * <summary>
@@ -289,7 +291,7 @@ namespace RegressionGames.DebugUtils
          * Draws all Gizmos that have been set.
          * </summary>
          */
-        protected internal void OnDrawGizmos()
+        public void OnDrawGizmos()
         {
 
             var gizmosContainer = GameObject.Find("RGGizmosContainer");
@@ -389,7 +391,7 @@ namespace RegressionGames.DebugUtils
                     // Then set the parameters
                     var billboardText = billboard.GetComponent<BillboardText>();
                     billboardText.content = billboardParams.Value.Item1;
-                    billboardText.yOffset = billboardParams.Value.Item2;
+                    billboardText.offset = billboardParams.Value.Item2;
                     billboardText.target = entityGameObject.gameObject;
                 }
                 catch (MissingReferenceException e)

--- a/Runtime/Scripts/RGBotConfigs/RGAction_KeyPress.cs
+++ b/Runtime/Scripts/RGBotConfigs/RGAction_KeyPress.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using RegressionGames.StateActionTypes;
+using RegressionGames.DebugUtils;
+using UnityEngine;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Controls;
+using UnityEngine.InputSystem.LowLevel;
+#endif
+
+// ReSharper disable InconsistentNaming
+namespace RegressionGames.RGBotConfigs
+{
+ 
+    [RequireComponent(typeof(RGEntity))]
+    [DisallowMultipleComponent]
+    
+    public class RGAction_KeyPress: RGAction
+    {
+        [Tooltip("Draw debug gizmos for current key inputs in editor runtime ?")]
+        public bool renderDebugGizmos = false;
+
+        public Vector3 debugGizmosOffset = new Vector3(0f,-1f,2f);
+        
+#if ENABLE_INPUT_SYSTEM
+        // Allow this on any RGEntity that has an InputActionAsset
+        public InputActionAsset InputAction;
+#endif   
+        
+        private ConcurrentQueue<RG_KeyPress_Data> _keysToPress = new();
+
+        private Dictionary<Key, InputControl> _inputActions = new();
+        private InputControl _anyKey = null;
+        
+        private Dictionary<Key, double> keysDown = new();
+
+        private RGGizmos RgGizmos;
+
+        private void Start()
+        {
+#if ENABLE_INPUT_SYSTEM
+            this.RgGizmos = new();
+            if (InputAction == null)
+            {
+                throw new Exception("RGAction_KeyPress requires an InputActionAsset to be specified");
+            }
+
+            foreach (var inputActionActionMap in InputAction.actionMaps)
+            {
+                foreach (var inputAction in inputActionActionMap)
+                {
+                    foreach (var inputActionControl in inputAction.controls)
+                    {
+                        if (inputActionControl is KeyControl iac)
+                        {
+                            _inputActions.Add(iac.keyCode, inputActionControl);    
+                        }
+                        else if (inputActionControl is AnyKeyControl)
+                        {
+                            _anyKey = inputActionControl;
+                        }
+                    }
+                }
+            }
+#endif
+        }
+
+        public void Update()
+        {
+#if ENABLE_INPUT_SYSTEM
+            // one button click per frame update
+            if (_keysToPress.TryDequeue(out RG_KeyPress_Data keyToPress))
+            {
+                List<InputControl> actionsToTake = new();
+                // check for any key 
+                if (_anyKey != null)
+                {
+                    actionsToTake.Add(_anyKey);
+                }
+
+                var theKey = _inputActions.GetValueOrDefault(keyToPress.keyId, null);
+                if (theKey != null)
+                {
+                    actionsToTake.Add(theKey);
+                }
+
+                foreach (var control in actionsToTake)
+                {
+                    PressKey(keyToPress.keyId, control, keyToPress.holdTime);
+                }
+            }
+            
+            // handle un-pressing any keys that have expired their time
+            var keys = keysDown.Keys.ToList();
+            foreach (var key in keys)
+            {
+                // this is < instead of <= so that keys last at least 1 frame
+                if (keysDown[key] < Time.unscaledTime)
+                {
+                    // dictionary will have this value because we clicked it
+                    UnPressKey(key, _inputActions.GetValueOrDefault(key));
+                }
+            }
+
+            if (keysDown.Count == 0 && _anyKey != null)
+            {
+                // un-press the 'any' key
+                UnPressKey(null, _anyKey);
+            }
+            
+            int id = gameObject.transform.GetInstanceID();
+            // render debug text
+            if (renderDebugGizmos)
+            {
+                var debugText = "";
+                var keysList = keysDown.ToList();
+                keysList.Sort((a,b) => a.Key-b.Key);
+                foreach (var (key,value) in keysList)
+                {
+                    debugText += $"{key.ToString()} : {(value-Time.unscaledTime):F2}\r\n";
+                }
+
+                
+                if (string.IsNullOrEmpty(debugText))
+                {
+                    RgGizmos.DestroyText(id);
+                }
+                else
+                {
+                    RgGizmos.CreateText(id, debugText, debugGizmosOffset);
+                }
+
+                // force updating these now
+                RgGizmos.OnDrawGizmos();
+            }
+            else
+            {
+                RgGizmos.DestroyText(id);
+                // force updating these now
+                RgGizmos.OnDrawGizmos();
+            }
+            
+            // Update Input System
+            InputSystem.Update();
+#endif
+        }
+
+        private void DrawDebugText()
+        {
+#if ENABLE_INPUT_SYSTEM
+            // render debug text
+            if (renderDebugGizmos)
+            {
+                var debugText = "";
+                var keysList = keysDown.ToList();
+                keysList.Sort((a,b) => (int)Math.Round(a.Value-b.Value, 0));
+                foreach (var (key,value) in keysList)
+                {
+                    debugText += $"{key.ToString()} : {Math.Truncate((value-Time.unscaledTime) * 100) / 100}\r\n";
+                }
+
+                int id = gameObject.transform.GetInstanceID();
+                if (string.IsNullOrEmpty(debugText))
+                {
+                    RgGizmos.DestroyText(id);
+                }
+                else
+                {
+                    RgGizmos.CreateText(id, debugText, debugGizmosOffset);
+                }
+
+                // force drawing these now
+                RgGizmos.OnDrawGizmos();
+            }
+#endif
+        }
+
+        private void UnPressKey(Key? key, InputControl control)
+        {
+            // 1 == pressed state
+            // 0 == un-pressed state
+            void SetUpAndQueueEvent<TValue>(InputEventPtr eventPtr, TValue state) where TValue: struct
+            {
+                eventPtr.time = InputState.currentTime;
+                control.WriteValueIntoEvent(state, eventPtr);
+                InputSystem.QueueEvent(eventPtr);
+            }
+            
+            using (DeltaStateEvent.From(control, out var eventPtr))
+            {
+                SetUpAndQueueEvent(eventPtr, 0f);
+                if (key != null)
+                {
+                    keysDown.Remove((Key)key);
+                }
+            }
+        }
+
+        private void PressKey(Key key, InputControl control, double holdTime = -1f)
+        {
+            // 1 == pressed state
+            // 0 == un-pressed state
+            void SetUpAndQueueEvent<TValue>(InputEventPtr eventPtr, TValue state) where TValue: struct
+            {
+                eventPtr.time = InputState.currentTime;
+                control.WriteValueIntoEvent(state, eventPtr);
+                InputSystem.QueueEvent(eventPtr);
+            }
+            
+            using (DeltaStateEvent.From(control, out var eventPtr))
+            {
+                var hasKeyDown = keysDown.ContainsKey(key);
+                // set or update the un-press time tracker
+                var timeToUnPress = Time.unscaledTime + (holdTime > 0f ? holdTime : 0f);
+                keysDown[key] = timeToUnPress;
+                if (!hasKeyDown)
+                {
+                    SetUpAndQueueEvent(eventPtr, 1f);
+                }
+            }
+        }
+
+        public override string GetActionName()
+        {
+            return "KeyPress";
+        }
+
+        public override void StartAction(Dictionary<string, object> input)
+        {
+            object keyId = input.GetValueOrDefault("keyId", null);
+            object holdTime = input.GetValueOrDefault("holdTime", null);
+
+            try
+            {
+                if (keyId != null)
+                {
+                    Key key;
+                    if (keyId is Key id)
+                    {
+                        key = id;
+                    }
+                    else
+                    {
+                        if (!Enum.TryParse(keyId.ToString(), out key))
+                        {
+                            RGDebug.LogWarning(
+                                $"WARNING: Ignoring RGAction_KeyPress with missing/invalid input for keyId: {keyId} or holdTime: {holdTime}");
+                            return;
+                        }
+                    }
+                    double? htDouble = null;
+                    if (holdTime != null)
+                    {
+                        htDouble = Convert.ToDouble(holdTime);
+                    }
+
+                    _keysToPress.Enqueue(new RG_KeyPress_Data(key, htDouble));
+                }
+                else
+                {
+                    RGDebug.LogWarning(
+                        $"WARNING: Ignoring RGAction_KeyPress with missing/invalid input for keyId: {keyId} or holdTime: {holdTime}");
+                }
+            }
+            catch (Exception e)
+            {
+                RGDebug.LogWarning($"WARNING: Ignoring RGAction_KeyPress with missing/invalid input for keyId: {keyId} or holdTime: {holdTime}");
+            }
+        }
+    }
+    
+    internal class RG_KeyPress_Data
+    {
+        public readonly Key keyId;
+        public readonly double holdTime = -1f;
+
+        public RG_KeyPress_Data(Key keyId, double? holdTime)
+        {
+            this.keyId = keyId;
+            if (holdTime != null)
+            {
+                this.holdTime = (double)holdTime;
+            }
+        }
+    }
+
+    public class RGActionRequest_KeyPress : RGActionRequest
+    {
+        public RGActionRequest_KeyPress(Key keyId, double holdTime = -1f)
+        {
+            action = "KeyPress";
+            Input = new() { { "keyId", keyId }, {"holdTime", holdTime} };
+        }
+    }
+}

--- a/Runtime/Scripts/RGBotConfigs/RGAction_KeyPress.cs.meta
+++ b/Runtime/Scripts/RGBotConfigs/RGAction_KeyPress.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7f6ac6697ed643e39a331556f2725a02
+timeCreated: 1701109006

--- a/Runtime/Scripts/RegressionGames.asmdef
+++ b/Runtime/Scripts/RegressionGames.asmdef
@@ -2,6 +2,7 @@
     "name": "RegressionGames",
     "rootNamespace": "",
     "references": [
+        "Unity.InputSystem",
         "Unity.TextMeshPro"
     ],
     "includePlatforms": [],

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "3.1.0",
-    "com.unity.textmeshpro": "3.0.6"
+    "com.unity.textmeshpro": "3.0.6",
+    "com.unity.inputsystem": "1.6.0"
   },
   "samples": [
     {


### PR DESCRIPTION
- Adds a new `RGAction_KeyPress` class that supports raw key input events using Unity's InputSystem for bots
- Updates RGGizmos to support Vector3 offsets instead of just yOffsets <- **THIS IS NOT BACKWARDS COMPATIBLE**
  - This will currently only impact other RG developers and their example bots (like @vontell racer bot)
- Updates RGGizmos to be usable by our SDK internals, not just user bot code.
- Discussion Points/Todos
  - This currently REQUIRES inclusion of Unity's InputSystem as a dependency, thus limiting our supported customer set.  I need help finding a way to restructure our unity package (and repo) so that we can easily package stuff like this as 'additional downloads'
    - I found a limitation of manually created RGAction classes in our generation code for agent builder.  We handled this pretty well for states, but need some work for actions to make this fully generic.  See [(Linear REG-1476)](https://linear.app/regression-games/issue/REG-1476/unity-sdk-find-hand-coded-rgaction-classes-in-ab-extract)
  - Documentation additions/updates about using this in bots
- Bot Code Example
```csharp
        private long _millis = 0;

        public override void ProcessTick(RG rgObject)
        {
            //Push a random key every second and hold it for 2 seconds
            long milliseconds = DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
            if (milliseconds - _millis > 1000)
            {
                _millis = milliseconds;

                var thisEntity = rgObject.FindPlayers().First();
                
                try
                {
                    Key[] keys = { Key.W, Key.A, Key.S, Key.D };
                    var random = new System.Random();
                    var index = random.Next(0, keys.Length);
                    var action = new RGActionRequest_KeyPress(keys[index], 2.0);
                    rgObject.PerformAction(action);
                }
                catch (Exception ex)
                {
                    RGDebug.LogError($"Error pressing key: {ex}");
                }
            }
        }
```

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
