### PR TITLE
[REG-1479] Default objectType to the gameObject name less qualifiers

### DIFF
--- a/Runtime/Scripts/RGBotConfigs/RGEntity.cs
+++ b/Runtime/Scripts/RGBotConfigs/RGEntity.cs
@@ -9,7 +9,7 @@ namespace RegressionGames.RGBotConfigs
     [DisallowMultipleComponent]
     public class RGEntity : MonoBehaviour
     {
-        [Tooltip("A type name for associating like objects in the state")]
+        [Tooltip("A type name for associating like objects in the state.  If this is not specified, the system will use the name of the GameObject up to the first '(' as the objectType.  This default attempts to group similar objects into the same objectType.")]
         public string objectType;
         
         [Tooltip("Does this object represent a human/bot player ?")]

--- a/Runtime/Scripts/RGBotConfigs/RGState.cs
+++ b/Runtime/Scripts/RGBotConfigs/RGState.cs
@@ -93,7 +93,20 @@ namespace RegressionGames.RGBotConfigs
             var theTransform = rgEntity.transform;
             
             state["id"] = theTransform.GetInstanceID();
-            state["type"] = rgEntity.objectType;
+            // default to the gameObject name without uniqueness numbers
+            var otName = rgEntity.objectType.Trim();
+            if (string.IsNullOrEmpty(otName))
+            {
+                var goName = rgEntity.gameObject.name;
+                var index = goName.IndexOf('(');
+                if (index > 0)
+                {
+                    goName = goName.Substring(0, index);
+                }
+                otName = goName.Trim();
+            }
+
+            state["type"] = otName;
             state["isPlayer"] = rgEntity.isPlayer;
             state["isRuntimeObject"] = rgEntity.isRuntimeObject;
             state["position"] = theTransform.position;


### PR DESCRIPTION
- Defaults the `RGEntity` objectType to the name of the GameObject if not specified.

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
