### PR TITLE
[REG-1530] Reformat all C# code to match 'dotnet-format' style

### DIFF
--- a/src/gg.regression.unity.bots/Editor/Scripts/BotManagement/RGBotSynchronizer.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/BotManagement/RGBotSynchronizer.cs
@@ -19,9 +19,9 @@ namespace RegressionGames.Editor.BotManagement
     public class RGBotSynchronizer
     {
 #if UNITY_EDITOR
-        private static readonly RGBotSynchronizer _this = new ();
+        private static readonly RGBotSynchronizer _this = new();
 
-        private static RGServiceManager _rgServiceManager = new (); // editor, not game/scene so don't look for one, make one
+        private static RGServiceManager _rgServiceManager = new(); // editor, not game/scene so don't look for one, make one
 
         // This must match RGBotRuntimeManagement.cs
         private const string BOTS_PATH = "Assets/RegressionGames/Runtime/Bots";
@@ -165,7 +165,7 @@ namespace RegressionGames.Editor.BotManagement
                 var countUpdated = 0;
                 foreach (var (botId, (localBot, md5, localLastUpdated)) in localBotZips)
                 {
-                    if(remoteBots.FirstOrDefault(b => b.id == botId) is not {} remoteBot)
+                    if (remoteBots.FirstOrDefault(b => b.id == botId) is not { } remoteBot)
                     {
                         RGDebug.LogError($"Unable to find remote bot with id {botId} to update.");
                         continue;
@@ -481,7 +481,7 @@ namespace RegressionGames.Editor.BotManagement
         private void CreateBotAssetFile(string folderName, string botName, long botId, string botChecksum)
         {
             var botRecordAssetPath = $"{folderName}/BotRecord.asset";
-            if ( AssetDatabase.GetMainAssetTypeAtPath( botRecordAssetPath ) == null)
+            if (AssetDatabase.GetMainAssetTypeAtPath(botRecordAssetPath) == null)
             {
                 RGDebug.LogDebug($"Writing {botRecordAssetPath}");
                 RGBot botRecord = new RGBot()
@@ -495,7 +495,7 @@ namespace RegressionGames.Editor.BotManagement
                 RGBotAsset botRecordAsset = ScriptableObject.CreateInstance<RGBotAsset>();
                 botRecordAsset.Bot = botRecord;
                 botRecordAsset.ChecksumAtLastSync = botChecksum;
-                AssetDatabase.CreateAsset(botRecordAsset, botRecordAssetPath );
+                AssetDatabase.CreateAsset(botRecordAsset, botRecordAssetPath);
                 AssetDatabase.SaveAssets();
             }
         }
@@ -503,7 +503,8 @@ namespace RegressionGames.Editor.BotManagement
 
     // Extension code borrowed from StackOverflow to allow creating a zip of directory
     // while filtering out certain contents
-    public static class ZipHelper {
+    public static class ZipHelper
+    {
         public static void CreateFromDirectory(string sourceDirectoryName,
             string destinationArchiveFileName,
             CompressionLevel compressionLevel = CompressionLevel.Fastest,
@@ -511,10 +512,12 @@ namespace RegressionGames.Editor.BotManagement
             Predicate<string> exclusionFilter = null
         )
         {
-            if (string.IsNullOrEmpty(sourceDirectoryName)) {
+            if (string.IsNullOrEmpty(sourceDirectoryName))
+            {
                 throw new ArgumentNullException("sourceDirectoryName");
             }
-            if (string.IsNullOrEmpty(destinationArchiveFileName)) {
+            if (string.IsNullOrEmpty(destinationArchiveFileName))
+            {
                 throw new ArgumentNullException("destinationArchiveFileName");
             }
             var filesToAdd = Directory.GetFiles(sourceDirectoryName, "*", SearchOption.AllDirectories);

--- a/src/gg.regression.unity.bots/Editor/Scripts/CodeGenerators/BuildAutoProcessor.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/CodeGenerators/BuildAutoProcessor.cs
@@ -9,18 +9,18 @@ namespace RegressionGames.Editor.CodeGenerators
     class BuildAutoPreProcessor : IPreprocessBuildWithReport
     {
         public int callbackOrder { get { return 0; } }
-        
+
         public void OnPreprocessBuild(BuildReport report)
         {
             BuildAssetPostProcessor.TriggerGeneration();
         }
     }
-   
+
     class BuildAssetPostProcessor : UnityEditor.AssetPostprocessor
     {
 
         static bool _enabled = true;
-        
+
         public static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets,
             string[] movedFromAssetPaths, bool didDomainReload)
         {
@@ -39,7 +39,7 @@ namespace RegressionGames.Editor.CodeGenerators
             {
                 _enabled = false;
                 RGDebug.LogInfo("Generating Regression Games scripts automatically due to asset change or build.");
-                RGCodeGenerator.GenerateRGScripts(); 
+                RGCodeGenerator.GenerateRGScripts();
             }
         }
     }

--- a/src/gg.regression.unity.bots/Editor/Scripts/CodeGenerators/CodeGeneratorUtils.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/CodeGenerators/CodeGeneratorUtils.cs
@@ -9,7 +9,7 @@ namespace RegressionGames
     public class CodeGeneratorUtils
     {
         public static readonly string HeaderComment = $"/*\r\n* This file has been automatically generated. Do not modify.\r\n*/\r\n\r\n";
-        
+
         public static string SanitizeActionName(string name)
         {
             return Regex.Replace(name.Replace(" ", "_"), "[^0-9a-zA-Z_]", "_");

--- a/src/gg.regression.unity.bots/Editor/Scripts/CodeGenerators/GenerateRGActionClasses.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/CodeGenerators/GenerateRGActionClasses.cs
@@ -19,7 +19,7 @@ namespace RegressionGames.Editor.CodeGenerators
     {
         public static void Generate(List<RGActionAttributeInfo> actionInfos)
         {
-            Dictionary<string, Task> fileWriteTasks = new(); 
+            Dictionary<string, Task> fileWriteTasks = new();
             // Iterate through BotActions
             foreach (var botAction in actionInfos)
             {
@@ -41,7 +41,7 @@ namespace RegressionGames.Editor.CodeGenerators
                     }
 
                     var projectNamespace = CodeGeneratorUtils.GetNamespaceForProject();
-                    
+
                     botAction.GeneratedClassName =
                         $"{projectNamespace}.RGAction_{CodeGeneratorUtils.SanitizeActionName(botAction.ActionName)}";
 
@@ -60,7 +60,7 @@ namespace RegressionGames.Editor.CodeGenerators
                                             $"RGAction_{CodeGeneratorUtils.SanitizeActionName(botAction.ActionName)}")
                                         .AddModifiers(
                                             SyntaxFactory.Token(SyntaxKind.PublicKeyword)
-                                            // Only add one of the "class" keywords here
+                                        // Only add one of the "class" keywords here
                                         )
                                         .AddBaseListTypes(
                                             SyntaxFactory.SimpleBaseType(SyntaxFactory.ParseTypeName("RGAction"))
@@ -78,7 +78,7 @@ namespace RegressionGames.Editor.CodeGenerators
                                             $"RGActionRequest_{CodeGeneratorUtils.SanitizeActionName(botAction.ActionName)}")
                                         .AddModifiers(
                                             SyntaxFactory.Token(SyntaxKind.PublicKeyword)
-                                            // Only add one of the "class" keywords here
+                                        // Only add one of the "class" keywords here
                                         )
                                         .AddBaseListTypes(
                                             SyntaxFactory.SimpleBaseType(SyntaxFactory.ParseTypeName("RGActionRequest"))
@@ -99,7 +99,7 @@ namespace RegressionGames.Editor.CodeGenerators
                     string fileContents = CodeGeneratorUtils.HeaderComment + formattedCode;
 
                     Directory.CreateDirectory(Path.GetDirectoryName(filePath));
-                    var task= File.WriteAllTextAsync(filePath, fileContents);
+                    var task = File.WriteAllTextAsync(filePath, fileContents);
                     fileWriteTasks[filePath] = task;
                 }
             }
@@ -167,7 +167,7 @@ namespace RegressionGames.Editor.CodeGenerators
 
             return getActionNameMethod;
         }
-        
+
         private static ArgumentSyntax GenerateActionDelegate(RGActionAttributeInfo action)
         {
             // Generate the GetComponent<Object>().MethodName piece for both cases (0 and non-0 parameters)
@@ -236,14 +236,14 @@ namespace RegressionGames.Editor.CodeGenerators
             foreach (var parameter in action.Parameters)
             {
                 string paramName = parameter.Name;
-                
+
                 methodInvocationArguments.Add(paramName);
                 parameterParsingStatements.Add(SyntaxFactory.ParseStatement($"{parameter.Type} {paramName} = default;"));
                 parameterParsingStatements.Add(SyntaxFactory.IfStatement(IfCondition(parameter), IfBody(parameter), ElseBody(parameter)));
             }
 
-            string methodInvocationArgumentsString = methodInvocationArguments.Count > 0 ? 
-                                                     ", " + string.Join(", ", methodInvocationArguments) : 
+            string methodInvocationArgumentsString = methodInvocationArguments.Count > 0 ?
+                                                     ", " + string.Join(", ", methodInvocationArguments) :
                                                      string.Empty;
 
             parameterParsingStatements.Add(SyntaxFactory.ParseStatement($"Invoke(\"{action.ActionName}\"{methodInvocationArgumentsString});"));
@@ -264,16 +264,16 @@ namespace RegressionGames.Editor.CodeGenerators
         {
             return SyntaxFactory.InvocationExpression(
                 SyntaxFactory.MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression, 
-                    SyntaxFactory.IdentifierName("input"), 
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("input"),
                     SyntaxFactory.IdentifierName("TryGetValue")
                     )).WithArgumentList(
                 SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SeparatedList(new List<ArgumentSyntax> 
-                    { 
+                    SyntaxFactory.SeparatedList(new List<ArgumentSyntax>
+                    {
                         SyntaxFactory.Argument(
                             SyntaxFactory.LiteralExpression(
-                                SyntaxKind.StringLiteralExpression, 
+                                SyntaxKind.StringLiteralExpression,
                                 SyntaxFactory.Literal(param.Name)
                             )
                         ),
@@ -309,7 +309,7 @@ namespace RegressionGames.Editor.CodeGenerators
         {
             var paramType = param.Type;
             var paramName = param.Name;
-            
+
             string tryParseStatement;
             if (paramType.ToLower() == "string" || paramType.ToLower() == "system.string")
             {
@@ -368,15 +368,15 @@ namespace RegressionGames.Editor.CodeGenerators
             {
                 return default(ElseClauseSyntax);
             }
-            
+
             // Validation check for key existence if param must be non-null
-            return SyntaxFactory.ElseClause(SyntaxFactory.Block(new StatementSyntax[] 
+            return SyntaxFactory.ElseClause(SyntaxFactory.Block(new StatementSyntax[]
                     {
                         SyntaxFactory.ExpressionStatement(
                             SyntaxFactory.InvocationExpression(
                                     SyntaxFactory.MemberAccessExpression(
-                                        SyntaxKind.SimpleMemberAccessExpression, 
-                                        SyntaxFactory.IdentifierName("RGDebug"), 
+                                        SyntaxKind.SimpleMemberAccessExpression,
+                                        SyntaxFactory.IdentifierName("RGDebug"),
                                         SyntaxFactory.IdentifierName("LogError")
                                 )
                             ).WithArgumentList(
@@ -384,14 +384,14 @@ namespace RegressionGames.Editor.CodeGenerators
                                     SyntaxFactory.SingletonSeparatedList(
                                         SyntaxFactory.Argument(
                                             SyntaxFactory.LiteralExpression(
-                                                SyntaxKind.StringLiteralExpression, 
+                                                SyntaxKind.StringLiteralExpression,
                                                 SyntaxFactory.Literal($"No parameter '{param.Name}' found")
                                                 )
                                             )
                                         )
                                     )
                                 )
-                            ), SyntaxFactory.ReturnStatement() 
+                            ), SyntaxFactory.ReturnStatement()
                     }
                 ));
         }
@@ -400,7 +400,7 @@ namespace RegressionGames.Editor.CodeGenerators
         {
             var methodParameters = new List<ParameterSyntax>();
             var parameterParsingStatements = new List<StatementSyntax>();
-            
+
             foreach (var rgParameterInfo in action.Parameters)
             {
                 methodParameters.Add(SyntaxFactory.Parameter(SyntaxFactory.Identifier(rgParameterInfo.Name))
@@ -416,7 +416,7 @@ namespace RegressionGames.Editor.CodeGenerators
             }
 
             inputString += "\r\n};";
-            
+
             parameterParsingStatements.Add(
                 SyntaxFactory.ParseStatement(inputString)
             );

--- a/src/gg.regression.unity.bots/Editor/Scripts/CodeGenerators/GenerateRGActionMapClass.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/CodeGenerators/GenerateRGActionMapClass.cs
@@ -34,11 +34,11 @@ namespace RegressionGames.Editor.CodeGenerators
             NamespaceDeclarationSyntax namespaceDeclaration = SyntaxFactory
                 .NamespaceDeclaration(SyntaxFactory.ParseName(CodeGeneratorUtils.GetNamespaceForProject()))
                 .AddUsings(
-                    usings.Select(v=>SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(v))).ToArray()
+                    usings.Select(v => SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(v))).ToArray()
                 )
                 .AddMembers(GenerateClass(botActions));
-            
-            
+
+
             // Create a compilation unit and add the namespace declaration
             CompilationUnitSyntax compilationUnit = SyntaxFactory.CompilationUnit()
                 .AddUsings(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("System")))
@@ -52,10 +52,10 @@ namespace RegressionGames.Editor.CodeGenerators
             string filePath = Path.Combine(Application.dataPath, "RegressionGames", "Runtime", "GeneratedScripts", fileName);
             string fileContents = CodeGeneratorUtils.HeaderComment + formattedCode;
             Directory.CreateDirectory(Path.GetDirectoryName(filePath));
-            File.WriteAllText(filePath, fileContents);            
+            File.WriteAllText(filePath, fileContents);
             RGDebug.Log($"Successfully Generated {filePath}");
         }
-        
+
         private static ClassDeclarationSyntax GenerateClass(List<RGActionAttributeInfo> botActions)
         {
             var methodsList = new List<MethodDeclarationSyntax>();
@@ -66,27 +66,27 @@ namespace RegressionGames.Editor.CodeGenerators
                 .AddModifiers(SyntaxFactory.Token(SyntaxKind.PrivateKeyword))
                 .WithBody(SyntaxFactory.Block(filteredActions
                     .GroupBy(b => b.Object)
-                    .SelectMany(g => 
+                    .SelectMany(g =>
                         {
-                            var innerIfStatements = g.Select(b => 
+                            var innerIfStatements = g.Select(b =>
                                 SyntaxFactory.ExpressionStatement(
                                     SyntaxFactory.InvocationExpression(
                                         SyntaxFactory.MemberAccessExpression(
-                                            SyntaxKind.SimpleMemberAccessExpression, 
-                                            SyntaxFactory.IdentifierName("gameObject"), 
+                                            SyntaxKind.SimpleMemberAccessExpression,
+                                            SyntaxFactory.IdentifierName("gameObject"),
                                             SyntaxFactory.IdentifierName($"AddComponent<RGAction_{CodeGeneratorUtils.SanitizeActionName(b.ActionName)}>")
                                         )
                                     )
                                 )
                             ).ToArray();
-                            
-                            return new StatementSyntax[] 
+
+                            return new StatementSyntax[]
                             {
                                 SyntaxFactory.IfStatement(
                                     SyntaxFactory.InvocationExpression(
                                         SyntaxFactory.MemberAccessExpression(
-                                            SyntaxKind.SimpleMemberAccessExpression, 
-                                            SyntaxFactory.ThisExpression(), 
+                                            SyntaxKind.SimpleMemberAccessExpression,
+                                            SyntaxFactory.ThisExpression(),
                                             SyntaxFactory.GenericName("TryGetComponent")
                                                 .WithTypeArgumentList(
                                                     SyntaxFactory.TypeArgumentList(
@@ -98,8 +98,8 @@ namespace RegressionGames.Editor.CodeGenerators
                                         ),
                                         SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(
                                             SyntaxFactory.Argument(
-                                                null, 
-                                                SyntaxFactory.Token(SyntaxKind.OutKeyword), 
+                                                null,
+                                                SyntaxFactory.Token(SyntaxKind.OutKeyword),
                                                 SyntaxFactory.DeclarationExpression(
                                                     SyntaxFactory.IdentifierName("var"),
                                                     SyntaxFactory.DiscardDesignation(SyntaxFactory.Token(SyntaxKind.UnderscoreToken))

--- a/src/gg.regression.unity.bots/Editor/Scripts/CodeGenerators/GenerateRGSerializationClass.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/CodeGenerators/GenerateRGSerializationClass.cs
@@ -52,14 +52,14 @@ namespace RegressionGames.Editor.CodeGenerators
                 {
                     continue;
                 }
-                
+
                 foreach (RGParameterInfo parameter in botAction.Parameters)
                 {
                     if (RGUtils.IsCSharpPrimitive(parameter.Type))
                     {
                         continue;
                     }
-                    
+
                     if (!processedTypes.Contains(parameter.Type))
                     {
                         processedTypes.Add(parameter.Type);

--- a/src/gg.regression.unity.bots/Editor/Scripts/CodeGenerators/GenerateRGStateClasses.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/CodeGenerators/GenerateRGStateClasses.cs
@@ -20,7 +20,7 @@ namespace RegressionGames.Editor.CodeGenerators
     {
         public static void Generate(List<RGStateAttributesInfo> rgStateAttributesInfos)
         {
-            Dictionary<string, Task> fileWriteTasks = new(); 
+            Dictionary<string, Task> fileWriteTasks = new();
             foreach (var rgStateAttributeInfo in rgStateAttributesInfos)
             {
                 if (rgStateAttributeInfo.ShouldGenerateCSFile)
@@ -62,7 +62,7 @@ namespace RegressionGames.Editor.CodeGenerators
 
                     // Create the Start method
                     var startMethod = GenerateStartMethod(componentType, rgStateAttributeInfo.State);
-                    
+
                     // Create the SEInstance method
                     var seInstanceMethod = GenerateGetTypeForStateEntityMethod(componentType);
 
@@ -81,7 +81,7 @@ namespace RegressionGames.Editor.CodeGenerators
                             ClassDeclaration($"RGStateEntity_{rgStateAttributeInfo.ClassName}")
                                 .AddModifiers(
                                     Token(SyntaxKind.PublicKeyword)
-                                    // Only add one of the "class" keywords here
+                                // Only add one of the "class" keywords here
                                 )
                                 .AddBaseListTypes(
                                     SimpleBaseType(
@@ -116,8 +116,8 @@ namespace RegressionGames.Editor.CodeGenerators
                     string filePath = Path.Combine(Application.dataPath, subfolderName, fileName);
                     string fileContents = CodeGeneratorUtils.HeaderComment + formattedCode;
                     Directory.CreateDirectory(Path.GetDirectoryName(filePath));
-                    
-                    var task= File.WriteAllTextAsync(filePath, fileContents);
+
+                    var task = File.WriteAllTextAsync(filePath, fileContents);
                     fileWriteTasks[filePath] = task;
                 }
             }
@@ -201,7 +201,7 @@ namespace RegressionGames.Editor.CodeGenerators
                     Identifier("GetTypeForStateEntity"))
                 .WithModifiers(
                     TokenList(
-                        new []{
+                        new[]{
                             Token(SyntaxKind.ProtectedKeyword),
                             Token(SyntaxKind.OverrideKeyword)}))
                 .WithBody(
@@ -229,7 +229,7 @@ namespace RegressionGames.Editor.CodeGenerators
             // Add statements to add each state variable to the dictionary
             statements.AddRange(memberInfos.Select(mi =>
             {
-                ExpressionSyntax valueExpression = mi.FieldType == "method" 
+                ExpressionSyntax valueExpression = mi.FieldType == "method"
                     ? InvocationExpression(
                         MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,
@@ -276,9 +276,9 @@ namespace RegressionGames.Editor.CodeGenerators
 
             return getStateMethod;
         }
-        
-        
-        
+
+
+
         private static MemberDeclarationSyntax[] GenerateStateEntityFields(List<RGStateAttributeInfo> memberInfos)
         {
             var fields = new List<MemberDeclarationSyntax>();
@@ -286,19 +286,19 @@ namespace RegressionGames.Editor.CodeGenerators
             {
                 fields.Add(GeneratePropertyDeclaration(memberInfo));
             }
-            
+
             return fields.ToArray();
         }
 
         private static PropertyDeclarationSyntax GeneratePropertyDeclaration(RGStateAttributeInfo memberInfo)
         {
-            var specialNumberTypes = new [] {
+            var specialNumberTypes = new[] {
                 "float","double","decimal","sbyte","byte","short","ushort","int","uint","long","ulong"
             };
             if (specialNumberTypes.Contains(memberInfo.Type.ToLowerInvariant()))
             {
                 return GeneratePropertyDeclarationForNumbers(memberInfo);
-            } 
+            }
             // else generate regular format
             return GeneratePropertyDeclarationForNormalTypes(memberInfo);
         }

--- a/src/gg.regression.unity.bots/Editor/Scripts/CodeGenerators/RGCodeGenerator.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/CodeGenerators/RGCodeGenerator.cs
@@ -41,8 +41,9 @@ namespace RegressionGames.Editor.CodeGenerators
         // Used to exclude sample projects' directories from generation
         // so that we don't duplicate .cs files that are already included in the sample projects.
         // But while still scanning them so that we can include their States/Actions in the json.
-        private static readonly HashSet<string> ExcludeDirectories = new() {
-           "ThirdPersonDemoURP"
+        private static readonly HashSet<string> ExcludeDirectories = new()
+        {
+            "ThirdPersonDemoURP"
         };
 
         private static bool _hasExtractProblem = false;
@@ -581,33 +582,33 @@ namespace RegressionGames.Editor.CodeGenerators
                             switch (member)
                             {
                                 case FieldDeclarationSyntax fieldDeclaration:
-                                {
-                                    fieldName = fieldDeclaration.Declaration.Variables.First().Identifier.ValueText;
-                                    type = RemoveGlobalPrefix(semanticModel
-                                        .GetTypeInfo(fieldDeclaration.Declaration.Type)
-                                        .Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
-                                    if (!fieldDeclaration.Modifiers.Any(SyntaxKind.PublicKeyword))
                                     {
-                                        RecordWarning($"Field '{fieldDeclaration.Declaration.Variables.First().Identifier.ValueText}' in class '{className}' is not public and will not be included in the available state fields.");
-                                        continue;
-                                    }
+                                        fieldName = fieldDeclaration.Declaration.Variables.First().Identifier.ValueText;
+                                        type = RemoveGlobalPrefix(semanticModel
+                                            .GetTypeInfo(fieldDeclaration.Declaration.Type)
+                                            .Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+                                        if (!fieldDeclaration.Modifiers.Any(SyntaxKind.PublicKeyword))
+                                        {
+                                            RecordWarning($"Field '{fieldDeclaration.Declaration.Variables.First().Identifier.ValueText}' in class '{className}' is not public and will not be included in the available state fields.");
+                                            continue;
+                                        }
 
-                                    break;
-                                }
+                                        break;
+                                    }
                                 case PropertyDeclarationSyntax propertyDeclaration:
-                                {
-                                    fieldName = propertyDeclaration.Identifier.ValueText;
-                                    type = RemoveGlobalPrefix(semanticModel
-                                        .GetTypeInfo(propertyDeclaration.Type)
-                                        .Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
-                                    if (!propertyDeclaration.Modifiers.Any(SyntaxKind.PublicKeyword))
                                     {
-                                        RecordWarning($"Property '{propertyDeclaration.Identifier.ValueText}' in class '{className}' is not public and will not be included in the available state properties.");
-                                        continue;
-                                    }
+                                        fieldName = propertyDeclaration.Identifier.ValueText;
+                                        type = RemoveGlobalPrefix(semanticModel
+                                            .GetTypeInfo(propertyDeclaration.Type)
+                                            .Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+                                        if (!propertyDeclaration.Modifiers.Any(SyntaxKind.PublicKeyword))
+                                        {
+                                            RecordWarning($"Property '{propertyDeclaration.Identifier.ValueText}' in class '{className}' is not public and will not be included in the available state properties.");
+                                            continue;
+                                        }
 
-                                    break;
-                                }
+                                        break;
+                                    }
                                 default:
                                     // no methods
                                     continue;
@@ -719,7 +720,7 @@ namespace RegressionGames.Editor.CodeGenerators
                     var allEntities = Object.FindObjectsOfType<RGEntity>().Where(v => !string.IsNullOrEmpty(v.objectType));
                     foreach (var entity in allEntities)
                     {
-                        var (stateClassNames,actionClassNames) = entity.LookupStatesAndActions();
+                        var (stateClassNames, actionClassNames) = entity.LookupStatesAndActions();
 
                         var entityStateActionJson = DeriveStateAndActionJsonForEntity(entity.objectType, stateClassNames, actionClassNames, statesInfos, actionInfos);
 
@@ -775,7 +776,7 @@ namespace RegressionGames.Editor.CodeGenerators
                     RGEntity prefabComponent = prefab.GetComponent<RGEntity>();
                     if (prefabComponent != null && !string.IsNullOrEmpty(prefabComponent.objectType))
                     {
-                        var (stateClassNames,actionClassNames) = prefabComponent.LookupStatesAndActions();
+                        var (stateClassNames, actionClassNames) = prefabComponent.LookupStatesAndActions();
 
                         var prefabStateActionJson = DeriveStateAndActionJsonForEntity(prefabComponent.objectType, stateClassNames, actionClassNames, statesInfos, actionInfos);
                         CheckForMisMatchedStateOrActionsOnEntity(prefabComponent, prefabStateActionJson, result);
@@ -789,20 +790,20 @@ namespace RegressionGames.Editor.CodeGenerators
                 }
             }
 
-            (List<RGEntityStatesJson>, List<RGEntityActionsJson>) listResult = new  ()
+            (List<RGEntityStatesJson>, List<RGEntityActionsJson>) listResult = new()
             {
                 Item1 = result.Item1.ToList(),
                 Item2 = result.Item2.ToList()
             };
 
-            listResult.Item1.Sort((a,b) => a.ObjectType.CompareTo(b.ObjectType));
-            listResult.Item2.Sort((a,b) => a.ObjectType.CompareTo(b.ObjectType));
+            listResult.Item1.Sort((a, b) => a.ObjectType.CompareTo(b.ObjectType));
+            listResult.Item2.Sort((a, b) => a.ObjectType.CompareTo(b.ObjectType));
             return listResult;
         }
 
-        private static void CheckForMisMatchedStateOrActionsOnEntity(RGEntity entity, (RGEntityStatesJson, RGEntityActionsJson) entityStateActionJson, (HashSet<RGEntityStatesJson>, HashSet<RGEntityActionsJson>)result)
+        private static void CheckForMisMatchedStateOrActionsOnEntity(RGEntity entity, (RGEntityStatesJson, RGEntityActionsJson) entityStateActionJson, (HashSet<RGEntityStatesJson>, HashSet<RGEntityActionsJson>) result)
         {
-            if(result.Item1.TryGetValue(entityStateActionJson.Item1, out var existingItem1))
+            if (result.Item1.TryGetValue(entityStateActionJson.Item1, out var existingItem1))
             {
                 // this is a bit expensive, but necessary to ensure all RGStateEntities of the same ObjectType expose the same state/Actions
                 if (existingItem1.States.Count != entityStateActionJson.Item1.States.Count ||
@@ -821,7 +822,7 @@ namespace RegressionGames.Editor.CodeGenerators
                     RecordWarning($"RGEntity of ObjectType: {entity.objectType} has conflicting state definitions on different game objects or prefabs;  state lists: [{string.Join(", ", entityStateActionJson.Item1.States)}] <-> [{string.Join(", ", existingItem1.States)}]");
                 }
             }
-            if(result.Item2.TryGetValue(entityStateActionJson.Item2, out var existingItem2))
+            if (result.Item2.TryGetValue(entityStateActionJson.Item2, out var existingItem2))
             {
                 // this is a bit expensive, but necessary to ensure all RGStateEntities of the same ObjectType expose the same state/Actions
                 if (existingItem2.Actions.Count != entityStateActionJson.Item2.Actions.Count ||

--- a/src/gg.regression.unity.bots/Editor/Scripts/RGBotReplayWindow.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGBotReplayWindow.cs
@@ -22,7 +22,7 @@ namespace RegressionGames.Editor
     public class RGBotReplayWindow : EditorWindow
     {
         public const string PREFAB_PATH = "Packages/gg.regression.unity.bots/Editor/Prefabs";
-       
+
         //TODO: Get this from game engine
         private const int PHYSICS_TICK_RATE = 20; // 0.02 sec or 20 ms per physics tick
         private readonly Color _darkerColor = Color.white * 0.1f;
@@ -89,21 +89,21 @@ namespace RegressionGames.Editor
             EditorGUI.BeginDisabledGroup(fileName == null || fileName.Length < 1);
             if (GUILayout.Button("Reload ...", GUILayout.ExpandWidth(false))) Reload();
             EditorGUI.EndDisabledGroup();
-            
+
             GUILayout.FlexibleSpace();
-                        
+
 
             EditorGUILayout.EndHorizontal();
-            
+
             GUILayout.Space(5);
-            
+
             if (!ReplayModelManager.GetInstance().HasEntries())
             {
                 EditorGUILayout.HelpBox("Custom Replay Models have not been configured for this project.\nLoad your first replay zip to auto populate the entity types, then configure their model associations using the `Configure Custom Replay Models` button.\n(You can also manually add, edit, or remove associations at any time.)", MessageType.Warning, true);
             }
-            
+
             // Button for registering custom replay models
-            if (GUILayout.Button("Configure Custom Replay Models", new GUILayoutOption[] {GUILayout.ExpandWidth(false)}))
+            if (GUILayout.Button("Configure Custom Replay Models", new GUILayoutOption[] { GUILayout.ExpandWidth(false) }))
             {
                 // create or load the prefabs list
                 ShowReplayModelsInspector();
@@ -257,7 +257,7 @@ namespace RegressionGames.Editor
                 headerContent = new GUIContent("Actions", "Actions entity took in the current tick."),
                 headerTextAlignment = TextAlignment.Center
             });
-            
+
             _columns.Add(new MultiColumnHeaderState.Column
             {
                 allowToggleVisibility = false,
@@ -504,43 +504,43 @@ namespace RegressionGames.Editor
                         if (isSpawned)
                         {
                             var actions = dataTickInfo.actions;
-                       
+
                             // Fit each action equally into the space with text hover help
                             for (var j = 0; j < actions.Length; j++)
                             {
                                 // draw a colored rect
                                 var actionRect = CreateInfoRect(columnIndex, rowRect.y, actions.Length, j);
                                 EditorGUI.DrawRect(actionRect, Color.gray * Color.yellow);
-                                
+
                                 // then put a label in it
                                 var label = new GUIContent($"{actions[j].action}", $"{textForAction(j + 1, actions[j])}");
                                 EditorGUI.DropShadowLabel(actionRect, label, actionLabelGUIStyle);
                             }
                         }
-                    
-                        // Validations column
-                        ++columnIndex;
-                        if (_multiColumnHeader.IsColumnVisible(columnIndex))
-                            if (isSpawned)
-                            {
-                                var validationResults = dataTickInfo.validationResults;
-                                
-                                // Fit each validation equally into the space with text hover help
-                                for (var j = 0; j < validationResults.Length; j++)
-                                {
-                                    var currentValidation = validationResults[j];
 
-                                    // draw a colored rect
-                                    var validationRect = CreateInfoRect(columnIndex, rowRect.y, validationResults.Length, j);
-                                    var color = currentValidation.passed ? Color.green : Color.red;
-                                    EditorGUI.DrawRect(validationRect, Color.gray * color);
-                                    
-                                    // then put a label in it
-                                    var tooltip = (currentValidation.passed ? "[PASSED] " : "[FAILED] ") + currentValidation.message;
-                                    var label = new GUIContent(currentValidation.message, tooltip);
-                                    EditorGUI.DropShadowLabel(validationRect, label, validationLabelGUIStyle);
-                                }
+                    // Validations column
+                    ++columnIndex;
+                    if (_multiColumnHeader.IsColumnVisible(columnIndex))
+                        if (isSpawned)
+                        {
+                            var validationResults = dataTickInfo.validationResults;
+
+                            // Fit each validation equally into the space with text hover help
+                            for (var j = 0; j < validationResults.Length; j++)
+                            {
+                                var currentValidation = validationResults[j];
+
+                                // draw a colored rect
+                                var validationRect = CreateInfoRect(columnIndex, rowRect.y, validationResults.Length, j);
+                                var color = currentValidation.passed ? Color.green : Color.red;
+                                EditorGUI.DrawRect(validationRect, Color.gray * color);
+
+                                // then put a label in it
+                                var tooltip = (currentValidation.passed ? "[PASSED] " : "[FAILED] ") + currentValidation.message;
+                                var label = new GUIContent(currentValidation.message, tooltip);
+                                EditorGUI.DropShadowLabel(validationRect, label, validationLabelGUIStyle);
                             }
+                        }
 
                     ++a;
                 }
@@ -569,7 +569,7 @@ namespace RegressionGames.Editor
                 insetRect.y += padding.Value.y;
                 insetRect.height -= padding.Value.y * 2;
             }
-            
+
             return insetRect;
         }
 
@@ -580,12 +580,12 @@ namespace RegressionGames.Editor
         private Rect CreateInfoRect(int columnIndex, float height, int componentsPerRow, int xOffset)
         {
             var insetRect = CreateInsetRect(columnIndex, height, null);
-            
+
             const float minWidth = 5f;
             const float maxWidth = 150f;
             var width = insetRect.width / Math.Max(1, componentsPerRow);
             width = Math.Min(Math.Max(width, minWidth), maxWidth);
-            
+
             // leave a 1 pixel gap .. this keeps many actions from flowing together
             insetRect.width = width - 1;
             insetRect.x += width * xOffset;
@@ -597,7 +597,7 @@ namespace RegressionGames.Editor
         {
             GetWindow(typeof(RGBotReplayWindow), false, "RG Bot Replay");
         }
-        
+
         // Did not add to the top menu yet, but might in the future
         //[MenuItem("Regression Games/Configure Custom Replay Models")]
         public static void ShowReplayModelsInspector()
@@ -706,12 +706,12 @@ namespace RegressionGames.Editor
                     {
                         position = ti.state.position;
                     }
-                    
+
                     if (ti?.state?.rotation != null)
                     {
                         rotation = ti.state.rotation;
                     }
-                    
+
                     var typeRootName = $"{tickData.data.type}s";
                     var typeRoot = findChildByName(rootObject.transform, typeRootName);
                     if (typeRoot == null)
@@ -1011,7 +1011,7 @@ namespace RegressionGames.Editor
                                 tickInfoManager.processTick(tickIndexNumber, rData.tickInfo);
                                 if (rData.playerId != null && rData.playerId != -1)
                                     tickInfoManager.processReplayData(tickIndexNumber, (long)rData.playerId, rData);
-                                    
+
                                 if (rData.tickRate != null)
                                     // get the right tickRate
                                     tickRate = (int)rData.tickRate;
@@ -1019,7 +1019,7 @@ namespace RegressionGames.Editor
                                 ++tickIndexNumber;
                             }
                     }
-                    
+
                     // save any assets we created, like replay model associations
                     // we do this once here instead of internally when adding the asset for
                     // performance reasons.. this is expensive
@@ -1089,5 +1089,5 @@ namespace RegressionGames.Editor
             if (currentTick == priorTick) playing = false;
         }
     }
-    #endif
+#endif
 }

--- a/src/gg.regression.unity.bots/Editor/Scripts/RGEntityStatesJson.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGEntityStatesJson.cs
@@ -4,7 +4,7 @@ using UnityEngine.Serialization;
 
 namespace RegressionGames.Editor
 {
-    
+
     [Serializable]
     // ReSharper disable InconsistentNaming
     public class RGEntityStatesJson

--- a/src/gg.regression.unity.bots/Editor/Scripts/RGSettingsUIRegistrar.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGSettingsUIRegistrar.cs
@@ -19,7 +19,7 @@ namespace RegressionGames.Editor
     public class RGSettingsUIRegistrar
     {
 
-        private static RGServiceManager rgServiceManager = new (); // editor, not game/scene so don't look for one, make one
+        private static RGServiceManager rgServiceManager = new(); // editor, not game/scene so don't look for one, make one
 
         private static string token = null;
         private static string priorUser = null;
@@ -44,31 +44,31 @@ namespace RegressionGames.Editor
                     SerializedObject settings = RGSettings.GetSerializedSettings();
                     SerializedObject userSettings = RGUserSettings.GetSerializedUserSettings();
                     EditorGUI.BeginChangeCheck();
-                    
+
                     SerializedProperty hostField = settings.FindProperty("rgHostAddress");
                     hostField.stringValue = EditorGUILayout.TextField("RG Host URL", hostField.stringValue);
-                    
+
                     SerializedProperty emailField = userSettings.FindProperty("email");
                     emailField.stringValue = EditorGUILayout.TextField("RG Email", emailField.stringValue);
                     SerializedProperty passwordField = userSettings.FindProperty("password");
                     passwordField.stringValue = EditorGUILayout.PasswordField("RG Password", passwordField.stringValue);
-                    
+
                     SerializedProperty logLevel = settings.FindProperty("logLevel");
                     logLevel.enumValueIndex = (int)(DebugLogLevel)EditorGUILayout.EnumPopup("Log Level", (DebugLogLevel)logLevel.enumValueIndex);
 
                     SerializedProperty enableOverlay = settings.FindProperty("enableOverlay");
                     enableOverlay.boolValue =
                         EditorGUILayout.Toggle("Enable Screen Overlay ?", enableOverlay.boolValue);
-                    
+
                     SerializedProperty useSystemSettings = settings.FindProperty("useSystemSettings");
                     useSystemSettings.boolValue =
                         EditorGUILayout.Toggle("Use Global Bot Settings ?", useSystemSettings.boolValue);
-                    
+
                     EditorGUI.BeginDisabledGroup(useSystemSettings.boolValue != true);
                     SerializedProperty numBotsProp = settings.FindProperty("numBots");
                     numBotsProp.intValue = EditorGUILayout.IntSlider("Number Of Bots", numBotsProp.intValue, 0, 7, new GUILayoutOption[] { });
                     SerializedProperty botsSelected = settings.FindProperty("botsSelected");
-                    if ((EditorApplication.timeSinceStartup-timeOfLastEdit) > 3f && token == null && priorPassword == null && priorHost == null && priorUser == null && passwordField.stringValue.Length > 4 && emailField.stringValue.Length > 4 && hostField.stringValue.Length > 4)
+                    if ((EditorApplication.timeSinceStartup - timeOfLastEdit) > 3f && token == null && priorPassword == null && priorHost == null && priorUser == null && passwordField.stringValue.Length > 4 && emailField.stringValue.Length > 4 && hostField.stringValue.Length > 4)
                     {
                         priorPassword = passwordField.stringValue;
                         priorUser = emailField.stringValue;
@@ -84,14 +84,14 @@ namespace RegressionGames.Editor
                         {
                             foreach (var rgBot in botList)
                             {
-                                if (rgBot is { IsUnityBot: true , IsLocal: false})
+                                if (rgBot is { IsUnityBot: true, IsLocal: false })
                                 {
                                     listOfBots.Add(rgBot);
                                 }
                             }
                         }, () =>
                         {
-                            
+
                         });
                         // get Local bots
                         RGBotAssetsManager.GetInstance()?.RefreshAvailableBots();
@@ -103,7 +103,7 @@ namespace RegressionGames.Editor
                                 listOfBots.Add(localBot);
                             }
                         }
-                        listOfBots.Sort((a,b) => String.Compare(a.UIString, b.UIString, StringComparison.Ordinal));
+                        listOfBots.Sort((a, b) => String.Compare(a.UIString, b.UIString, StringComparison.Ordinal));
                         bots = listOfBots.ToArray();
                     }
 
@@ -117,7 +117,7 @@ namespace RegressionGames.Editor
                             botIndexMap[bot.id] = index;
                             return index++;
                         });
-                        
+
                         for (int i = 1; i <= numBotsProp.intValue; i++)
                         {
                             try
@@ -131,10 +131,10 @@ namespace RegressionGames.Editor
 
                                 var priorIndex = 0;
                                 botIndexMap.TryGetValue(botSelected.longValue, out priorIndex);
-                                    var indexSelected = EditorGUILayout.IntPopup($"Bot # {i}",
-                                        priorIndex,
-                                    botUIStrings.ToArray(), botIndexes.ToArray(),
-                                    new GUILayoutOption[] { });
+                                var indexSelected = EditorGUILayout.IntPopup($"Bot # {i}",
+                                    priorIndex,
+                                botUIStrings.ToArray(), botIndexes.ToArray(),
+                                new GUILayoutOption[] { });
                                 if (indexSelected > bots.Length)
                                 {
                                     indexSelected = 0;
@@ -194,14 +194,14 @@ namespace RegressionGames.Editor
 
             var tcs = new TaskCompletionSource<bool>();
 
-            await rgServiceManager.Auth(priorUser, priorPassword, 
-                responseToken => 
+            await rgServiceManager.Auth(priorUser, priorPassword,
+                responseToken =>
                 {
                     token = responseToken;
                     bots = null;
                     tcs.SetResult(true);
-                }, 
-                f => 
+                },
+                f =>
                 {
                     token = null;
                     bots = null;

--- a/src/gg.regression.unity.bots/Editor/Scripts/RGStateAttributesInfo.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGStateAttributesInfo.cs
@@ -10,7 +10,7 @@ namespace RegressionGames.Editor
     {
         public List<RGStateAttributesInfo> RGStateAttributesInfo { get; set; }
     }
-    
+
     [Serializable]
     public class RGStateAttributesInfo
     {

--- a/src/gg.regression.unity.bots/Editor/Scripts/RGStatesInfo.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGStatesInfo.cs
@@ -9,7 +9,7 @@ namespace RegressionGames.Editor
     {
         public List<RGStatesInfo> RGStatesInfo { get; set; }
     }
-    
+
     [Serializable]
     public class RGStatesInfo
     {

--- a/src/gg.regression.unity.bots/Editor/Scripts/RGTickInfoActionManager.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGTickInfoActionManager.cs
@@ -73,23 +73,23 @@ namespace RegressionGames.Editor
 
                 bool isRuntimeObject = entity.isRuntimeObject;
                 populateReplayDataForEntity(entityId, isPlayer, isRuntimeObject, entity.type);
-                
+
                 // handle strong typing on position / rotation accessors
                 if (entity.ContainsKey("position") && entity["position"] is JObject)
                 {
-                        var jObj = (JObject)entity["position"];
-                        entity["position"] = new Vector3(jObj["x"].Value<float>(),
-                            jObj["y"].Value<float>(),
-                            jObj["z"].Value<float>());
+                    var jObj = (JObject)entity["position"];
+                    entity["position"] = new Vector3(jObj["x"].Value<float>(),
+                        jObj["y"].Value<float>(),
+                        jObj["z"].Value<float>());
                 }
-                
+
                 if (entity.ContainsKey("rotation") && entity["rotation"] is JObject)
                 {
-                        var jObj = (JObject)entity["rotation"];
-                        entity["rotation"] = new Quaternion(jObj["x"].Value<float>(),
-                            jObj["y"].Value<float>(),
-                            jObj["z"].Value<float>(),
-                            jObj["w"].Value<float>());
+                    var jObj = (JObject)entity["rotation"];
+                    entity["rotation"] = new Quaternion(jObj["x"].Value<float>(),
+                        jObj["y"].Value<float>(),
+                        jObj["z"].Value<float>(),
+                        jObj["w"].Value<float>());
                 }
             }
         }
@@ -100,7 +100,7 @@ namespace RegressionGames.Editor
             tickInfo.actions = data.actions == null ? Array.Empty<RGActionRequest>() : data.actions;
             tickInfo.validationResults = data.validationResults == null ? Array.Empty<RGValidationResult>() : data.validationResults;
             // show path and actions by default only for bot players with actions
-            populateReplayDataForEntity(entityId, true,false, null, true,
+            populateReplayDataForEntity(entityId, true, false, null, true,
                 true, true);
         }
 

--- a/src/gg.regression.unity.bots/Editor/Scripts/ReplayModelManager.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/ReplayModelManager.cs
@@ -11,17 +11,18 @@ namespace RegressionGames.Editor
 #if UNITY_EDITOR
     public class ReplayModelManager : ScriptableObject
     {
-        
+
         public readonly static string ASSET_PATH = "Assets/RegressionGames/Editor/CustomReplayModels.asset";
-        
-        
+
+
         [SerializeField] private NamedModel[] models = Array.Empty<NamedModel>();
 
 
         public void OnEnable()
         {
-            
-            if ( AssetDatabase.GetMainAssetTypeAtPath( ASSET_PATH ) != null) {
+
+            if (AssetDatabase.GetMainAssetTypeAtPath(ASSET_PATH) != null)
+            {
                 _this = AssetDatabase.LoadAssetAtPath<ReplayModelManager>(ASSET_PATH);
             }
         }
@@ -45,11 +46,12 @@ namespace RegressionGames.Editor
                 _this = CreateInstance<ReplayModelManager>();
             }
 
-            if ( AssetDatabase.GetMainAssetTypeAtPath( ASSET_PATH ) == null) {
-                AssetDatabase.CreateAsset(_this, ASSET_PATH );
+            if (AssetDatabase.GetMainAssetTypeAtPath(ASSET_PATH) == null)
+            {
+                AssetDatabase.CreateAsset(_this, ASSET_PATH);
                 AssetDatabase.SaveAssets();
             }
-            
+
             return _this;
         }
 
@@ -60,7 +62,7 @@ namespace RegressionGames.Editor
                 AssetDatabase.OpenAsset(_this);
             }
         }
-        
+
         public bool HasEntries()
         {
             return models.Length > 0;
@@ -80,7 +82,7 @@ namespace RegressionGames.Editor
 
             return false;
         }
-        
+
         [CanBeNull]
         public GameObject getModelPrefabForType(string type, string charType)
         {
@@ -95,13 +97,13 @@ namespace RegressionGames.Editor
 
             nm = models.FirstOrDefault(model => model.objectType == type);
             if (nm.objectType != null && nm.modelPrefab != null) return nm.modelPrefab;
-                
+
             GameObject defaultPrefab = AssetDatabase.LoadAssetAtPath<GameObject>(
                 $"{RGBotReplayWindow.PREFAB_PATH}/DefaultModel.prefab");
 
             // could be null
             return defaultPrefab;
-            
+
         }
 
         [Serializable]
@@ -112,7 +114,7 @@ namespace RegressionGames.Editor
                 this.objectType = objectType;
                 this.modelPrefab = modelPrefab;
             }
-            
+
             [CanBeNull] public string objectType;
             [CanBeNull] public GameObject modelPrefab;
         }

--- a/src/gg.regression.unity.bots/Editor/Scripts/Startup/RegressionPackagePopup.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/Startup/RegressionPackagePopup.cs
@@ -34,7 +34,7 @@ public class RegressionPackagePopup : EditorWindow
         string assetsPath = "Assets/Editor/Images/banner.png";
 
         bannerImage = AssetDatabase.LoadAssetAtPath<Texture2D>(packagePath);
-    
+
         if (bannerImage == null)
         {
             bannerImage = AssetDatabase.LoadAssetAtPath<Texture2D>(assetsPath);
@@ -45,7 +45,7 @@ public class RegressionPackagePopup : EditorWindow
             Debug.LogWarning("Failed to load banner image");
         }
     }
-    
+
     [MenuItem("Regression Games/Getting Started")]
     public static async void ShowWindow()
     {
@@ -53,7 +53,7 @@ public class RegressionPackagePopup : EditorWindow
         email = RGUserSettings.GetOrCreateUserSettings().GetEmail();
         password = RGUserSettings.GetOrCreateUserSettings().GetPassword();
         await Login();
-        
+
         if (window == null)
         {
             Rect windowRect = new Rect(100, 100, 600, 600);
@@ -81,16 +81,16 @@ public class RegressionPackagePopup : EditorWindow
     private void RenderLoginScreen()
     {
         if (bannerImage != null)
-        { 
+        {
             GUILayout.Box(bannerImage, GUILayout.ExpandWidth(true), GUILayout.Height(200));
         }
-        
+
         // H1
         GUIStyle h1Style = new GUIStyle(EditorStyles.largeLabel);
         h1Style.fontSize = 20;
         h1Style.fontStyle = FontStyle.Bold;
         h1Style.normal.textColor = Color.white;
-        
+
         // P
         GUIStyle pStyle = new GUIStyle(EditorStyles.label);
         pStyle.fontSize = 12;
@@ -114,7 +114,7 @@ public class RegressionPackagePopup : EditorWindow
             "will help you get started quickly.", pStyle, GUILayout.Width(550));
         GUILayout.FlexibleSpace();
         GUILayout.EndHorizontal();
-        
+
         GUILayout.Space(20);
         // Email field
         GUILayout.BeginHorizontal();
@@ -155,7 +155,7 @@ public class RegressionPackagePopup : EditorWindow
         // Create Account and Forgot Password Links
         GUIStyle linkStyle = new GUIStyle(EditorStyles.label);
         linkStyle.fontSize = 12;
-        
+
         GUILayout.BeginHorizontal();
         GUILayout.FlexibleSpace();
         if (GUILayout.Button("Create Account", linkStyle))
@@ -164,7 +164,7 @@ public class RegressionPackagePopup : EditorWindow
         }
 
         GUILayout.Space(10);
-        
+
         // For mouse hover effect
         if (Event.current.type == EventType.Repaint && GUILayoutUtility.GetLastRect().Contains(Event.current.mousePosition))
         {
@@ -182,14 +182,14 @@ public class RegressionPackagePopup : EditorWindow
         if (Event.current.type == EventType.Repaint && GUILayoutUtility.GetLastRect().Contains(Event.current.mousePosition))
         {
             EditorGUIUtility.AddCursorRect(GUILayoutUtility.GetLastRect(), MouseCursor.Link);
-        } 
+        }
     }
 
     private void RenderWelcomeScreen()
     {
         // set flags on render as extra check against duplicated popups
         PlayerPrefs.SetInt(RGGuestCheck, 1);
-        
+
         // render window info
         RenderBanner();
         RenderAlwaysShowOnStartupCheckbox();
@@ -209,14 +209,14 @@ public class RegressionPackagePopup : EditorWindow
         GUI.color = new Color(0, 0, 0, 0.5f);
         GUI.DrawTexture(new Rect(0, 0, 600, 120), EditorGUIUtility.whiteTexture);
         GUI.color = prevColor;
-        
+
         // Define the text style
         GUIStyle h1Style = new GUIStyle(EditorStyles.largeLabel)
         {
             normal = { textColor = Color.white },
             alignment = TextAnchor.MiddleLeft,
             fontSize = 20,
-            fontStyle = FontStyle.Bold 
+            fontStyle = FontStyle.Bold
         };
 
         // Determine the position and size for the label
@@ -225,16 +225,16 @@ public class RegressionPackagePopup : EditorWindow
         // Draw the title text
         GUI.Label(textRect, "Regression Games Setup Guide", h1Style);
     }
-    
+
     private void RenderAlwaysShowOnStartupCheckbox()
     {
         GUILayout.Space(120);
-        
+
         // Get the current value from PlayerPrefs
         bool alwaysShowOnStartup = PlayerPrefs.GetInt(RGWindowCheck, 1) == 1;
 
         // Define the style for the label
-        GUIStyle labelStyle = new GUIStyle(GUI.skin.label) 
+        GUIStyle labelStyle = new GUIStyle(GUI.skin.label)
         {
             fontStyle = FontStyle.Bold,
             fontSize = 12
@@ -242,7 +242,7 @@ public class RegressionPackagePopup : EditorWindow
 
         // Define the position and size for the label
         Rect labelRect = new Rect(20, 130, 200, 20);
-    
+
         // Draw the label
         GUI.Label(labelRect, "Always Show On Startup", labelStyle);
 
@@ -303,7 +303,7 @@ public class RegressionPackagePopup : EditorWindow
             Application.OpenURL("https://docs.regression.gg/studios/unity/unity-sdk/creating-bots/csharp/configuration");
         }
     }
-    
+
     private void RenderSampleQuickstart()
     {
         // Define the styles for the sample section
@@ -317,7 +317,7 @@ public class RegressionPackagePopup : EditorWindow
         {
             wordWrap = true
         };
-        
+
         GUIStyle boldDescriptionStyle = new GUIStyle(EditorStyles.label)
         {
             wordWrap = true,
@@ -348,7 +348,7 @@ public class RegressionPackagePopup : EditorWindow
         }
         GUI.enabled = true;
     }
-    
+
     private bool IsURPEnabled()
     {
         var renderPipelineAsset = GraphicsSettings.currentRenderPipeline;
@@ -362,7 +362,7 @@ public class RegressionPackagePopup : EditorWindow
         }
         return false;
     }
-    
+
     private void ImportSample(string sampleName)
     {
         string packageName = "gg.regression.unity.bots";
@@ -405,7 +405,7 @@ public class RegressionPackagePopup : EditorWindow
             RGDebug.LogError("The sample could not be found or is not in an embedded or local package.");
         }
     }
-    
+
     [InitializeOnLoadMethod]
     private static void InitializeOnLoadMethod()
     {
@@ -414,7 +414,7 @@ public class RegressionPackagePopup : EditorWindow
             SessionState.SetBool(RGUnityCheck, true);
             bool showOnStartup = PlayerPrefs.GetInt(RGWindowCheck, 1) == 1;
             if (showOnStartup)
-            { 
+            {
                 EditorApplication.update += ShowOnStartup;
             }
         }
@@ -428,7 +428,7 @@ public class RegressionPackagePopup : EditorWindow
             ShowWindow();
         }
     }
-    
+
     private static async Task Login()
     {
         if (string.IsNullOrEmpty(email) || string.IsNullOrEmpty(password))
@@ -456,8 +456,8 @@ public class RegressionPackagePopup : EditorWindow
         {
             window.Repaint();
             return;
-        } 
-        
+        }
+
         // continue without log in
         PlayerPrefs.SetInt(RGGuestCheck, 1);
         if (window != null)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/ActiveRGBotUIElement.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/ActiveRGBotUIElement.cs
@@ -20,11 +20,11 @@ namespace RegressionGames
                 statusText.text = $"{state}";
             }
         }
-        
+
         public void Start()
         {
             Button b = GetComponentInChildren<Button>();
-            
+
             b.onClick.AddListener(() =>
             {
                 FindObjectOfType<RGOverlayMenu>()?.StopBotInstance(_entry.id);
@@ -32,7 +32,7 @@ namespace RegressionGames
             RGBotServerListener.GetInstance().AddUnityBotStateListener(_entry.id, UpdateState);
             statusText.text = $"{RGBotServerListener.GetInstance().GetUnityBotState(_entry.id)}";
         }
-        
+
         public void PopulateBotEntry(RGBotInstance entry)
         {
             _entry = entry;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/BehaviorTree/BehaviorTreeNode.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/BehaviorTree/BehaviorTreeNode.cs
@@ -16,7 +16,7 @@ namespace RegressionGames.BehaviorTree
 
         /// <summary>The name of the node.</summary>
         public readonly string Name;
-        
+
         /// <summary>The path from the root to this node.</summary>
         public string Path => Parent is null ? Name : $"{Parent.Path}/{Name}";
 
@@ -41,7 +41,7 @@ namespace RegressionGames.BehaviorTree
             RGDebug.LogVerbose($"Behavior Tree Node '{Path}' completed with result '{result}'");
             return result;
         }
-        
+
         /// <summary>
         /// Executes the node, given the provided <see cref="RG"/> object as context.
         /// </summary>
@@ -74,7 +74,7 @@ namespace RegressionGames.BehaviorTree
         protected void ClearData(string key)
             => GetRoot().Data.Remove(key);
 
-        internal void SetParent(BehaviorTreeNode parent) 
+        internal void SetParent(BehaviorTreeNode parent)
             => Parent = parent;
 
         protected RootNode GetRoot()
@@ -95,11 +95,11 @@ namespace RegressionGames.BehaviorTree
             return root;
         }
     }
-    
+
     /// <summary>
     /// Base class for any <see cref="BehaviorTreeNode"/> with child nodes.
     /// </summary>
-    public abstract class ContainerNode: BehaviorTreeNode
+    public abstract class ContainerNode : BehaviorTreeNode
     {
         private List<BehaviorTreeNode> _children = new();
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/BehaviorTree/Decorators.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/BehaviorTree/Decorators.cs
@@ -32,7 +32,7 @@ namespace RegressionGames.BehaviorTree
     /// <summary>
     /// A node that executes it's child, but ignores the result and always returns <see cref="NodeStatus.Success"/>.
     /// </summary>
-    public class AlwaysSucceed: DecoratorNode
+    public class AlwaysSucceed : DecoratorNode
     {
         public AlwaysSucceed() : base("Always Succeed")
         {
@@ -52,7 +52,7 @@ namespace RegressionGames.BehaviorTree
     /// <summary>
     /// A node that executes it's child, but ignores the result and always returns <see cref="NodeStatus.Failure"/>.
     /// </summary>
-    public class AlwaysFail: DecoratorNode
+    public class AlwaysFail : DecoratorNode
     {
         public AlwaysFail() : base("Always Fail")
         {
@@ -77,7 +77,7 @@ namespace RegressionGames.BehaviorTree
     /// If the child node returns <see cref="NodeStatus.Failure"/>, this node returns <see cref="NodeStatus.Success"/>.
     /// If the child node returns <see cref="NodeStatus.Success"/>, this node returns <see cref="NodeStatus.Failure"/>.
     /// </remarks>
-    public class Invert: DecoratorNode
+    public class Invert : DecoratorNode
     {
         public Invert() : base("Invert")
         {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/BehaviorTree/NodeStatus.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/BehaviorTree/NodeStatus.cs
@@ -6,12 +6,12 @@ namespace RegressionGames.BehaviorTree
         /// The node has completed successfully.
         /// </summary>
         Success,
-        
+
         /// <summary>
         /// The node failed to execute.
         /// </summary>
         Failure,
-        
+
         /// <summary>
         /// The node is still running.
         /// </summary>

--- a/src/gg.regression.unity.bots/Runtime/Scripts/BehaviorTree/RGBehaviorTreeBot.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/BehaviorTree/RGBehaviorTreeBot.cs
@@ -2,7 +2,7 @@ using RegressionGames.RGBotLocalRuntime;
 
 namespace RegressionGames.BehaviorTree
 {
-    public abstract class RGBehaviorTreeBot: RGUserBot
+    public abstract class RGBehaviorTreeBot : RGUserBot
     {
         private BehaviorTreeNode _rootNode;
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/BehaviorTree/RootNode.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/BehaviorTree/RootNode.cs
@@ -18,8 +18,8 @@ namespace RegressionGames.BehaviorTree
 
         protected override NodeStatus Execute(RG rgObject)
         {
-            return Children.Count > 0 
-                ? Children.First().Invoke(rgObject) 
+            return Children.Count > 0
+                ? Children.First().Invoke(rgObject)
                 : NodeStatus.Failure;
         }
     }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/BehaviorTree/SelectorNode.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/BehaviorTree/SelectorNode.cs
@@ -11,7 +11,7 @@ namespace RegressionGames.BehaviorTree
     {
         protected override NodeStatus Execute(RG rgObject)
         {
-            foreach(var child in Children)
+            foreach (var child in Children)
             {
                 var result = child.Invoke(rgObject);
                 if (result == NodeStatus.Success || result == NodeStatus.Running)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/BehaviorTree/SequenceNode.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/BehaviorTree/SequenceNode.cs
@@ -10,7 +10,7 @@ namespace RegressionGames.BehaviorTree
     {
         protected override NodeStatus Execute(RG rgObject)
         {
-            foreach(var child in Children)
+            foreach (var child in Children)
             {
                 var result = child.Invoke(rgObject);
                 if (result != NodeStatus.Success)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/DataCollection/RGDataCollection.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/DataCollection/RGDataCollection.cs
@@ -59,7 +59,7 @@ namespace RegressionGames.DataCollection
             public List<Task> replayDataTasks = new();
             public Task validationDataTask;
             public Task logFlushTask;
-            public RGValidationSummary validationSummary = new(0,0,0);
+            public RGValidationSummary validationSummary = new(0, 0, 0);
 
             public BotInstanceDataCollectionState(RGBot bot, DateTime startTime)
             {
@@ -108,7 +108,7 @@ namespace RegressionGames.DataCollection
         public void ProcessScreenshotRequests()
         {
             var done = false;
-            while(!done && _screenshotTicksRequested.TryDequeue(out long tick) )
+            while (!done && _screenshotTicksRequested.TryDequeue(out long tick))
             {
                 // only allow one screenshot per tick #
                 // if many bots are running locally, they may all ask for the same tick
@@ -383,7 +383,7 @@ namespace RegressionGames.DataCollection
         private string GetSessionDirectory(string path = "")
         {
             //TODO: (REG-1422) Make this deterministic in a way that we can sync data later if the connection was down
-            var fullPath = Path.Combine(_rootPath, "RGData",  _sessionName, path);
+            var fullPath = Path.Combine(_rootPath, "RGData", _sessionName, path);
             var directory = Path.GetDirectoryName(fullPath);
             if (directory != null)
             {
@@ -427,7 +427,8 @@ namespace RegressionGames.DataCollection
 
     // Extension code borrowed from StackOverflow to allow creating a zip of directory
     // while filtering out certain contents
-    public static class ZipHelper {
+    public static class ZipHelper
+    {
         public static void CreateFromDirectory(string sourceDirectoryName,
             string destinationArchiveFileName,
             CompressionLevel compressionLevel = CompressionLevel.Fastest,
@@ -435,10 +436,12 @@ namespace RegressionGames.DataCollection
             Predicate<string> exclusionFilter = null
         )
         {
-            if (string.IsNullOrEmpty(sourceDirectoryName)) {
+            if (string.IsNullOrEmpty(sourceDirectoryName))
+            {
                 throw new ArgumentNullException("sourceDirectoryName");
             }
-            if (string.IsNullOrEmpty(destinationArchiveFileName)) {
+            if (string.IsNullOrEmpty(destinationArchiveFileName))
+            {
                 throw new ArgumentNullException("destinationArchiveFileName");
             }
             var filesToAdd = Directory.GetFiles(sourceDirectoryName, "*", SearchOption.AllDirectories);

--- a/src/gg.regression.unity.bots/Runtime/Scripts/DebugUtils/BillboardText.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/DebugUtils/BillboardText.cs
@@ -8,12 +8,12 @@ public class BillboardText : MonoBehaviour
     public string content = "";
     public Vector3 offset = new Vector3(0f, 2f, 0f);
     public GameObject target;
-    
+
     void Awake()
     {
         _text = GetComponentInChildren<TextMeshProUGUI>();
     }
-    
+
     void LateUpdate()
     {
         // First, if the entity we were a part of is gone, destroy ourselves
@@ -23,10 +23,10 @@ public class BillboardText : MonoBehaviour
             Destroy(this);
             return;
         }
-        
+
         // Now update our position to be the same as the target
         transform.position = target.transform.position + offset;
-        
+
         // Then rotate to face the camera
         Transform camTransform = Camera.main != null ? Camera.main.transform : null;
         if (camTransform != null)
@@ -36,7 +36,7 @@ public class BillboardText : MonoBehaviour
                                 (camTransform.forward * 100_000);
             transform.LookAt(lookPoint);
         }
-        
+
         // Finally, update the text of the billboard
         if (content != _text.text)
         {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/DebugUtils/RGGizmos.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/DebugUtils/RGGizmos.cs
@@ -291,11 +291,11 @@ namespace RegressionGames.DebugUtils
         {
 
             var gizmosContainer = GameObject.Find("RGGizmosContainer");
-            if ( gizmosContainer == null)
+            if (gizmosContainer == null)
             {
                 gizmosContainer = new GameObject("RGGizmosContainer");
             }
-            
+
             // Draw lines
             foreach (var lineParams in _linesFromEntityToPosition.Values)
             {
@@ -318,7 +318,7 @@ namespace RegressionGames.DebugUtils
             {
                 Debug.DrawLine(lineParams.Item1, lineParams.Item2, lineParams.Item3);
             }
-            
+
             // Draw spheres
             foreach (var sphereParams in _spheresAtPosition.Values)
             {
@@ -348,7 +348,7 @@ namespace RegressionGames.DebugUtils
                     Gizmos.DrawSphere(originInstance.transform.position, sphereParams.Item3);
                 }
             }
-            
+
             // Delete any billboards that are no longer being drawn
             var billboardsToRemove = _drawnBillboards.Where(b => !_billboardsToDraw.ContainsKey(b.Key));
             foreach (var billboard in billboardsToRemove)
@@ -356,7 +356,7 @@ namespace RegressionGames.DebugUtils
                 Object.Destroy(billboard.Value);
                 _drawnBillboards.Remove(billboard.Key, out _);
             }
-            
+
             // Now update or create any billboards that are being drawn
             foreach (var billboardParams in _billboardsToDraw)
             {
@@ -369,9 +369,10 @@ namespace RegressionGames.DebugUtils
                         _drawnBillboards.Remove(billboardParams.Key, out _);
                         continue;
                     }
-                    
+
                     // If the billboard game object does not exist, create it
-                    var billboard = _drawnBillboards.GetOrAdd(billboardParams.Key, (key) => {
+                    var billboard = _drawnBillboards.GetOrAdd(billboardParams.Key, (key) =>
+                    {
                         var billboardObject = Object.Instantiate(_billboardAsset, Vector3.zero, Quaternion.identity);
                         billboardObject.transform.parent = gizmosContainer.transform;
                         return billboardObject;
@@ -383,7 +384,7 @@ namespace RegressionGames.DebugUtils
                         _drawnBillboards.Remove(billboardParams.Key, out _);
                         continue;
                     };
-                        
+
                     // Then set the parameters
                     var billboardText = billboard.GetComponent<BillboardText>();
                     billboardText.content = billboardParams.Value.Item1;
@@ -396,10 +397,10 @@ namespace RegressionGames.DebugUtils
                     // In that case, just remove the billboard from the list of drawn billboards.
                     _drawnBillboards.Remove(billboardParams.Key, out _);
                 }
-                
+
             }
 
         }
-        
+
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/DictionaryExtensions.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/DictionaryExtensions.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace RegressionGames
 {
-public static class DictionaryExtensions
+    public static class DictionaryExtensions
     {
         /**
          * <summary>Retrieve the value of the named field as the specified type or null if it does not exist.
@@ -16,7 +16,7 @@ public static class DictionaryExtensions
         {
             return GetField<T>(dictionary, fieldName, default(T));
         }
-        
+
         /**
          * <summary>Retrieve the value of the named field as the specified type or null if it does not exist.
          * Note, some types in Unity can only be constructed on the Main thread.
@@ -40,7 +40,7 @@ public static class DictionaryExtensions
                         {
                             ReferenceLoopHandling = ReferenceLoopHandling.Ignore
                         }));
-                    
+
                 }
             }
             catch (Exception e)
@@ -50,7 +50,7 @@ public static class DictionaryExtensions
 
             return defaultValue;
         }
-        
+
         /**
          * <summary>Retrieve the value of the named field or null if the field does not exist.</summary>
          */

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotConfigs/RGAction.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotConfigs/RGAction.cs
@@ -16,57 +16,57 @@ namespace RegressionGames.RGBotConfigs
      *
      */
     [RequireComponent(typeof(RGEntity))]
-     public abstract class RGAction : MonoBehaviour
-     {
-         /*
-          * Stores a map of labels to delegates. Used to link RGAction attributes back to
-          * their original methods
-          */
-         private Dictionary<string, Delegate> methodMap = new Dictionary<string, Delegate>();
+    public abstract class RGAction : MonoBehaviour
+    {
+        /*
+         * Stores a map of labels to delegates. Used to link RGAction attributes back to
+         * their original methods
+         */
+        private Dictionary<string, Delegate> methodMap = new Dictionary<string, Delegate>();
 
-         /**
-            * The name of this action, which is used by the bot to request this specific action
-            */
-         public abstract string GetActionName();
+        /**
+           * The name of this action, which is used by the bot to request this specific action
+           */
+        public abstract string GetActionName();
 
-         /**
-            * The action to kick off, given some arguments. Usually this will set up some state
-            * variables inside of this component, and then most of the logic will happen in an
-            * update function.
-            */
-         public abstract void StartAction(Dictionary<string, object> input);
+        /**
+           * The action to kick off, given some arguments. Usually this will set up some state
+           * variables inside of this component, and then most of the logic will happen in an
+           * update function.
+           */
+        public abstract void StartAction(Dictionary<string, object> input);
 
-         /*
-          * Add a method delegate to our map, with the given label. Labels are unique identifiers
-          * to the delegates. Used to map RGAction attributes back to their original methods
-          */
-         protected void AddMethod(string label, Delegate method)
-         {
-             if (!methodMap.ContainsKey(label))
-             {
-                 methodMap[label] = method;
-             }
-             else
-             {
-                 RGDebug.LogError($"Method with label '{label}' already exists.");
-             }
-         }
+        /*
+         * Add a method delegate to our map, with the given label. Labels are unique identifiers
+         * to the delegates. Used to map RGAction attributes back to their original methods
+         */
+        protected void AddMethod(string label, Delegate method)
+        {
+            if (!methodMap.ContainsKey(label))
+            {
+                methodMap[label] = method;
+            }
+            else
+            {
+                RGDebug.LogError($"Method with label '{label}' already exists.");
+            }
+        }
 
-         /*
-          * Invokes the delegate with the given label, with the given args. Args are a generic
-          * list of objects, to accommodate any number of parameters of any type
-          */
-         protected void Invoke(string label, params object[] args)
-         {
-             if (methodMap.TryGetValue(label, out Delegate method))
-             {
-                 method.DynamicInvoke(args);
-             }
-             else
-             {
-                 RGDebug.LogError($"Method with label '{label}' not found.");
-             }
-         }
-     }
+        /*
+         * Invokes the delegate with the given label, with the given args. Args are a generic
+         * list of objects, to accommodate any number of parameters of any type
+         */
+        protected void Invoke(string label, params object[] args)
+        {
+            if (methodMap.TryGetValue(label, out Delegate method))
+            {
+                method.DynamicInvoke(args);
+            }
+            else
+            {
+                RGDebug.LogError($"Method with label '{label}' not found.");
+            }
+        }
+    }
 }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotConfigs/RGAction_ClickButton.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotConfigs/RGAction_ClickButton.cs
@@ -13,7 +13,7 @@ namespace RegressionGames.RGBotConfigs
     public class RGAction_ClickButton : RGAction
     {
         private ConcurrentQueue<Button> _buttonsToClick = new();
-        
+
         public void Update()
         {
             // one button click per frame update

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotConfigs/RGAction_KeyPress.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotConfigs/RGAction_KeyPress.cs
@@ -12,17 +12,17 @@ using UnityEngine.InputSystem.LowLevel;
 // ReSharper disable InconsistentNaming
 namespace RegressionGames.RGBotConfigs
 {
- 
+
     [RequireComponent(typeof(RGEntity))]
     [DisallowMultipleComponent]
-    
-    public class RGAction_KeyPress: RGAction
+
+    public class RGAction_KeyPress : RGAction
     {
         [Tooltip("Draw debug gizmos for current key inputs in editor runtime ?")]
         public bool renderDebugGizmos = false;
 
-        public Vector3 debugGizmosOffset = new Vector3(0f,-1f,2f);
-        
+        public Vector3 debugGizmosOffset = new Vector3(0f, -1f, 2f);
+
         // Allow this on any RGEntity that has an InputActionAsset
         public InputActionAsset InputAction;
 
@@ -30,7 +30,7 @@ namespace RegressionGames.RGBotConfigs
 
         private Dictionary<Key, InputControl> _inputActions = new();
         private InputControl _anyKey = null;
-        
+
         private Dictionary<Key, double> keysDown = new();
 
         private RGGizmos RgGizmos;
@@ -51,7 +51,7 @@ namespace RegressionGames.RGBotConfigs
                     {
                         if (inputActionControl is KeyControl iac)
                         {
-                            _inputActions.Add(iac.keyCode, inputActionControl);    
+                            _inputActions.Add(iac.keyCode, inputActionControl);
                         }
                         else if (inputActionControl is AnyKeyControl)
                         {
@@ -85,7 +85,7 @@ namespace RegressionGames.RGBotConfigs
                     PressKey(keyToPress.keyId, control, keyToPress.holdTime);
                 }
             }
-            
+
             // handle un-pressing any keys that have expired their time
             var keys = keysDown.Keys.ToList();
             foreach (var key in keys)
@@ -103,20 +103,20 @@ namespace RegressionGames.RGBotConfigs
                 // un-press the 'any' key
                 UnPressKey(null, _anyKey);
             }
-            
+
             int id = gameObject.transform.GetInstanceID();
             // render debug text
             if (renderDebugGizmos)
             {
                 var debugText = "";
                 var keysList = keysDown.ToList();
-                keysList.Sort((a,b) => a.Key-b.Key);
-                foreach (var (key,value) in keysList)
+                keysList.Sort((a, b) => a.Key - b.Key);
+                foreach (var (key, value) in keysList)
                 {
-                    debugText += $"{key.ToString()} : {(value-Time.unscaledTime):F2}\r\n";
+                    debugText += $"{key.ToString()} : {(value - Time.unscaledTime):F2}\r\n";
                 }
 
-                
+
                 if (string.IsNullOrEmpty(debugText))
                 {
                     RgGizmos.DestroyText(id);
@@ -130,7 +130,7 @@ namespace RegressionGames.RGBotConfigs
             {
                 RgGizmos.DestroyText(id);
             }
-            
+
             // Update Input System
             InputSystem.Update();
         }
@@ -151,10 +151,10 @@ namespace RegressionGames.RGBotConfigs
             {
                 var debugText = "";
                 var keysList = keysDown.ToList();
-                keysList.Sort((a,b) => (int)Math.Round(a.Value-b.Value, 0));
-                foreach (var (key,value) in keysList)
+                keysList.Sort((a, b) => (int)Math.Round(a.Value - b.Value, 0));
+                foreach (var (key, value) in keysList)
                 {
-                    debugText += $"{key.ToString()} : {Math.Truncate((value-Time.unscaledTime) * 100) / 100}\r\n";
+                    debugText += $"{key.ToString()} : {Math.Truncate((value - Time.unscaledTime) * 100) / 100}\r\n";
                 }
 
                 int id = gameObject.transform.GetInstanceID();
@@ -176,13 +176,13 @@ namespace RegressionGames.RGBotConfigs
         {
             // 1 == pressed state
             // 0 == un-pressed state
-            void SetUpAndQueueEvent<TValue>(InputEventPtr eventPtr, TValue state) where TValue: struct
+            void SetUpAndQueueEvent<TValue>(InputEventPtr eventPtr, TValue state) where TValue : struct
             {
                 eventPtr.time = InputState.currentTime;
                 control.WriteValueIntoEvent(state, eventPtr);
                 InputSystem.QueueEvent(eventPtr);
             }
-            
+
             using (DeltaStateEvent.From(control, out var eventPtr))
             {
                 SetUpAndQueueEvent(eventPtr, 0f);
@@ -197,13 +197,13 @@ namespace RegressionGames.RGBotConfigs
         {
             // 1 == pressed state
             // 0 == un-pressed state
-            void SetUpAndQueueEvent<TValue>(InputEventPtr eventPtr, TValue state) where TValue: struct
+            void SetUpAndQueueEvent<TValue>(InputEventPtr eventPtr, TValue state) where TValue : struct
             {
                 eventPtr.time = InputState.currentTime;
                 control.WriteValueIntoEvent(state, eventPtr);
                 InputSystem.QueueEvent(eventPtr);
             }
-            
+
             using (DeltaStateEvent.From(control, out var eventPtr))
             {
                 var hasKeyDown = keysDown.ContainsKey(key);
@@ -214,14 +214,14 @@ namespace RegressionGames.RGBotConfigs
                     // make sure new value is after the existing value
                     if (timeToUnPress > keysDown[key])
                     {
-                        keysDown[key] = timeToUnPress;        
+                        keysDown[key] = timeToUnPress;
                     }
                 }
                 else
                 {
                     keysDown[key] = timeToUnPress;
                 }
-                
+
                 if (!hasKeyDown)
                 {
                     SetUpAndQueueEvent(eventPtr, 1f);
@@ -277,7 +277,7 @@ namespace RegressionGames.RGBotConfigs
             }
         }
     }
-    
+
     internal class RG_KeyPress_Data
     {
         public readonly Key keyId;
@@ -298,7 +298,7 @@ namespace RegressionGames.RGBotConfigs
         public RGActionRequest_KeyPress(Key keyId, double holdTime = -1f)
         {
             action = "KeyPress";
-            Input = new() { { "keyId", keyId }, {"holdTime", holdTime} };
+            Input = new() { { "keyId", keyId }, { "holdTime", holdTime } };
         }
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotConfigs/RGAgent.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotConfigs/RGAgent.cs
@@ -40,7 +40,7 @@ namespace RegressionGames.RGBotConfigs
 
         public RGAction GetActionHandler(string actionName)
         {
-            if(actionMap.TryGetValue(actionName, out RGAction action))
+            if (actionMap.TryGetValue(actionName, out RGAction action))
             {
                 return action;
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotConfigs/RGEntity.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotConfigs/RGEntity.cs
@@ -11,30 +11,30 @@ namespace RegressionGames.RGBotConfigs
     {
         [Tooltip("A type name for associating like objects in the state.  If this is not specified, the system will use the name of the GameObject up to the first '(' as the objectType.  This default attempts to group similar objects into the same objectType.")]
         public string objectType;
-        
+
         [Tooltip("Does this object represent a human/bot player ?")]
         public bool isPlayer;
 
         // this is used in our toolkit to understand which things would need dynamic models
         [Tooltip("Is this object spawned during runtime, or a fixed object in the scene?")]
         public bool isRuntimeObject = false;
-        
+
         [Tooltip("This option allows you to quickly include most public or serializable properties from all Colliders and MonoBehaviours attached to this GameObject." +
                  "\r\n\r\nWARNING:\r\nThis feature can negatively impact game performance and is best used during early development to quickly prototype your bots before optimizing later using [RGState] attributes to generate custom RGState classes." +
                  "\r\n\r\nSee https://docs.regression.gg/ for more information on optimizing state size and performance." +
                  "\r\r\r\n\r\nNOTE:\r\nThis feature utilizes reflection and may not work properly in environments where AOT is in use." +
                  "\r\n\r\nSee https://docs.unity3d.com/Manual/ScriptingRestrictions.html for more information on AOT and environment scripting restrictions")]
         public bool includeStateForAllBehaviours = false;
-        
+
         // maps action names to RGAction components
         private Dictionary<string, RGAction> actionMap = new Dictionary<string, RGAction>();
-            
+
         // The client Id that owns this entity
         // Used as a performance optimization for mapping the ClientId into the state payloads
         public long? ClientId = null;
 
         internal UnityEngine.UI.Button Button = null;
-        
+
         /**
          * Updates the registry with a game object that has RGAction scripts attached to it
          */
@@ -57,7 +57,7 @@ namespace RegressionGames.RGBotConfigs
             else
             {
                 var overlayMenu = this.GetComponent<RGOverlayMenu>();
-                
+
                 var actions = this.GetComponents<RGAction>();
                 foreach (var action in actions)
                 {
@@ -85,7 +85,7 @@ namespace RegressionGames.RGBotConfigs
 
         public RGAction GetActionHandler(string actionName)
         {
-            if(actionMap.TryGetValue(actionName, out RGAction action))
+            if (actionMap.TryGetValue(actionName, out RGAction action))
             {
                 return action;
             }
@@ -98,11 +98,11 @@ namespace RegressionGames.RGBotConfigs
          */
         public (HashSet<string>, HashSet<string>) LookupStatesAndActions()
         {
-            (HashSet<string>, HashSet<string>) result = new ();
+            (HashSet<string>, HashSet<string>) result = new();
 
             // don't use the class level one, because it is only populated on start
             var button = gameObject.GetComponent<UnityEngine.UI.Button>();
-            
+
             result.Item1 = new HashSet<string>();
             result.Item2 = new HashSet<string>();
             // lookup states
@@ -122,21 +122,21 @@ namespace RegressionGames.RGBotConfigs
                     result.Item1.Add(stateComponent.GetType().FullName);
                 }
             }
-            
+
             // lookup actions
             var actionComponents = gameObject.GetComponents<RGAction>();
             foreach (var actionComponent in actionComponents)
             {
                 result.Item2.Add(actionComponent.GetType().FullName);
             }
-            
+
             // if button.. make sure it has click button action
             if (button != null)
             {
                 var clickButtonAction = typeof(RGAction_ClickButton).FullName;
                 result.Item2.Add(clickButtonAction);
             }
-            
+
             return result;
         }
     }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotConfigs/RGState.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotConfigs/RGState.cs
@@ -20,7 +20,7 @@ namespace RegressionGames.RGBotConfigs
         // ReSharper disable once InconsistentNaming
         // we require each state to have an 'RGEntity' component
         protected RGEntity rgEntity => GetComponent<RGEntity>();
-        
+
         /**
          * <summary>A function that is overriden to provide the custom state of this specific GameObject.
          * For example, you may want to retrieve and set the health of a player on the returned
@@ -48,7 +48,7 @@ namespace RegressionGames.RGBotConfigs
 
             return state;
         }
-        
+
         protected virtual Type GetTypeForStateEntity()
         {
             return typeof(RGStateEntity<RGState>);
@@ -69,15 +69,15 @@ namespace RegressionGames.RGBotConfigs
             }
             return (IRGStateEntity)Activator.CreateInstance(type);
         }
-        
-        
+
+
         // Used to fill in the core state for any RGEntity that does NOT have an
         // RGState implementation on its game object
         public static IRGStateEntity GenerateCoreStateForRGEntity(RGEntity rgEntity)
         {
             IRGStateEntity state;
 
-            
+
             // if button.. include whether it is interactable
             var button = rgEntity.Button;
             if (button != null)
@@ -91,7 +91,7 @@ namespace RegressionGames.RGBotConfigs
                 state = new RGStateEntity<RGState>();
             }
             var theTransform = rgEntity.transform;
-            
+
             state["id"] = theTransform.GetInstanceID();
             // default to the gameObject name without uniqueness numbers
             var otName = rgEntity.objectType.Trim();
@@ -119,7 +119,7 @@ namespace RegressionGames.RGBotConfigs
             }
             return state;
         }
-        
+
         private static void PopulateEverythingStateForEntity(IRGStateEntity state, RGEntity entity)
         {
             var obsoleteAttributeType = typeof(ObsoleteAttribute);

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotConfigs/RGStateProviders/RGStatePlatformer2DPlayerStatsProvider.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotConfigs/RGStateProviders/RGStatePlatformer2DPlayerStatsProvider.cs
@@ -11,22 +11,22 @@ namespace RGBotConfigs.RGStateProviders
          * <summary> Get the max horizontal velocity of the player </summary>
          */
         public float MaxVelocity();
-        
+
         /**
          * <summary> Get the current height that the player can jump </summary>
          */
         public float JumpHeight();
-        
+
         /**
          * <summary> Get the max height that the player can jump</summary>
          */
         public float MaxJumpHeight();
-        
+
         /**
          * <summary> Get the current max safe fall height for the player.  From this height the player will not take damage.&lt;0 means they can fall any height without damage </summary>
          */
         public float SafeFallHeight();
-        
+
         /**
          * <summary> Get the current max non fatal fall height for the player.  From this height the player will take damage, but will not die from the fall. &lt;0 means they can fall any height without damage </summary>
          */

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotConfigs/RGStateProviders/RGState_Platformer2DLevel.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotConfigs/RGStateProviders/RGState_Platformer2DLevel.cs
@@ -10,7 +10,7 @@ namespace RegressionGames.RGBotConfigs.RGStateProviders
     public class RGPlatformer2DPosition
     {
         public Vector2 position;
-        
+
         // number of grid tiles tall this position is (computed up to the configured max on RGState_Platformer2DLevel)
         public int tilesHeight;
 
@@ -30,17 +30,17 @@ namespace RegressionGames.RGBotConfigs.RGStateProviders
         public Vector3 tileCellSize => (Vector3)this.GetValueOrDefault("tileCellSize", Vector3.one);
         public RGPlatformer2DPosition[] platformPositions => (RGPlatformer2DPosition[])this.GetValueOrDefault("platformPositions", Array.Empty<RGPlatformer2DPosition>());
     }
-    
+
     /**
      * Provides state information about the tile grid in the current visible screen space.
      */
     [Serializable]
-    public class RGState_Platformer2DLevel: RGState
+    public class RGState_Platformer2DLevel : RGState
     {
         [Tooltip("How many tile spaces above a platform to consider when determining the height available on top of a platform.  This should match the height of the largest character model navigating the scene in tile units.")]
         [Min(1)]
         public int tileSpaceAbove = 2;
-        
+
         [NonSerialized]
         [Tooltip("Draw debug gizmos for platform locations in editor runtime ?")]
         public bool renderDebugGizmos = true;
@@ -63,7 +63,7 @@ namespace RegressionGames.RGBotConfigs.RGStateProviders
             var mainCamera = Camera.main;
 
             var cellBounds = tileMap.cellBounds;
-            
+
             if (mainCamera != null)
             {
                 var screenHeight = mainCamera.pixelHeight;
@@ -76,8 +76,8 @@ namespace RegressionGames.RGBotConfigs.RGStateProviders
                 tileBottomLeft.z = cellBounds.zMin;
                 var tileTopRight = tileMap.WorldToCell(topRight);
                 tileTopRight.z = cellBounds.zMax;
-                
-                
+
+
                 cellBounds = new BoundsInt(tileBottomLeft, tileTopRight - tileBottomLeft);
             }
 
@@ -110,7 +110,7 @@ namespace RegressionGames.RGBotConfigs.RGStateProviders
                                 finalSpotAbove = cellPlace;
                                 heightAvailable = 1;
                             }
-                            
+
                             // check up to the tileSpaceAbove
                             for (int i = 2; i <= tileSpaceAbove; i++)
                             {
@@ -146,7 +146,7 @@ namespace RegressionGames.RGBotConfigs.RGStateProviders
                     }
                 }
             }
-            
+
             _lastPositions = safePositions;
             _lastCellSize = tileMap.cellSize;
 
@@ -162,7 +162,7 @@ namespace RegressionGames.RGBotConfigs.RGStateProviders
             foreach (var platformPosition in platformPositions)
             {
                 Gizmos.DrawWireSphere(new Vector3(platformPosition.position.x + cellSize.x / 2, platformPosition.position.y + cellSize.y / 2, 0),
-                    cellSize.x/2);
+                    cellSize.x / 2);
             }
         }
 
@@ -171,7 +171,7 @@ namespace RegressionGames.RGBotConfigs.RGStateProviders
             return typeof(RGStateEntity_Platformer2DLevel);
         }
     }
-    
 
-    
+
+
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotConfigs/RGStateProviders/RGState_Platformer2DPlayer.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotConfigs/RGStateProviders/RGState_Platformer2DPlayer.cs
@@ -18,7 +18,7 @@ namespace RegressionGames.RGBotConfigs.RGStateProviders
         public float safeFallHeight => (float)this.GetValueOrDefault("safeFallHeight", -1f);
         public float nonFatalFallHeight => (float)this.GetValueOrDefault("nonFatalFallHeight", -1f);
     }
-    
+
     [Serializable]
     public class RGState_Platformer2DPlayer : RGState
     {
@@ -33,20 +33,20 @@ namespace RegressionGames.RGBotConfigs.RGStateProviders
         [Tooltip(
             "The max height that the player can jump.  (Updated automatically when using a RGStatePlatformer2DPlayerStatsProvider)")]
         public float maxJumpHeight;
-        
+
         [Tooltip("The current horizontal velocity of the player.  (Updated automatically when using a RGStatePlatformer2DPlayerStatsProvider)")]
         public float velocity;
-        
+
         [Tooltip("The current max horizontal velocity of the player.  (Updated automatically when using a RGStatePlatformer2DPlayerStatsProvider)")]
         public float maxVelocity;
-        
+
         [Tooltip("The current max safe fall height of the player.  From this height the player will take zero damage. <0 means infinite. >=0 is treated as the actual value  (Updated automatically when using a RGStatePlatformer2DPlayerStatsProvider)")]
         public float safeFallHeight = -1f;
 
         [Tooltip(
             "The current max non fatal fall height of the player.  From this height the player may take damage, but will not die from the fall. <0 means infinite. >=0 is treated as the actual value  (Updated automatically when using a RGStatePlatformer2DPlayerStatsProvider)")]
         public float nonFatalFallHeight = -1f;
-        
+
         private Vector2? _truePosition = null;
 
         [NonSerialized]
@@ -72,13 +72,13 @@ namespace RegressionGames.RGBotConfigs.RGStateProviders
             return new()
             {
                 // override the meaning of position to be centered at player collider feet
-                {"position", (Vector3)(Vector2)_truePosition},
-                {"jumpHeight", jumpHeight},
-                {"maxJumpHeight", maxJumpHeight},
-                {"velocity", velocity},
-                {"maxVelocity", maxVelocity},
-                {"safeFallHeight", safeFallHeight},
-                {"nonFatalFallHeight", nonFatalFallHeight}
+                { "position", (Vector3)(Vector2)_truePosition },
+                { "jumpHeight", jumpHeight },
+                { "maxJumpHeight", maxJumpHeight },
+                { "velocity", velocity },
+                { "maxVelocity", maxVelocity },
+                { "safeFallHeight", safeFallHeight },
+                { "nonFatalFallHeight", nonFatalFallHeight }
             };
         }
 
@@ -94,13 +94,13 @@ namespace RegressionGames.RGBotConfigs.RGStateProviders
             var theCollider = gameObject.GetComponent<BoxCollider2D>();
             var colliderOffset = theCollider.offset;
             var colliderSize = theCollider.size;
-            
+
             // bottom of the feet centered horizontally
             return new Vector2(
-                thePosition.x - colliderOffset.x - colliderSize.x/2,
+                thePosition.x - colliderOffset.x - colliderSize.x / 2,
                 thePosition.y - colliderOffset.y - colliderSize.y
             );
-            
+
         }
 
         private void OnDrawGizmos()
@@ -111,7 +111,7 @@ namespace RegressionGames.RGBotConfigs.RGStateProviders
                 Gizmos.DrawWireSphere((Vector2)_truePosition, 0.125f);
             }
         }
-        
+
     }
-    
+
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/RG.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/RG.cs
@@ -32,7 +32,7 @@ namespace RegressionGames.RGBotLocalRuntime
          * <summary>{string} The current game scene name.</summary>
          */
         public string SceneName => _tickInfo.sceneName;
-        
+
         /**
          * <summary>{long} The current tick since the start of the first bot that was run this session.</summary>
          */
@@ -271,7 +271,8 @@ namespace RegressionGames.RGBotLocalRuntime
             /**
              * <returns>{double} The square distance between two positions</returns>
              */
-            public static double DistanceSq (Vector3 position1, Vector3 position2) {
+            public static double DistanceSq(Vector3 position1, Vector3 position2)
+            {
                 return Math.Pow(position2.x - position1.x, 2) + Math.Pow(position2.y - position1.y, 2) + Math.Pow(position2.z - position1.z, 2);
             }
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/RGBotAsset.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/RGBotAsset.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace RegressionGames.RGBotLocalRuntime
 {
     //Wrapper object for saving RGBot as an asset
-    public class RGBotAsset: ScriptableObject
+    public class RGBotAsset : ScriptableObject
     {
         /// <summary>
         /// Server-side bot metadata retrieved from RegressionGames.

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/RGBotAssetsManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/RGBotAssetsManager.cs
@@ -54,7 +54,7 @@ namespace RegressionGames.RGBotLocalRuntime
 
 #if UNITY_EDITOR
             // Load up the listing of available local bots
-            string[] botGuids = AssetDatabase.FindAssets($"t:{typeof(RGBotAsset).FullName}", new string[] {"Assets"});
+            string[] botGuids = AssetDatabase.FindAssets($"t:{typeof(RGBotAsset).FullName}", new string[] { "Assets" });
             foreach (var botGuid in botGuids)
             {
                 var botAssetPath = AssetDatabase.GUIDToAssetPath(botGuid);

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/RGBotLifecycle.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/RGBotLifecycle.cs
@@ -3,12 +3,12 @@ namespace RegressionGames.RGBotLocalRuntime
     public class RGBotLifecycle
     {
         private string _type;
-        
+
         private RGBotLifecycle(string type)
         {
             this._type = type;
         }
-        
+
         public static readonly RGBotLifecycle MANAGED = new RGBotLifecycle("MANAGED");
         public static readonly RGBotLifecycle PERSISTENT = new RGBotLifecycle("PERSISTENT");
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/RGBotRunner.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/RGBotRunner.cs
@@ -130,7 +130,7 @@ namespace RegressionGames.RGBotLocalRuntime
                         // Run User Code
                         try
                         {
-                            using(UserBotTickMarker.Auto())
+                            using (UserBotTickMarker.Auto())
                             {
                                 _userBotCode.ProcessTick(_rgObject);
                             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/RGBotRuntimeManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/RGBotRuntimeManager.cs
@@ -11,7 +11,7 @@ using Random = System.Random;
 namespace RegressionGames.RGBotLocalRuntime
 {
     [HelpURL("https://docs.regression.gg/studios/unity/unity-sdk/overview")]
-    public class RGBotRuntimeManager: MonoBehaviour
+    public class RGBotRuntimeManager : MonoBehaviour
     {
         private static RGBotRuntimeManager _this = null;
 
@@ -25,7 +25,7 @@ namespace RegressionGames.RGBotLocalRuntime
         public void Awake()
         {
             // only allow 1 of these to be alive
-            if( _this != null && _this.gameObject != this.gameObject)
+            if (_this != null && _this.gameObject != this.gameObject)
             {
                 Destroy(this.gameObject);
                 return;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/RGUserBot.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/RGUserBot.cs
@@ -36,7 +36,7 @@ namespace RegressionGames.RGBotLocalRuntime
 
         protected abstract bool GetIsSpawnable();
         protected abstract RGBotLifecycle GetBotLifecycle();
-        
+
         /**
          * <summary>Used to configure the user's bot before starting. ALWAYS call base.ConfigureBot(rgObject) to help setup key information about your bot.</summary>
          * <param name="rgObject">{RG} Container object with access to character config, clientId, and state information</param>
@@ -48,9 +48,9 @@ namespace RegressionGames.RGBotLocalRuntime
          * <param name="rgObject">{RG} Container object with access to character config, clientId, and state information</param>
          */
         public abstract void ProcessTick(RG rgObject);
-        
+
         // Debug functions
-        
+
         public void OnDrawGizmos()
         {
             _rgGizmos.OnDrawGizmos();

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/SampleBot/RGSampleBot.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/SampleBot/RGSampleBot.cs
@@ -34,7 +34,7 @@ namespace RegressionGames.RGBotLocalRuntime.SampleBot
             var myPlayers = rgObject.GetMyPlayers();
             if (myPlayers.Count == 0) return;
             var thisEntity = myPlayers[0];
-            
+
             //Temporary test code
             try
             {
@@ -42,7 +42,7 @@ namespace RegressionGames.RGBotLocalRuntime.SampleBot
                 if (entities.Count > 0)
                 {
                     var target = entities[new Random().Next(entities.Count)];
-                    
+
                     RGGizmos.CreateLine(thisEntity.id, target.position, Color.red, "TargetEnemy");
                     RGGizmos.CreateSphere(target.id, Color.blue, 0.7f, false, "TargetEnemy");
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotSpawnManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotSpawnManager.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace RegressionGames
 {
-    
+
     /**
      * <summary>
      * The RGBotSpawnManager is the central configuration point for how bots spawn into your Unity Scene.
@@ -24,23 +24,23 @@ namespace RegressionGames
          * Internal reference for this object, for use in singleton management.
          */
         private static RGBotSpawnManager _this = null;
-        
+
         /**
          * A mapping from client IDs (i.e. the IDs used to identify bots connected from the Regression Games
          * backend) to the GameObjects in the scene for that bot.
          */
-        public readonly ConcurrentDictionary<long, GameObject> BotMap = new ();
-        
+        public readonly ConcurrentDictionary<long, GameObject> BotMap = new();
+
         /**
          * A set of information about bots to spawn, which are eventually popped off the queue.
          */
-        private readonly ConcurrentQueue<BotInformation> _botsToSpawn = new ();
-        
+        private readonly ConcurrentQueue<BotInformation> _botsToSpawn = new();
+
         /**
          * Tracks whether an initial set of bots have been spawned.
          */
         private bool _initialSpawnDone = false;
-        
+
         /**
          * <summary>
          * Defines how a bot if spawned into a scene. More specifically, <paramref name="botInformation"></paramref>
@@ -81,7 +81,7 @@ namespace RegressionGames
         protected virtual void Awake()
         {
             // only allow 1 of these to be alive
-            if( _this != null && this.gameObject != _this.gameObject)
+            if (_this != null && this.gameObject != _this.gameObject)
             {
                 Destroy(this.gameObject);
                 return;
@@ -155,7 +155,7 @@ namespace RegressionGames
                 return;
             }
             BotInformation botInformation;
-            while(_botsToSpawn.TryDequeue(out botInformation))
+            while (_botsToSpawn.TryDequeue(out botInformation))
             {
                 RGDebug.LogInfo($"Spawning bot: {botInformation.botName} for client Id: {botInformation.clientId}");
                 // make sure this client is still connected
@@ -184,7 +184,7 @@ namespace RegressionGames
                 if (bot == null) return;
                 BotMap[botInformation.clientId] = bot;
             }
-            
+
             RGBotServerListener rgBotServerListener = RGBotServerListener.GetInstance();
             if (rgBotServerListener != null)
             {
@@ -288,10 +288,10 @@ namespace RegressionGames
                 {
                     RGDebug.LogDebug($"[SeatBot] Sending socket handshake response characterConfig: {botToSpawn.characterConfig} - to client id: {botToSpawn.clientId}");
                     //send the client a handshake response so they can start processing
-                    rgBotServerListener.GetClientConnection(botToSpawn.clientId).SendHandshakeResponse( new RGServerHandshake( rgBotServerListener.UnitySideToken, botToSpawn.characterConfig, null));
+                    rgBotServerListener.GetClientConnection(botToSpawn.clientId).SendHandshakeResponse(new RGServerHandshake(rgBotServerListener.UnitySideToken, botToSpawn.characterConfig, null));
                 }
-                
-                
+
+
                 // If the bot already exists, let the client know about the new ID. Otherwise, queue to respawn
                 GameObject existingBot = GetBot(botToSpawn.clientId);
                 if (existingBot != null)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGCertificateHolder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGCertificateHolder.cs
@@ -11,7 +11,7 @@ namespace RegressionGames
         private X509Certificate2 RG_CERT;
 
         [CanBeNull] private static RGCertOnlyPublicKey _this = null;
-        
+
         public static RGCertOnlyPublicKey GetInstance()
         {
             if (_this == null)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGDebug.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGDebug.cs
@@ -6,7 +6,7 @@ namespace RegressionGames
 {
     public static class RGDebug
     {
-        public enum RGLogLevel {Verbose, Debug, Info, Warning, Error}
+        public enum RGLogLevel { Verbose, Debug, Info, Warning, Error }
 
         /**
          * Logging of 'Verbose' logs. Only visible if Log Level is set to 'Verbose'
@@ -25,7 +25,7 @@ namespace RegressionGames
         {
             LogToConsole(message, RGLogLevel.Debug);
         }
-        
+
         /**
          * Logging of 'Info' logs. Only visible if Log Level is set to 'Info' or
          * lower in the Regression Project Settings.
@@ -35,7 +35,7 @@ namespace RegressionGames
         {
             LogToConsole(message, RGLogLevel.Info);
         }
-        
+
         /**
          * Logging of 'Info' logs. Only visible if Log Level is set to 'Info' or
          * lower in the Regression Project Settings
@@ -80,7 +80,7 @@ namespace RegressionGames
             }
             Debug.LogException(exception);
         }
-        
+
         public static bool IsVerboseEnabled => CheckLogLevel(RGLogLevel.Verbose);
         public static bool IsDebugEnabled => CheckLogLevel(RGLogLevel.Debug);
         public static bool IsInfoEnabled => CheckLogLevel(RGLogLevel.Info);
@@ -99,7 +99,7 @@ namespace RegressionGames
             {
                 return;
             }
-            
+
             switch (logLevel)
             {
                 case RGLogLevel.Verbose:
@@ -118,7 +118,7 @@ namespace RegressionGames
                     break;
             }
         }
-        
+
         // Determine if the log message is within the log levels in the settings
         private static bool CheckLogLevel(RGLogLevel logLevel)
         {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGEnvConfigs.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGEnvConfigs.cs
@@ -3,7 +3,7 @@ using JetBrains.Annotations;
 
 namespace RegressionGames
 {
-    
+
     /**
      * Environment variable and command line argument utilities for configuring Regression Games
      */
@@ -21,7 +21,7 @@ namespace RegressionGames
          */
         [CanBeNull]
         public static string ReadAPIKey() => ReadEnvVarOrCommandLine(RG_API_KEY);
-        
+
         /**
          * Reads the RG_HOST from either the environment variable or command
          * line arguments. This is useful for automated CI builds, where the
@@ -30,7 +30,7 @@ namespace RegressionGames
          */
         [CanBeNull]
         public static string ReadHost() => ReadEnvVarOrCommandLine(RG_HOST);
-        
+
         /**
          * Reads the BOT from either the environment variable or command
          * line arguments. This is useful for automated CI builds, where the

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGIconPulse.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGIconPulse.cs
@@ -12,7 +12,7 @@ namespace RegressionGames
         public float ogPulseInterval = 3f;
 
         public float pulseDuration = 1f;
-        
+
         public int maxAlpha = 120;
 
         private float lastPulse = -1f;
@@ -43,7 +43,7 @@ namespace RegressionGames
             image = GetComponent<Image>();
             ogPulseInterval = pulseInterval;
         }
-        
+
         void LateUpdate()
         {
             float time = Time.time;
@@ -57,7 +57,7 @@ namespace RegressionGames
             // -1 -> 1
             float rangeVal = (timeSinceLast / pulseDuration) * 2 - 1;
 
-            float alphaValue = ( Mathf.Abs(rangeVal) * -1 * maxAlpha + maxAlpha)/255f;
+            float alphaValue = (Mathf.Abs(rangeVal) * -1 * maxAlpha + maxAlpha) / 255f;
 
             image.color = new Color(image.color.r, image.color.g, image.color.b, alphaValue);
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlayMenu.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlayMenu.cs
@@ -13,7 +13,7 @@ namespace RegressionGames
     [HelpURL("https://docs.regression.gg/studios/unity/unity-sdk/overview")]
     public class RGOverlayMenu : MonoBehaviour
     {
-        
+
         public Image launcherIcon;
         public RGIconPulse launcherPulse;
 
@@ -28,8 +28,8 @@ namespace RegressionGames
         public GameObject botEntryPrefab;
 
         public TMP_Dropdown nextBotDropdown;
-        
-        private static List<RGBotInstance> _activeBots = new ();
+
+        private static List<RGBotInstance> _activeBots = new();
 
         private int lastCount = -1;
 
@@ -52,7 +52,7 @@ namespace RegressionGames
             rgServiceManager = GetComponent<RGServiceManager>();
             _this = this;
             DontDestroyOnLoad(_this.gameObject);
-            
+
             UpdateBots();
 
         }
@@ -90,20 +90,20 @@ namespace RegressionGames
                     DestroyImmediate(botListingRoot.transform.GetChild(0).gameObject);
                 }
 
-                for (int i =0; i< _activeBots.Count; i++)
+                for (int i = 0; i < _activeBots.Count; i++)
                 {
                     RGBotInstance botEntry = _activeBots[i];
-                    
+
                     RectTransform rt = botEntryPrefab.GetComponent<RectTransform>();
                     Vector3 position = new Vector3(0f, rt.rect.height * -i, 0f);
-                    
+
                     GameObject newEntry = Instantiate(
                         original: botEntryPrefab,
                         parent: botListingRoot.transform
                         );
 
                     newEntry.transform.localPosition = position;
-                    
+
                     ActiveRGBotUIElement uiElement = newEntry.GetComponent<ActiveRGBotUIElement>();
                     uiElement.PopulateBotEntry(botEntry);
                 }
@@ -185,7 +185,7 @@ namespace RegressionGames
                 }
             }
         }
-        
+
         public void StopBotInstance(long id)
         {
             RGBotServerListener.GetInstance()?.HandleClientTeardown(id);
@@ -198,7 +198,7 @@ namespace RegressionGames
         {
             RGBotServerListener.GetInstance()?.TeardownAllClients();
         }
-        
+
         public void UpdateBots()
         {
             ConcurrentBag<RGBot> botBag = new ConcurrentBag<RGBot>();
@@ -210,13 +210,13 @@ namespace RegressionGames
             {
                 instances.Add(localBotInstance);
             }
-            
+
             var localBotDefinitions = RGBotAssetsManager.GetInstance()?.GetAvailableBots();
             foreach (var localBotDefinition in localBotDefinitions)
             {
-                botBag.Add(localBotDefinition);    
+                botBag.Add(localBotDefinition);
             }
-            
+
             // update the latest bot list from RGService
             _ = rgServiceManager.GetBotsForCurrentUser(
                 bots =>
@@ -270,7 +270,7 @@ namespace RegressionGames
                     else
                     {
                         ProcessBotUpdateList(instances);
-                        ProcessDropdownOptions(botBag); 
+                        ProcessDropdownOptions(botBag);
                     }
                 },
                 () =>
@@ -278,7 +278,7 @@ namespace RegressionGames
                     ProcessBotUpdateList(instances);
                     ProcessDropdownOptions(botBag);
                 });
-            
+
         }
 
         private void ProcessDropdownOptions(ConcurrentBag<RGBot> botBag)
@@ -286,13 +286,13 @@ namespace RegressionGames
             List<string> botStrings = botBag.Distinct().Select(bot => bot.UIString).ToList();
             // sort alpha
             botStrings.Sort();
-            
-            List<TMP_Dropdown.OptionData> dropOptions = new ();
+
+            List<TMP_Dropdown.OptionData> dropOptions = new();
             foreach (var optionString in botStrings)
             {
                 dropOptions.Add(new TMP_Dropdown.OptionData(optionString));
             }
-            nextBotDropdown.options = dropOptions; 
+            nextBotDropdown.options = dropOptions;
         }
 
         private void ProcessBotUpdateList(ConcurrentBag<RGBotInstance> instances)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGRuntimeProperties.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGRuntimeProperties.cs
@@ -5,7 +5,7 @@ namespace RegressionGames
     public class RGRuntimeProperties
     {
 
-        
+
         public const string NEXT_BOT_INSTANCE_ID = "RGNextBotInstanceId";
 
         public static long GetNextBotInstanceId()
@@ -14,7 +14,7 @@ namespace RegressionGames
             var nextId = PlayerPrefs.GetInt(NEXT_BOT_INSTANCE_ID, 0) + 1;
 
             PlayerPrefs.SetInt(NEXT_BOT_INSTANCE_ID, nextId);
-            
+
             // this is so that 'to a human' these ids look sequential
             if (systemId < 0)
             {
@@ -27,5 +27,5 @@ namespace RegressionGames
             return systemId;
         }
     }
-    
+
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGServiceManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGServiceManager.cs
@@ -25,7 +25,7 @@ namespace RegressionGames
         // 1 hour
         public static readonly int WEB_REQUEST_FILE_TIMEOUT_SECONDS = 60 * 60;
 
-        private static Mutex authLock = new Mutex(false,"AuthLock");
+        private static Mutex authLock = new Mutex(false, "AuthLock");
 
         private string rgAuthToken;
 
@@ -104,7 +104,7 @@ namespace RegressionGames
             // don't all first off an auth request in parallel
             if (!IsAuthed())
             {
-                while (!authLock.WaitOne(1_000));
+                while (!authLock.WaitOne(1_000)) ;
 
                 try
                 {
@@ -643,12 +643,12 @@ namespace RegressionGames
         /**
          * MUST be called on main thread only... This is because `new UnityWebRequest` makes a .Create call internally
          */
-        private async Task SendWebRequest(string uri, string method, string payload, Func<string, Task> onSuccess, Func<string, Task> onFailure, bool isAuth=false, string contentType="application/json")
+        private async Task SendWebRequest(string uri, string method, string payload, Func<string, Task> onSuccess, Func<string, Task> onFailure, bool isAuth = false, string contentType = "application/json")
         {
             var messageId = ++correlationId;
             // don't log the details of auth requests :)
             string payloadToLog = isAuth ? "{***:***, ...}" : payload;
-            RGDebug.LogVerbose($"<{messageId}> API request - {method}  {uri}{(!string.IsNullOrEmpty(payload)?$"\r\n{payloadToLog}":"")}");
+            RGDebug.LogVerbose($"<{messageId}> API request - {method}  {uri}{(!string.IsNullOrEmpty(payload) ? $"\r\n{payloadToLog}" : "")}");
             UnityWebRequest request = new UnityWebRequest(uri, method);
 
             try
@@ -844,7 +844,7 @@ namespace RegressionGames
         private readonly UnityWebRequestAsyncOperation _asyncOperation;
 
 
-        public UnityWebRequestAwaiter( UnityWebRequestAsyncOperation asyncOperation ) => _asyncOperation = asyncOperation;
+        public UnityWebRequestAwaiter(UnityWebRequestAsyncOperation asyncOperation) => _asyncOperation = asyncOperation;
 
         public UnityWebRequestAwaiter GetAwaiter()
         {
@@ -853,7 +853,7 @@ namespace RegressionGames
 
         public UnityWebRequest GetResult() => _asyncOperation.webRequest;
 
-        public void OnCompleted( Action continuation ) => _asyncOperation.completed += _ => continuation();
+        public void OnCompleted(Action continuation) => _asyncOperation.completed += _ => continuation();
 
         public bool IsCompleted => _asyncOperation.isDone;
     }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGSettings.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGSettings.cs
@@ -4,9 +4,9 @@ using UnityEngine;
 
 namespace RegressionGames
 {
-    public enum DebugLogLevel {Off, Verbose, Debug, Info, Warning, Error}
-    
-    public class RGSettings: ScriptableObject
+    public enum DebugLogLevel { Off, Verbose, Debug, Info, Warning, Error }
+
+    public class RGSettings : ScriptableObject
     {
         private const string SETTINGS_PATH = "Assets/RGSettings.asset";
 
@@ -25,7 +25,7 @@ namespace RegressionGames
          */
         private static RGSettings _settings = null;
         private static bool dirty = true;
-        
+
         public static RGSettings GetOrCreateSettings()
         {
             if (_settings == null || dirty)
@@ -59,7 +59,7 @@ namespace RegressionGames
                 AssetDatabase.SaveAssets();
 #endif
             }
-            
+
             // backwards compat for migrating RG devs before we had a single host address field
             if (string.IsNullOrEmpty(_settings.rgHostAddress))
             {
@@ -122,7 +122,7 @@ namespace RegressionGames
             }
             return systemId;
         }
-        
+
         public bool GetUseSystemSettings()
         {
             return useSystemSettings;
@@ -153,5 +153,5 @@ namespace RegressionGames
             return rgHostAddress;
         }
     }
-    
+
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGSettingsDynamicEnabler.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGSettingsDynamicEnabler.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 namespace RegressionGames
 {
-    public class RGSettingsDynamicEnabler: MonoBehaviour
+    public class RGSettingsDynamicEnabler : MonoBehaviour
     {
         public bool disableIfUsingGlobalSettings = false;
         public void OnEnable()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGUserSettings.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGUserSettings.cs
@@ -49,14 +49,14 @@ namespace RegressionGames
 
             return _userSettings;
         }
-        
+
 #if UNITY_EDITOR
         public static SerializedObject GetSerializedUserSettings()
         {
             return new SerializedObject(GetOrCreateUserSettings());
         }
 #endif
-        
+
         public static void OptionsUpdated()
         {
             //mark dirty
@@ -75,7 +75,7 @@ namespace RegressionGames
                 // if not called on main thread this will exception
             }
         }
-        
+
         public string GetEmail()
         {
             return email;
@@ -85,7 +85,7 @@ namespace RegressionGames
         {
             email = newEmail;
         }
-        
+
         public string GetPassword()
         {
             return password;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGUtils.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGUtils.cs
@@ -50,7 +50,7 @@ namespace RegressionGames
             foreach (var entry in Directory.GetFileSystemEntries(path))
             {
                 var entryDate = GetLatestWriteDate(entry);
-                if(entryDate > currentDate)
+                if (entryDate > currentDate)
                 {
                     currentDate = entryDate.Value;
                 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateActionTypes/IRGStateEntity.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateActionTypes/IRGStateEntity.cs
@@ -12,7 +12,7 @@ namespace RegressionGames.StateActionTypes
         public Vector3 position => Vector3.zero;
         public Quaternion rotation => Quaternion.identity;
         public long? clientId => null;
-        
+
         /**
          * <summary>Retrieve the value of the named field as the specified type or default value
          * Note, some types in Unity can only be constructed on the Main thread.
@@ -34,7 +34,7 @@ namespace RegressionGames.StateActionTypes
         {
             return DictionaryExtensions.GetField<T>(this, fieldName);
         }
-        
+
         /**
          * <summary>Retrieve the value of the named field or null if the field does not exist.</summary>
          */

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateActionTypes/RGActionRequest.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateActionTypes/RGActionRequest.cs
@@ -13,7 +13,7 @@ namespace RegressionGames.StateActionTypes
 
         public RGActionRequest()
         {
-            
+
         }
 
         public RGActionRequest(string action, Dictionary<string, object> input)
@@ -25,7 +25,7 @@ namespace RegressionGames.StateActionTypes
         public override string ToString()
         {
             var inputString = Input?.Select(kv => kv.Key + ": " + kv.Value).ToArray();
-            return $"{{action: {action}, input: {{{string.Join(", ", inputString ?? new string [] {})} }} }}";
+            return $"{{action: {action}, input: {{{string.Join(", ", inputString ?? new string[] { })} }} }}";
         }
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateActionTypes/RGStateActionReplayData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateActionTypes/RGStateActionReplayData.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace RegressionGames.StateActionTypes
 {
-    
+
     [Serializable]
     public class RGStateActionReplayData
     {
@@ -19,13 +19,13 @@ namespace RegressionGames.StateActionTypes
         [CanBeNull] public long? sceneId;
 
         public RGTickInfoData tickInfo;
-        
+
         public string ToSerialized()
         {
             return JsonConvert.SerializeObject(this, Formatting.None, new JsonSerializerSettings
-                    {
-                        ReferenceLoopHandling = ReferenceLoopHandling.Ignore
-                    });
+            {
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+            });
         }
 
         /**

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateActionTypes/RGStateEntity.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateActionTypes/RGStateEntity.cs
@@ -27,7 +27,7 @@ namespace RegressionGames.StateActionTypes
         public Quaternion rotation => (Quaternion)(this.GetValueOrDefault("rotation") ?? Quaternion.identity);
 
         public long? clientId => (long?)this.GetValueOrDefault("clientId", null);
-        
+
         // This is mostly implemented to make visibility in the debugger much easier... especially when finding the right object in the overall state
         public override string ToString()
         {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateActionTypes/RGStateEntity_Button.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateActionTypes/RGStateEntity_Button.cs
@@ -10,7 +10,7 @@ namespace RegressionGames.StateActionTypes
     {
         // is this button currently interactable
         public bool interactable => (bool)this.GetValueOrDefault("interactable", false);
-        
+
         // This is mostly implemented to make visibility in the debugger much easier... especially when finding the right object in the overall state
         public override string ToString()
         {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateActionTypes/RGTickInfoData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateActionTypes/RGTickInfoData.cs
@@ -24,7 +24,7 @@ namespace RegressionGames.StateActionTypes
             this.sceneName = sceneName;
             this.gameState = gameState;
         }
-        
+
         [JsonConstructor]
         // this is strongly typed so that the json convertor uses it to populate the map correctly
         public RGTickInfoData(long tick, string sceneName, Dictionary<string, RGStateEntity<RGState>> gameState)
@@ -32,7 +32,7 @@ namespace RegressionGames.StateActionTypes
             this.tick = tick;
             this.sceneName = sceneName;
             this.gameState = new();
-            foreach (var (key,value) in gameState)
+            foreach (var (key, value) in gameState)
             {
                 this.gameState[key] = value;
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateActionTypes/RGValidationResult.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateActionTypes/RGValidationResult.cs
@@ -8,7 +8,7 @@ namespace RegressionGames.StateActionTypes
     [Serializable]
     public class RGValidationResult
     {
-        
+
         public string name;
         [JsonConverter(typeof(StringEnumConverter))]
         public RGValidationResultType result;
@@ -16,7 +16,7 @@ namespace RegressionGames.StateActionTypes
         public string id;
         public DateTime timestamp;
         public long tick;
-        
+
         // These are kept for backwards compatibility
         public string message;
         public bool passed;
@@ -31,7 +31,7 @@ namespace RegressionGames.StateActionTypes
             this.tick = tick;
             this.id = Guid.NewGuid().ToString();
             this.timestamp = DateTime.Now;
-            
+
             // For backwards compatibility
             this.message = name;
             this.passed = result == RGValidationResultType.PASS;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGAuthRequest.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGAuthRequest.cs
@@ -8,7 +8,7 @@ namespace RegressionGames.Types
         public string email;
         public string password;
 
-        public RGAuthRequest( string email, string password)
+        public RGAuthRequest(string email, string password)
         {
             this.email = email;
             this.password = password;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGBotInstance.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGBotInstance.cs
@@ -19,7 +19,7 @@ namespace RegressionGames.Types
 
         public override bool Equals(object obj)
         {
-            if ( obj != null && obj.GetType() == typeof(RGBotInstance))
+            if (obj != null && obj.GetType() == typeof(RGBotInstance))
             {
                 return ((RGBotInstance)obj).id == id;
             }
@@ -28,8 +28,8 @@ namespace RegressionGames.Types
 
         public override int GetHashCode()
         {
-            return (int) id;
+            return (int)id;
         }
     }
-    
+
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGBotInstanceExternalConnectionInfo.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGBotInstanceExternalConnectionInfo.cs
@@ -8,7 +8,7 @@ namespace RegressionGames.Types
         public long botInstanceId;
         public string address;
         public int port;
-        
+
         public override string ToString()
         {
             return $"{botInstanceId} - {address}:{port}";

--- a/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGBotInstanceList.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGBotInstanceList.cs
@@ -6,7 +6,7 @@ namespace RegressionGames.Types
     public class RGBotInstanceList
     {
         public RGBotInstance[] botInstances;
-        
+
         public override string ToString()
         {
             return string.Join<RGBotInstance>(",", botInstances);

--- a/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGClientConnection.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGClientConnection.cs
@@ -20,11 +20,11 @@ namespace RegressionGames.Types
 
         public virtual async void Connect()
         {
-            
+
         }
 
         public abstract bool SendTeardown();
-        
+
         public abstract bool SendTickInfo(RGTickInfoData tickInfo);
 
         public abstract bool SendHandshakeResponse(RGServerHandshake handshake);
@@ -34,7 +34,7 @@ namespace RegressionGames.Types
         public virtual void Close()
         {
         }
-        
+
     }
 
     public enum RGClientConnectionType

--- a/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGClientConnection_Local.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGClientConnection_Local.cs
@@ -8,7 +8,7 @@ namespace RegressionGames.Types
     {
 
         private RGBotRunner _runner = null;
-        
+
         public RGClientConnection_Local(long clientId, string lifecycle = "MANAGED") : base(clientId, RGClientConnectionType.LOCAL, lifecycle)
         {
         }
@@ -61,7 +61,7 @@ namespace RegressionGames.Types
         {
             return this._runner != null;
         }
-        
+
     }
-    
+
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGClientConnection_Remote.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGClientConnection_Remote.cs
@@ -20,7 +20,7 @@ namespace RegressionGames.Types
 
         private const int SOCKET_READWRITE_TIMEOUT = 5_000; // 5 seconds
 
-        private SemaphoreSlim _connecting = new (1,1);
+        private SemaphoreSlim _connecting = new(1, 1);
         [CanBeNull] private RGBotInstanceExternalConnectionInfo _connectionInfo;
 
         public RGClientConnection_Remote(long clientId, string lifecycle = "MANAGED",
@@ -368,7 +368,7 @@ namespace RegressionGames.Types
                             $"Client Id: {ClientId} socket error or closed during read, need to re-establish connection for bot - {readTask.Exception}");
                     }
                     client.Close();
-                        connectionStates.Remove(client);
+                    connectionStates.Remove(client);
                 }
             });
         }
@@ -383,7 +383,7 @@ namespace RegressionGames.Types
             var clientId = clientSocketMessage.clientId;
             var data = clientSocketMessage.data;
             // helps JObject understand/parse the string better and fixes quotes on {}s for nested objects
-            data = data?.Replace("\\\"", "\"").Replace("\"{", "{").Replace("}\"","}");
+            data = data?.Replace("\\\"", "\"").Replace("\"{", "{").Replace("}\"", "}");
 
             var jObject = data == null ? null : JObject.Parse(data);
 
@@ -456,7 +456,7 @@ namespace RegressionGames.Types
             return address1.Equals(address2);
         }
     }
-    
+
     class ClientConnectionState
     {
         public int socketMessageLength = 0;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGCreateBotInstanceRequest.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGCreateBotInstanceRequest.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace RegressionGames.Types
 {
-    
+
     [Serializable]
     public class RGCreateBotInstanceRequest
     {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGServerPlayerId.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGServerPlayerId.cs
@@ -8,7 +8,7 @@ namespace RegressionGames.Types
         // send the client their player object's Id
         public int playerId;
 
-        public RGServerPlayerId( int playerId)
+        public RGServerPlayerId(int playerId)
         {
             this.playerId = playerId;
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGValidationSummary.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/Types/RGValidationSummary.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace RegressionGames.Types
 {
-    
+
     [Serializable]
     public class RGValidationSummary
     {


### PR DESCRIPTION
This is a PR to `ashley/refmt`. That means merging this PR will add these comments to the existing #126 .

I separated these out because this PR is all automated code formatting changes, which are quite noisy. This change was entirely generated via the official ['dotnet format'](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-format) C# reformatting tool. So, it's worth a scan, but between this and the build process, we can have some faith that it's safe.

When this **and** #126 are approved separately, I'll merge both in together.

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
