### PR TITLE
[REG-1686] Fix resource directory creation issue, fix sample

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGSettings.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGSettings.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using UnityEditor;
 using UnityEngine;
 
@@ -18,8 +19,9 @@ namespace RegressionGames
     {
         // We store this asset in the Resources folder so that it can be accessed from any build
         // Note that it can only be created in the editor, however.
+        private static readonly string SETTINGS_DIRECTORY = "Assets/Resources";
         private static readonly string SETTINGS_RESOURCE_NAME = "RGSettings";
-        private static readonly string SETTINGS_PATH = $"Assets/Resources/{SETTINGS_RESOURCE_NAME}.asset";
+        private static readonly string SETTINGS_PATH = $"{SETTINGS_DIRECTORY}/{SETTINGS_RESOURCE_NAME}.asset";
 
         // General settings about how the SDK should operate
         [SerializeField] private bool useSystemSettings;
@@ -64,6 +66,7 @@ namespace RegressionGames
 
                 _settings.feature_StateRecordingAndReplay = false;
 #if UNITY_EDITOR
+                Directory.CreateDirectory(SETTINGS_DIRECTORY);
                 AssetDatabase.CreateAsset(_settings, SETTINGS_PATH);
                 AssetDatabase.SaveAssets();
 #endif


### PR DESCRIPTION

Fixes an issue found during UAT: When the resources folder doesn't exist, we need to create it before making the settings asset.

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
