### PR TITLE
[RG-1489] Use 'RGDebug.LogException' as required

### DIFF
--- a/Editor/Scripts/Startup/RegressionPackagePopup.cs
+++ b/Editor/Scripts/Startup/RegressionPackagePopup.cs
@@ -396,7 +396,8 @@ public class RegressionPackagePopup : EditorWindow
             }
             catch (Exception e)
             {
-                RGDebug.LogError("Failed to import sample: " + e.Message);
+                RGDebug.LogError("Failed to import sample");
+                RGDebug.LogException(e);
             }
         }
         else

--- a/Editor/Scripts/Startup/RegressionPackagePopup.cs
+++ b/Editor/Scripts/Startup/RegressionPackagePopup.cs
@@ -396,8 +396,7 @@ public class RegressionPackagePopup : EditorWindow
             }
             catch (Exception e)
             {
-                RGDebug.LogError("Failed to import sample");
-                RGDebug.LogException(e);
+                RGDebug.LogException(e, "Failed to import sample");
             }
         }
         else

--- a/Runtime/Scripts/DataCollection/RGDataCollection.cs
+++ b/Runtime/Scripts/DataCollection/RGDataCollection.cs
@@ -291,7 +291,8 @@ namespace RegressionGames.DataCollection
             }
             catch (Exception e)
             {
-                RGDebug.LogError($"DataCollection[{clientId}] - Error uploading data: {e}");
+                RGDebug.LogError($"DataCollection[{clientId}] - Error uploading data");
+                RGDebug.LogException(e);
                 throw;
             }
             finally

--- a/Runtime/Scripts/DataCollection/RGDataCollection.cs
+++ b/Runtime/Scripts/DataCollection/RGDataCollection.cs
@@ -291,8 +291,7 @@ namespace RegressionGames.DataCollection
             }
             catch (Exception e)
             {
-                RGDebug.LogError($"DataCollection[{clientId}] - Error uploading data");
-                RGDebug.LogException(e);
+                RGDebug.LogException(e, $"DataCollection[{clientId}] - Error uploading data");
                 throw;
             }
             finally

--- a/Runtime/Scripts/RGBotLocalRuntime/RGBotRunner.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RGBotRunner.cs
@@ -142,8 +142,8 @@ namespace RegressionGames.RGBotLocalRuntime
                         }
                         catch (Exception ex)
                         {
-                            RGDebug.LogError($"ERROR: Bot instanceId: {BotInstance.id}, botName: {BotInstance.bot.name}, botId: {BotInstance.bot.id} crashed due to an uncaught exception.");
-                            RGDebug.LogException(ex);
+                            RGDebug.LogException(ex, 
+                                $"ERROR: Bot instanceId: {BotInstance.id}, botName: {BotInstance.bot.name}, botId: {BotInstance.bot.id} crashed due to an uncaught exception.");
                             _running = false;
                             RGBotServerListener.GetInstance().SetUnityBotState(BotInstance.id, RGUnityBotState.ERRORED);
                         }

--- a/Runtime/Scripts/RGBotLocalRuntime/RGBotRunner.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RGBotRunner.cs
@@ -142,7 +142,8 @@ namespace RegressionGames.RGBotLocalRuntime
                         }
                         catch (Exception ex)
                         {
-                            RGDebug.LogError($"ERROR: Bot instanceId: {BotInstance.id}, botName: {BotInstance.bot.name}, botId: {BotInstance.bot.id} crashed due to an uncaught exception. - {ex}");
+                            RGDebug.LogError($"ERROR: Bot instanceId: {BotInstance.id}, botName: {BotInstance.bot.name}, botId: {BotInstance.bot.id} crashed due to an uncaught exception.");
+                            RGDebug.LogException(ex);
                             _running = false;
                             RGBotServerListener.GetInstance().SetUnityBotState(BotInstance.id, RGUnityBotState.ERRORED);
                         }

--- a/Runtime/Scripts/RGBotLocalRuntime/SampleBot/RGSampleBot.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/SampleBot/RGSampleBot.cs
@@ -68,8 +68,7 @@ namespace RegressionGames.RGBotLocalRuntime.SampleBot
             }
             catch (Exception ex)
             {
-                RGDebug.LogError($"Error getting target position.");
-                RGDebug.LogException(ex);
+                RGDebug.LogException(ex, $"Error getting target position.");
             }
         }
     }

--- a/Runtime/Scripts/RGBotLocalRuntime/SampleBot/RGSampleBot.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/SampleBot/RGSampleBot.cs
@@ -68,7 +68,8 @@ namespace RegressionGames.RGBotLocalRuntime.SampleBot
             }
             catch (Exception ex)
             {
-                RGDebug.LogError($"Error getting target position: {ex}");
+                RGDebug.LogError($"Error getting target position.");
+                RGDebug.LogException(ex);
             }
         }
     }

--- a/Runtime/Scripts/RGBotLocalRuntime/Template/BotEntryPoint.cs.template
+++ b/Runtime/Scripts/RGBotLocalRuntime/Template/BotEntryPoint.cs.template
@@ -69,7 +69,8 @@ namespace <TEMPLATE_NAMESPACE>
             }
             catch (Exception ex)
             {
-                RGDebug.LogError($"Error getting target position: {ex}");
+                RGDebug.LogError($"Error getting target position.");
+                RGDebug.LogException(ex);
             }
         }
     }

--- a/Runtime/Scripts/RGBotLocalRuntime/Template/BotEntryPoint.cs.template
+++ b/Runtime/Scripts/RGBotLocalRuntime/Template/BotEntryPoint.cs.template
@@ -68,9 +68,8 @@ namespace <TEMPLATE_NAMESPACE>
                 }
             }
             catch (Exception ex)
-            {
-                RGDebug.LogError($"Error getting target position.");
-                RGDebug.LogException(ex);
+            {                
+                RGDebug.LogException(ex, $"Error getting target position.");
             }
         }
     }

--- a/Runtime/Scripts/RGBotServerListener.cs
+++ b/Runtime/Scripts/RGBotServerListener.cs
@@ -473,8 +473,7 @@ namespace RegressionGames
                     }
                     catch (Exception ex)
                     {
-                        RGDebug.LogError($"Exception during main thread action processing");
-                        RGDebug.LogException(ex);
+                        RGDebug.LogException(ex, "Exception during main thread action processing");
                     }
                 }
             }
@@ -733,8 +732,7 @@ namespace RegressionGames
                         }
                         catch (Exception e)
                         {
-                            RGDebug.LogError($"ERROR seating player");
-                            RGDebug.LogException(e);
+                            RGDebug.LogException(e, "ERROR seating player");
                         }
                     }
                     else

--- a/Runtime/Scripts/RGBotServerListener.cs
+++ b/Runtime/Scripts/RGBotServerListener.cs
@@ -473,7 +473,8 @@ namespace RegressionGames
                     }
                     catch (Exception ex)
                     {
-                        RGDebug.LogError($"Exception during main thread action processing: {ex.ToString()}");
+                        RGDebug.LogError($"Exception during main thread action processing");
+                        RGDebug.LogException(ex);
                     }
                 }
             }
@@ -732,7 +733,8 @@ namespace RegressionGames
                         }
                         catch (Exception e)
                         {
-                            RGDebug.LogError($"ERROR seating player - {e}");
+                            RGDebug.LogError($"ERROR seating player");
+                            RGDebug.LogException(e);
                         }
                     }
                     else

--- a/Runtime/Scripts/RGDebug.cs
+++ b/Runtime/Scripts/RGDebug.cs
@@ -67,11 +67,16 @@ namespace RegressionGames
          * Logging of 'Exception' logs. Only visible if Log Level is set to 'Error' or
          * lower in the Regression Project Settings
          */
-        public static void LogException(Exception exception)
+        public static void LogException(Exception exception, string message = default)
         {
             if (!CheckLogLevel(RGLogLevel.Error))
             {
                 return;
+            }
+
+            if (!string.IsNullOrEmpty(message))
+            {
+                Debug.LogWarning(message);
             }
             Debug.LogException(exception);
         }


### PR DESCRIPTION
**Changes**
Cases where we had:
```
catch (Exception e) {
   RGDebug.LogError($"Some Error Message - {e});
}
```
have been updated to:
```
catch (Exception e) {
   RGDebug.LogException(e, "Some Error Message");
}
```
and `RGDebug.LogException` has been updated to include an option string message that will log as a warning

This maintains clickable callbacks

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
