### PR TITLE
[REG-1425] Handle replay data / screenshot / validation disk buffering

### DIFF
--- a/Runtime/Scripts/RGBotLocalRuntime/RGBotRuntimeManager.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RGBotRuntimeManager.cs
@@ -93,7 +93,7 @@ namespace RegressionGames.RGBotLocalRuntime
                 RGClientConnection connection = RGBotServerListener.GetInstance()
                     .AddClientConnectionForBotInstance(botInstance.id, RGClientConnectionType.LOCAL);
                 
-                // Also attack the bot so we can upload later
+                // Also attach the bot so we can upload later
                 RGBotServerListener.GetInstance().MapClientToLocalBot(botInstance.id, botAssetRecord.BotAsset.Bot);
 
                 var botRunner = new RGBotRunner(botInstance, userBotCode,

--- a/Runtime/Scripts/RGServiceManager.cs
+++ b/Runtime/Scripts/RGServiceManager.cs
@@ -483,26 +483,14 @@ namespace RegressionGames
         /**
          * Uploads all validations for the bot instance to Regression Games in JSONL format
          */
-        public async Task UploadValidations(long botInstanceId, RGValidationResult[] request, Action onSuccess, Action onFailure)
+        public async Task UploadValidations(long botInstanceId, string filePath, Action onSuccess, Action onFailure)
         {
             if (await EnsureAuthed())
             {
-
-                // Convert the list into JSONL format
-                List<string> jsonLines = new List<string>();
-                foreach (var validation in request)
-                {
-                    string jsonString = JsonConvert.SerializeObject(validation);
-                    jsonLines.Add(jsonString);
-                }
-
-                // Combine the JSON strings with newline characters
-                string jsonLinesString = string.Join("\n", jsonLines);
-
-                await SendWebRequest(
+                await SendWebFileUploadRequest(
                     uri: $"{GetRgServiceBaseUri()}/bot-instance-history/{botInstanceId}/validations",
                     method: "POST",
-                    payload: jsonLinesString,
+                    filePath: filePath,
                     contentType: "application/jsonl",
                     onSuccess: async (s) =>
                     {


### PR DESCRIPTION
- Asynchronously writes replay data, validations, screenshots, etc to disk on each tick to avoid filling up memory with the data
  - Tracks validation summary in a running fashion for each client in memory
- Uploads the data from the files directly without fully reading into memory first

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
