### PR TITLE
[REG-1522] Shorten code generation time

### DIFF
--- a/Editor/Scripts/CodeGenerators/GenerateRGActionClasses.cs
+++ b/Editor/Scripts/CodeGenerators/GenerateRGActionClasses.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Linq;
 using UnityEngine;
 #if UNITY_EDITOR
+using System;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -17,6 +19,7 @@ namespace RegressionGames.Editor.CodeGenerators
     {
         public static void Generate(List<RGActionAttributeInfo> actionInfos)
         {
+            Dictionary<Task, Action> fileWriteTasks = new(); 
             // Iterate through BotActions
             foreach (var botAction in actionInfos)
             {
@@ -96,10 +99,15 @@ namespace RegressionGames.Editor.CodeGenerators
                     string fileContents = CodeGeneratorUtils.HeaderComment + formattedCode;
 
                     Directory.CreateDirectory(Path.GetDirectoryName(filePath));
-                    File.WriteAllText(filePath, fileContents);
-                    RGDebug.Log($"Successfully Generated {filePath}");
-                    AssetDatabase.Refresh();
+                    var task= File.WriteAllTextAsync(filePath, fileContents);
+                    fileWriteTasks[task] = () => RGDebug.Log($"Successfully Generated {filePath}");
                 }
+            }
+
+            Task.WaitAll(fileWriteTasks.Keys.ToArray());
+            foreach (var action in fileWriteTasks.Values)
+            {
+                action.Invoke();
             }
         }
 

--- a/Editor/Scripts/CodeGenerators/GenerateRGActionClasses.cs
+++ b/Editor/Scripts/CodeGenerators/GenerateRGActionClasses.cs
@@ -19,7 +19,7 @@ namespace RegressionGames.Editor.CodeGenerators
     {
         public static void Generate(List<RGActionAttributeInfo> actionInfos)
         {
-            Dictionary<Task, Action> fileWriteTasks = new(); 
+            Dictionary<string, Task> fileWriteTasks = new(); 
             // Iterate through BotActions
             foreach (var botAction in actionInfos)
             {
@@ -100,14 +100,14 @@ namespace RegressionGames.Editor.CodeGenerators
 
                     Directory.CreateDirectory(Path.GetDirectoryName(filePath));
                     var task= File.WriteAllTextAsync(filePath, fileContents);
-                    fileWriteTasks[task] = () => RGDebug.Log($"Successfully Generated {filePath}");
+                    fileWriteTasks[filePath] = task;
                 }
             }
 
-            Task.WaitAll(fileWriteTasks.Keys.ToArray());
-            foreach (var action in fileWriteTasks.Values)
+            Task.WaitAll(fileWriteTasks.Values.ToArray());
+            foreach (var filename in fileWriteTasks.Keys)
             {
-                action.Invoke();
+                RGDebug.Log($"Successfully Generated {filename}");
             }
         }
 

--- a/Editor/Scripts/CodeGenerators/GenerateRGActionMapClass.cs
+++ b/Editor/Scripts/CodeGenerators/GenerateRGActionMapClass.cs
@@ -54,8 +54,8 @@ namespace RegressionGames.Editor.CodeGenerators
             Directory.CreateDirectory(Path.GetDirectoryName(filePath));
             File.WriteAllText(filePath, fileContents);            
             RGDebug.Log($"Successfully Generated {filePath}");
-            AssetDatabase.Refresh();
         }
+        
         private static ClassDeclarationSyntax GenerateClass(List<RGActionAttributeInfo> botActions)
         {
             var methodsList = new List<MethodDeclarationSyntax>();

--- a/Editor/Scripts/CodeGenerators/GenerateRGSerializationClass.cs
+++ b/Editor/Scripts/CodeGenerators/GenerateRGSerializationClass.cs
@@ -38,7 +38,6 @@ namespace RegressionGames.Editor.CodeGenerators
             Directory.CreateDirectory(Path.GetDirectoryName(filePath));
             File.WriteAllText(filePath, fileContents);
             RGDebug.Log($"Successfully Generated {filePath}");
-            AssetDatabase.Refresh();
         }
 
         private static ClassDeclarationSyntax GenerateClass(List<RGActionAttributeInfo> botActions)

--- a/Editor/Scripts/CodeGenerators/GenerateRGStateClasses.cs
+++ b/Editor/Scripts/CodeGenerators/GenerateRGStateClasses.cs
@@ -20,7 +20,7 @@ namespace RegressionGames.Editor.CodeGenerators
     {
         public static void Generate(List<RGStateAttributesInfo> rgStateAttributesInfos)
         {
-            Dictionary<Task, Action> fileWriteTasks = new(); 
+            Dictionary<string, Task> fileWriteTasks = new(); 
             foreach (var rgStateAttributeInfo in rgStateAttributesInfos)
             {
                 if (rgStateAttributeInfo.ShouldGenerateCSFile)
@@ -118,14 +118,14 @@ namespace RegressionGames.Editor.CodeGenerators
                     Directory.CreateDirectory(Path.GetDirectoryName(filePath));
                     
                     var task= File.WriteAllTextAsync(filePath, fileContents);
-                    fileWriteTasks[task] = () => RGDebug.Log($"Successfully Generated {filePath}");
+                    fileWriteTasks[filePath] = task;
                 }
             }
 
-            Task.WaitAll(fileWriteTasks.Keys.ToArray());
-            foreach (var action in fileWriteTasks.Values)
+            Task.WaitAll(fileWriteTasks.Values.ToArray());
+            foreach (var filename in fileWriteTasks.Keys)
             {
-                action.Invoke();
+                RGDebug.Log($"Successfully Generated {filename}");
             }
         }
 

--- a/Editor/Scripts/CodeGenerators/RGCodeGenerator.cs
+++ b/Editor/Scripts/CodeGenerators/RGCodeGenerator.cs
@@ -82,6 +82,8 @@ namespace RegressionGames.Editor.CodeGenerators
                 EditorUtility.DisplayProgressBar("Generating Regression Games Scripts",
                     "Generating classes for RGAction attributes", 0.8f);
                 GenerateActionClasses(actionAttributeInfos);
+                
+                AssetDatabase.Refresh();
             }
             finally
             {
@@ -184,11 +186,8 @@ namespace RegressionGames.Editor.CodeGenerators
             {
                 Directory.Delete(directoryToDelete, true);
                 File.Delete(directoryToDelete + ".meta");
-                AssetDatabase.Refresh();
             }
             
-            //NOTE: We may have trouble here with serialization or actionMap with sample projects
-            // Much testing needed
             GenerateRGSerializationClass.Generate(actionInfos);
             GenerateRGActionClasses.Generate(actionInfos);
             GenerateRGActionMapClass.Generate(actionInfos);
@@ -368,7 +367,6 @@ namespace RegressionGames.Editor.CodeGenerators
             {
                 Directory.Delete(directoryToDelete, true);
                 File.Delete(directoryToDelete + ".meta");
-                AssetDatabase.Refresh();
             }
             
             GenerateRGStateClasses.Generate(rgStateAttributesInfos);


### PR DESCRIPTION
 - Limits AssetDatabase.Refresh calls to 1 instead of 1 per file generated
 - Writes states/actions files async to one another.

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
