### PR TITLE
[REG-1684] Fix NativeArray screenshot capture crash

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -58,7 +58,7 @@ namespace RegressionGames.StateRecorder
         private long _tickNumber;
         private DateTime _startTime;
 
-        private BlockingCollection<((string, long), (byte[], int, int, GraphicsFormat, NativeArray<byte>, Action))>
+        private BlockingCollection<((string, long), (byte[], int, int, GraphicsFormat, byte[], Action))>
             _frameQueue;
 
         private readonly List<(string, Task)> _fileWriteTasks = new();
@@ -253,8 +253,8 @@ namespace RegressionGames.StateRecorder
                 _tickNumber = 0;
                 _startTime = DateTime.Now;
                 _frameQueue =
-                    new BlockingCollection<((string, long), (byte[], int, int, GraphicsFormat, NativeArray<byte>, Action))>(
-                        new ConcurrentQueue<((string, long), (byte[], int, int, GraphicsFormat, NativeArray<byte>,
+                    new BlockingCollection<((string, long), (byte[], int, int, GraphicsFormat, byte[], Action))>(
+                        new ConcurrentQueue<((string, long), (byte[], int, int, GraphicsFormat, byte[],
                             Action)
                             )>());
 
@@ -472,7 +472,7 @@ namespace RegressionGames.StateRecorder
                                     screenShot.width,
                                     screenShot.height,
                                     screenShot.graphicsFormat,
-                                    screenShot.GetRawTextureData<byte>(),
+                                    screenShot.GetRawTextureData(),
                                     () =>
                                     {
                                         // MUST happen on main thread
@@ -524,19 +524,19 @@ namespace RegressionGames.StateRecorder
         }
 
         private void ProcessFrame(string directoryPath, long frameNumber, byte[] jsonData, int width, int height,
-            GraphicsFormat graphicsFormat, NativeArray<byte> frameData)
+            GraphicsFormat graphicsFormat, byte[] frameData)
         {
             RecordJSON(directoryPath, frameNumber, jsonData);
             RecordJPG(directoryPath, frameNumber, width, height, graphicsFormat, frameData);
         }
 
         private void RecordJPG(string directoryPath, long frameNumber,int width, int height,
-            GraphicsFormat graphicsFormat, NativeArray<byte> frameData)
+            GraphicsFormat graphicsFormat, byte[] frameData)
         {
             try
             {
                 var imageOutput =
-                    ImageConversion.EncodeNativeArrayToJPG(frameData, graphicsFormat, (uint)width, (uint)height);
+                    ImageConversion.EncodeArrayToJPG(frameData, graphicsFormat, (uint)width, (uint)height);
 
                 // write out the image to file
                 var path = $"{directoryPath}/screenshots/{frameNumber}".PadLeft(9, '0') + ".jpg";


### PR DESCRIPTION
- Fixes a crash in production builds of game using our SDK where a NativeArray operation would often crash the game

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
