### PR TITLE
[REG-1637] Patch C# SDK so that production builds in Unity are possible

### DIFF
--- a/src/gg.regression.unity.bots/Editor/Scripts/RGEditorUtils.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGEditorUtils.cs
@@ -32,7 +32,7 @@ namespace RegressionGames.Editor
         public static void CreateAllAssetFolders(string path)
         {
             path = path.TrimEnd('/');
-//TODO: REG-1424 Cannot depend on Editor only tools for bot runtimes
+            //TODO: REG-1424 Cannot depend on Editor only tools for bot runtimes
 #if UNITY_EDITOR
             if (AssetDatabase.IsValidFolder(path))
             {

--- a/src/gg.regression.unity.bots/Editor/Scripts/RGEditorUtils.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGEditorUtils.cs
@@ -1,5 +1,7 @@
 using System;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 
 namespace RegressionGames.Editor
 {
@@ -30,7 +32,8 @@ namespace RegressionGames.Editor
         public static void CreateAllAssetFolders(string path)
         {
             path = path.TrimEnd('/');
-
+//TODO: REG-1424 Cannot depend on Editor only tools for bot runtimes
+#if UNITY_EDITOR
             if (AssetDatabase.IsValidFolder(path))
             {
                 // This path already exists as a folder, so we're done.
@@ -57,6 +60,7 @@ namespace RegressionGames.Editor
             {
                 throw new InvalidOperationException("Unexpected folder name from AssetDatabase.CreateFolder");
             }
+#endif
         }
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/RGBotRuntimeManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/RGBotRuntimeManager.cs
@@ -63,7 +63,7 @@ namespace RegressionGames.RGBotLocalRuntime
                 // Find the bot entry point script
                 var entryPointPath = $"{botAssetRecord.Path}/BotEntryPoint.cs";
 
-//TODO: REG-1424 Make local bots workable in production runtimes
+                //TODO: REG-1424 Make local bots workable in production runtimes
 #if UNITY_EDITOR
                 var entryPointScript = AssetDatabase.LoadAssetAtPath<MonoScript>(entryPointPath);
                 if (entryPointScript == null)
@@ -113,7 +113,7 @@ namespace RegressionGames.RGBotLocalRuntime
 
                 return botInstance.id;
 #else
-                RGDebug.LogError($"TODO: REG-1424.  Local bots aren't supported yet in production builds.");
+                RGDebug.LogError("TODO: REG-1424. Local bots aren't supported yet in production builds.");
                 return 0;
 #endif
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/RGBotRuntimeManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGBotLocalRuntime/RGBotRuntimeManager.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using RegressionGames.Types;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using UnityEngine;
 using Random = System.Random;
 
@@ -61,6 +62,9 @@ namespace RegressionGames.RGBotLocalRuntime
             {
                 // Find the bot entry point script
                 var entryPointPath = $"{botAssetRecord.Path}/BotEntryPoint.cs";
+
+//TODO: REG-1424 Make local bots workable in production runtimes
+#if UNITY_EDITOR
                 var entryPointScript = AssetDatabase.LoadAssetAtPath<MonoScript>(entryPointPath);
                 if (entryPointScript == null)
                 {
@@ -108,6 +112,10 @@ namespace RegressionGames.RGBotLocalRuntime
                 RGOverlayMenu.GetInstance()?.UpdateBots();
 
                 return botInstance.id;
+#else
+                RGDebug.LogError($"TODO: REG-1424.  Local bots aren't supported yet in production builds.");
+                return 0;
+#endif
             }
             else
             {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -305,6 +305,7 @@ namespace RegressionGames.StateRecorder
                         framesSincePreviousTick = _frameCountSinceLastTick,
                         previousTickTime = _lastCvFrameTime,
                         fps = (int)(_frameCountSinceLastTick / (time - _lastCvFrameTime)),
+#if UNITY_EDITOR
                         engineStats = new EngineStatsData()
                         {
                             frameTime = UnityStats.frameTime,
@@ -321,6 +322,9 @@ namespace RegressionGames.StateRecorder
                             staticBatches = UnityStats.staticBatches,
                             instancedBatches = UnityStats.instancedBatches
                         }
+#else
+                        engineStats = new EngineStatsData()
+#endif
                     };
 
                     _lastCvFrameTime = time;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -163,8 +163,10 @@ namespace RegressionGames.StateRecorder
             _tokenSource?.Cancel();
             _tokenSource?.Dispose();
             _tokenSource = null;
+#if UNITY_EDITOR
             _encoder?.Dispose();
             _encoder = null;
+#endif
             KeyboardInputActionObserver.GetInstance()?.StopRecording();
             MouseInputActionObserver.GetInstance()?.StopRecording();
             if (_isRecording)
@@ -464,7 +466,9 @@ namespace RegressionGames.StateRecorder
         private BlockingCollection<((string, long), (byte[], int, int, GraphicsFormat, NativeArray<byte>, Action))>
             _frameQueue;
 
+#if UNITY_EDITOR
         private MediaEncoder _encoder;
+#endif
 
         private void ProcessFrames()
         {


### PR DESCRIPTION
Patches our C# SDK code so that customers including our SDK can still build their game for production.
REG-1488 and REG-1619 broke this

This is a stopgap PR until REG-1424 is prioritized and fixed.

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
