### PR TITLE
[REG-1498] Change default tick rate from 50 to 5

### DIFF
--- a/Runtime/Prefabs/RGOverlayCanvas.prefab
+++ b/Runtime/Prefabs/RGOverlayCanvas.prefab
@@ -675,7 +675,9 @@ Canvas:
   m_OverrideSorting: 1
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
   m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 30000
   m_TargetDisplay: 0
@@ -2518,7 +2520,9 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
   m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 10000
   m_TargetDisplay: 0
@@ -2604,7 +2608,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2df517e9e3158475fb07c8df157b00a3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  tickRate: 50
+  tickRate: 5
 --- !u!114 &5154676213986407094
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2641,9 +2645,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 12949602f31a04a319b1d6154c6a036e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isPlayer: 0
   objectType: 
+  isPlayer: 0
   isRuntimeObject: 0
+  includeStateForAllBehaviours: 0
 --- !u!1 &7045523072349830337
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
- Changes default tick rate from 50 to 5 on the Overlay prefab

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
