### PR TITLE
[REG-1473] Collect logs during bot execution and upload

### DIFF
--- a/Runtime/Scripts/DataCollection/LogDataPoint.cs
+++ b/Runtime/Scripts/DataCollection/LogDataPoint.cs
@@ -1,0 +1,31 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using UnityEngine;
+
+namespace RegressionGames.DataCollection
+{
+    [Serializable]
+    public class LogDataPoint
+    {
+        public DateTimeOffset timestamp { get; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public LogType level { get; }
+
+        public string message { get; }
+        public string stackTrace { get; }
+
+        public LogDataPoint(
+            DateTimeOffset timestamp,
+            LogType level,
+            string message,
+            string stackTrace)
+        {
+            this.timestamp = timestamp;
+            this.level = level;
+            this.message = message;
+            this.stackTrace = stackTrace;
+        }
+    }
+}

--- a/Runtime/Scripts/DataCollection/LogDataPoint.cs.meta
+++ b/Runtime/Scripts/DataCollection/LogDataPoint.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3318d48e8fd84d29b4568ae37ff3fb76
+timeCreated: 1701727827

--- a/Runtime/Scripts/DataCollection/RGDataCollection.cs
+++ b/Runtime/Scripts/DataCollection/RGDataCollection.cs
@@ -417,7 +417,7 @@ namespace RegressionGames.DataCollection
             var builder = new StringBuilder();
             foreach (var item in items)
             {
-                builder.AppendLine(RGSerializer.Serialize(item));
+                builder.AppendLine(JsonConvert.SerializeObject(item));
             }
 
             // Combine the JSON strings with newline characters

--- a/Runtime/Scripts/RGBotLocalRuntime/RGBotRunner.cs
+++ b/Runtime/Scripts/RGBotLocalRuntime/RGBotRunner.cs
@@ -1,13 +1,21 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using RegressionGames.DataCollection;
 using RegressionGames.StateActionTypes;
 using RegressionGames.Types;
+using Unity.Profiling;
 
 namespace RegressionGames.RGBotLocalRuntime
 {
- public class RGBotRunner
+    public class RGBotRunner
     {
+        // A marker used to measure the total time spent processing the bot tick, including flushing all actions and validations
+        private static readonly ProfilerMarker FullBotTickMarker = new(ProfilerCategory.Ai, "RegressionGames.BotTick.Full");
+
+        // A marker used to measure the time taken within the user's bot for each tick.
+        private static readonly ProfilerMarker UserBotTickMarker = new(ProfilerCategory.Ai, "RegressionGames.BotTick.User");
+
         public readonly RGBotInstance BotInstance;
 
         private Thread _thread;
@@ -116,10 +124,16 @@ namespace RegressionGames.RGBotLocalRuntime
                     {
                         _rgObject.SetTickInfo(tickInfo);
 
+                        // Start a profiler marker, which will be automatically ended when it goes out of scope.
+                        using var _ = FullBotTickMarker.Auto();
+
                         // Run User Code
                         try
                         {
-                            _userBotCode.ProcessTick(_rgObject);
+                            using(UserBotTickMarker.Auto())
+                            {
+                                _userBotCode.ProcessTick(_rgObject);
+                            }
 
                             // Flush Actions / Validations
                             List<RGActionRequest> actions = _rgObject.FlushActions();
@@ -135,14 +149,15 @@ namespace RegressionGames.RGBotLocalRuntime
                                 RGBotServerListener.GetInstance()
                                     .HandleClientValidationResult(BotInstance.id, rgValidationResult);
                             }
-                            
+
                             // Save all information from this tick for local bots
-                            RGBotServerListener.GetInstance()?.SaveDataForTick(BotInstance.id, tickInfo, actions, validations);
-                            
+                            RGBotServerListener.GetInstance()
+                                ?.SaveDataForTick(BotInstance.id, tickInfo, actions, validations);
                         }
                         catch (Exception ex)
                         {
-                            RGDebug.LogError($"ERROR: Bot instanceId: {BotInstance.id}, botName: {BotInstance.bot.name}, botId: {BotInstance.bot.id} crashed due to an uncaught exception. - {ex}");
+                            RGDebug.LogError(
+                                $"ERROR: Bot instanceId: {BotInstance.id}, botName: {BotInstance.bot.name}, botId: {BotInstance.bot.id} crashed due to an uncaught exception. - {ex}");
                             _running = false;
                             RGBotServerListener.GetInstance().SetUnityBotState(BotInstance.id, RGUnityBotState.ERRORED);
                         }
@@ -170,6 +185,5 @@ namespace RegressionGames.RGBotLocalRuntime
                 _userBotCode.OnDrawGizmos();
             }
         }
-
     }
 }

--- a/Runtime/Scripts/RGServiceManager.cs
+++ b/Runtime/Scripts/RGServiceManager.cs
@@ -515,14 +515,14 @@ namespace RegressionGames
         /**
          * Uploads all log messages for the bot instance to Regression Games in JSONL format
          */
-        public async Task UploadLogs(long botInstanceId, string logLines, Action onSuccess, Action onFailure)
+        public async Task UploadLogs(long botInstanceId, string filePath, Action onSuccess, Action onFailure)
         {
             if (await EnsureAuthed())
             {
-                await SendWebRequest(
+                await SendWebFileUploadRequest(
                     uri: $"{GetRgServiceBaseUri()}/bot-instance-history/{botInstanceId}/logs",
                     method: "POST",
-                    payload: logLines,
+                    filePath: filePath,
                     contentType: "application/jsonl",
                     onSuccess: async (s) =>
                     {

--- a/Runtime/Scripts/RGServiceManager.cs
+++ b/Runtime/Scripts/RGServiceManager.cs
@@ -512,6 +512,37 @@ namespace RegressionGames
             }
         }
 
+        /**
+         * Uploads all log messages for the bot instance to Regression Games in JSONL format
+         */
+        public async Task UploadLogs(long botInstanceId, string logLines, Action onSuccess, Action onFailure)
+        {
+            if (await EnsureAuthed())
+            {
+                await SendWebRequest(
+                    uri: $"{GetRgServiceBaseUri()}/bot-instance-history/{botInstanceId}/logs",
+                    method: "POST",
+                    payload: logLines,
+                    contentType: "application/jsonl",
+                    onSuccess: async (s) =>
+                    {
+                        RGDebug.LogDebug(
+                            $"RGService UploadLogs response received");
+                        onSuccess.Invoke();
+                    },
+                    onFailure: async (f) =>
+                    {
+                        RGDebug.LogWarning($"Failed to upload logs for bot instance {botInstanceId}: {f}");
+                        onFailure.Invoke();
+                    }
+                );
+            }
+            else
+            {
+                onFailure();
+            }
+        }
+
         public async Task GetExternalConnectionInformationForBotInstance(long botInstanceId, Action<RGBotInstanceExternalConnectionInfo> onSuccess, Action onFailure)
         {
             if (await EnsureAuthed())


### PR DESCRIPTION
This adds support to the Unity SDK to collect logs during bot execution. There are a few limitations in this first version, which lead to some open questions.

Log collection works as follows:
1. Prior to any bot starting, the `RGDataCollection` constructor hooks in to `Application.logMessageReceivedThreaded`, which is called when a log message is emitted **on any thread**.
2. When a bot starts, `RGDataCollection.RegisterBot` is called. This adds a `ConcurrentQueue<LogDataPoint>` to the `ConcurrentDictionary<long, ConcurrentQueue<LogDataPoint>>` tracking which bots are running and listening to logs. This starts collection of logs for this bot.
3. Each tick of the bot, we perform an atomic swap of the active log message queue with a new empty queue. This allows us to flush that set of messages to disk while simultaneously giving the collector a fresh queue to write to. The `ConcurrentQueue` collection does not provide an atomic way to do this swap internally, so we need to do it ourselves.
4. When a bot stops, we flush the last set of messages to disk. Then we upload the logs and the on-disk copy gets cleaned up.

The code to collect log messages is always running, but unless a bot is running, it will basically no-op. The presence of a queue in the `_clientIdToLogs` dictionary is what tells our collection logic to assign a log message that arrives to that bot instance.

In order to simplify some things, **and** enable the atomic swap in (3) above, I bundled all the dictionaries of `clientId -> Something` we had into a single dictionary of `clientId -> BotInstanceState` where `BotInstanceState` is a class that wraps up all the individual pieces we have. This allows us to only have to mess with the concurrent dictionary once as long as we are careful to access `BotInstanceState` in thread-safe ways.

And once again, Rider is aggressively removing whitespace. I recommend the "Hide whitespace" option in the PR review settings:

<img width="370" alt="image" src="https://github.com/Regression-Games/RGUnityBots/assets/7574/ab527e38-b01c-4fbe-9d9d-ba0ee7fe3ff1">

These are the settings I have in Rider that cause the reformat and I highly recommend we use them, as they ensure that we clean up trailing spaces and lines:

<img width="769" alt="image" src="https://github.com/Regression-Games/RGUnityBots/assets/7574/98370ddd-0c12-46c9-8cca-9aa624c19419">

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
