### PR TITLE
Fix user settings updating durring settings windows input updates

### DIFF
--- a/src/gg.regression.unity.bots/Editor/Scripts/RGSettingsUIRegistrar.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGSettingsUIRegistrar.cs
@@ -156,6 +156,7 @@ namespace RegressionGames.Editor
                     }
 
                     settings.ApplyModifiedProperties();
+                    userSettings.ApplyModifiedProperties();
                     if (EditorGUI.EndChangeCheck())
                     {
                         timeOfLastEdit = EditorApplication.timeSinceStartup;
@@ -168,6 +169,7 @@ namespace RegressionGames.Editor
                         }
                         AssetDatabase.SaveAssets();
                         RGSettings.OptionsUpdated();
+                        RGUserSettings.OptionsUpdated();
                         RGSettingsDynamicEnabler[] objects = GameObject.FindObjectsOfType<RGSettingsDynamicEnabler>(true);
                         foreach (RGSettingsDynamicEnabler rgSettingsDynamicEnabler in objects)
                         {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGUserSettings.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGUserSettings.cs
@@ -57,6 +57,25 @@ namespace RegressionGames
         }
 #endif
         
+        public static void OptionsUpdated()
+        {
+            //mark dirty
+            dirty = true;
+            try
+            {
+                // try to update and mark clean, but if failed
+                // will keep trying to update until clean
+#if UNITY_EDITOR
+                _userSettings = AssetDatabase.LoadAssetAtPath<RGUserSettings>(USER_SETTINGS_PATH);
+#endif
+                dirty = false;
+            }
+            catch (Exception ex)
+            {
+                // if not called on main thread this will exception
+            }
+        }
+        
         public string GetEmail()
         {
             return email;


### PR DESCRIPTION
**Changes**

Fixes bug where editing the email or password in `Project Settings -> Regression Games` would not save changes, causing the values to go back when clicked away

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
