### PR TITLE
Move email and password to new RGUserSettings scriptable object

### DIFF
--- a/Editor/Scripts/RGSettingsUIRegistrar.cs
+++ b/Editor/Scripts/RGSettingsUIRegistrar.cs
@@ -42,14 +42,15 @@ namespace RegressionGames.Editor
                 guiHandler = async (searchContext) =>
                 {
                     SerializedObject settings = RGSettings.GetSerializedSettings();
+                    SerializedObject userSettings = RGUserSettings.GetSerializedUserSettings();
                     EditorGUI.BeginChangeCheck();
                     
                     SerializedProperty hostField = settings.FindProperty("rgHostAddress");
                     hostField.stringValue = EditorGUILayout.TextField("RG Host URL", hostField.stringValue);
                     
-                    SerializedProperty emailField = settings.FindProperty("email");
+                    SerializedProperty emailField = userSettings.FindProperty("email");
                     emailField.stringValue = EditorGUILayout.TextField("RG Email", emailField.stringValue);
-                    SerializedProperty passwordField = settings.FindProperty("password");
+                    SerializedProperty passwordField = userSettings.FindProperty("password");
                     passwordField.stringValue = EditorGUILayout.PasswordField("RG Password", passwordField.stringValue);
                     
                     SerializedProperty logLevel = settings.FindProperty("logLevel");

--- a/Editor/Scripts/Startup/RegressionPackagePopup.cs
+++ b/Editor/Scripts/Startup/RegressionPackagePopup.cs
@@ -50,8 +50,8 @@ public class RegressionPackagePopup : EditorWindow
     public static async void ShowWindow()
     {
         // attempt a login with saved credentials
-        email = RGSettings.GetOrCreateSettings().GetEmail();
-        password = RGSettings.GetOrCreateSettings().GetPassword();
+        email = RGUserSettings.GetOrCreateUserSettings().GetEmail();
+        password = RGUserSettings.GetOrCreateUserSettings().GetPassword();
         await Login();
         
         if (window == null)
@@ -437,7 +437,7 @@ public class RegressionPackagePopup : EditorWindow
             return;
         }
 
-        var settings = RGSettings.GetOrCreateSettings();
+        var settings = RGUserSettings.GetOrCreateUserSettings();
         settings.SetEmail(email);
         settings.SetPassword(password);
         RGSettings.OptionsUpdated();

--- a/Runtime/Scripts/RGServiceManager.cs
+++ b/Runtime/Scripts/RGServiceManager.cs
@@ -70,7 +70,7 @@ namespace RegressionGames
                 else
                 {
                     RGDebug.LogDebug("Using username/password rather than env var for auth");
-                    RGSettings rgSettings = RGSettings.GetOrCreateSettings();
+                    RGUserSettings rgSettings = RGUserSettings.GetOrCreateUserSettings();
                     string email = rgSettings.GetEmail();
                     string password = rgSettings.GetPassword();
 

--- a/Runtime/Scripts/RGSettings.cs
+++ b/Runtime/Scripts/RGSettings.cs
@@ -8,13 +8,11 @@ namespace RegressionGames
     
     public class RGSettings: ScriptableObject
     {
-        public const string SETTINGS_PATH = "Assets/RGSettings.asset";
+        private const string SETTINGS_PATH = "Assets/RGSettings.asset";
 
         [SerializeField] private bool useSystemSettings;
         [SerializeField] private bool enableOverlay;
         [SerializeField] private int numBots;
-        [SerializeField] private string email;
-        [SerializeField] private string password;
         [SerializeField] private long[] botsSelected;
         [SerializeField] private DebugLogLevel logLevel;
         [SerializeField] private string rgHostAddress;
@@ -51,8 +49,6 @@ namespace RegressionGames
                 _settings.useSystemSettings = true;
                 _settings.enableOverlay = true;
                 _settings.numBots = 0;
-                _settings.email = "";
-                _settings.password = "";
                 _settings.botsSelected = Array.Empty<long>();
                 _settings.rgHostAddress = "https://play.regression.gg";
                 _settings.logLevel = DebugLogLevel.Info;
@@ -142,26 +138,6 @@ namespace RegressionGames
             return numBots;
         }
 
-        public string GetEmail()
-        {
-            return email;
-        }
-
-        public void SetEmail(string newEmail)
-        {
-            email = newEmail;
-        }
-        
-        public string GetPassword()
-        {
-            return password;
-        }
-
-        public void SetPassword(string newPassword)
-        {
-            password = newPassword;
-        }
-        
         public long[] GetBotsSelected()
         {
             return botsSelected;

--- a/Runtime/Scripts/RGUserSettings.cs
+++ b/Runtime/Scripts/RGUserSettings.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace RegressionGames
+{
+    public class RGUserSettings : ScriptableObject
+    {
+        [SerializeField] private string email;
+        [SerializeField] private string password;
+
+        private const string USER_SETTINGS_PATH = "Assets/UserSettings/RGUserSettings.asset";
+
+        private static RGUserSettings _userSettings = null;
+        private static bool dirty = true;
+
+        public static RGUserSettings GetOrCreateUserSettings()
+        {
+            if (_userSettings == null || dirty)
+            {
+                try
+                {
+#if UNITY_EDITOR
+                    _userSettings = AssetDatabase.LoadAssetAtPath<RGUserSettings>(USER_SETTINGS_PATH);
+#endif
+                    dirty = false;
+                }
+                catch (Exception ex)
+                {
+                    // if not called on main thread this will exception
+                }
+            }
+
+            if (_userSettings == null)
+            {
+                _userSettings = CreateInstance<RGUserSettings>();
+                _userSettings.email = "";
+                _userSettings.password = "";
+#if UNITY_EDITOR
+                if (!Directory.Exists(USER_SETTINGS_PATH))
+                {
+                    Directory.CreateDirectory(USER_SETTINGS_PATH);
+                }
+                AssetDatabase.CreateAsset(_userSettings, USER_SETTINGS_PATH);
+                AssetDatabase.SaveAssets();
+#endif
+            }
+
+            return _userSettings;
+        }
+        
+#if UNITY_EDITOR
+        public static SerializedObject GetSerializedUserSettings()
+        {
+            return new SerializedObject(GetOrCreateUserSettings());
+        }
+#endif
+        
+        public string GetEmail()
+        {
+            return email;
+        }
+
+        public void SetEmail(string newEmail)
+        {
+            email = newEmail;
+        }
+        
+        public string GetPassword()
+        {
+            return password;
+        }
+
+        public void SetPassword(string newPassword)
+        {
+            password = newPassword;
+        }
+    }
+}

--- a/Runtime/Scripts/RGUserSettings.cs.meta
+++ b/Runtime/Scripts/RGUserSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1150c4d27dd34cf694489b35177f64e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
**Changes**

* Help prevent sensitive user information from being leaked by source control
* Moved sensitive user info from `RGSettings` to a new `RGUserSettings` scriptable object.
* RGUserSettings is created at `Assets/UserSettings`, which is ignored by Unity's default `.gitignore`
* Updated login logic and settings panels to find user settings in new location

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
