### PR TITLE
[REG-1626] Enable replay interaction with Coherent GameFace components

### DIFF
--- a/src/gg.regression.unity.bots/Editor/Scripts/RGSettingsUIRegistrar.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGSettingsUIRegistrar.cs
@@ -25,7 +25,7 @@ namespace RegressionGames.Editor
             var provider = new SettingsProvider("Regression Games", SettingsScope.Project)
             {
                 // Create the SettingsProvider and initialize its drawing (IMGUI) function in place:
-                guiHandler = async (searchContext) =>
+                guiHandler = (searchContext) =>
                 {
                     SerializedObject settings = RGSettings.GetSerializedSettings();
                     EditorGUI.BeginChangeCheck();

--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlayCanvasV2.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlayCanvasV2.prefab
@@ -6355,7 +6355,7 @@ GameObject:
   - component: {fileID: 5893801167117800152}
   - component: {fileID: 5122435472915985299}
   m_Layer: 5
-  m_Name: Recodring Toolbar
+  m_Name: Recording Toolbar
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardInputActionObserver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardInputActionObserver.cs
@@ -202,11 +202,13 @@ namespace RegressionGames.StateRecorder
         });
         
         // Key -> (without-Shift, with-Shift) values
-        public static readonly IReadOnlyDictionary<Key, (char, char)> KeyToValueMap = new ReadOnlyDictionary<Key, (char,char)>(new Dictionary<Key, (char,char)>()
+        public static readonly IReadOnlyDictionary<Key, (char, char)> KeyboardKeyToValueMap = new ReadOnlyDictionary<Key, (char,char)>(new Dictionary<Key, (char,char)>()
         {
-            //row 1 (top row)
-
-            // row 2
+            // row 1 (top row) is generally function keys.
+            // ignore these since they don't have ascii characters associated with them
+            { Key.Delete, ((char)127, (char)127) },
+            
+            // row 2 - numbers and symbols
             { Key.Backquote, ('`', '~') },
             { Key.Digit1, ('1','!') },
             { Key.Digit2, ('2','@') },
@@ -222,8 +224,7 @@ namespace RegressionGames.StateRecorder
             { Key.Equals, ('=', '+')},
             { Key.Backspace, ((char)8, (char)8) },
 
-            //row 3
-            // TODO: Not sure how to do back-tab
+            // row 3 - qwerty
             { Key.Tab, ((char)9, (char)9) },
             { Key.Q, ('q','Q') },
             { Key.W, ('w','W') },
@@ -239,7 +240,7 @@ namespace RegressionGames.StateRecorder
             { Key.RightBracket, (']','}') },
             { Key.Backslash, ('\\','|') },
             
-            //row 4
+            // row 4 - asdf
             { Key.A, ('a','A') },
             { Key.S, ('s','S') },
             { Key.D, ('d','D') },
@@ -253,7 +254,7 @@ namespace RegressionGames.StateRecorder
             { Key.Quote, ('\'','"') },
             { Key.Enter, ('\n','\n') },
             
-            //row 5
+            // row 5 - zxcv
             // left shift modifies each of these so doesn't need its own entry
             { Key.Z, ('z','Z') },
             { Key.X, ('x','X') },
@@ -267,13 +268,10 @@ namespace RegressionGames.StateRecorder
             { Key.Slash, ('/','?') },
             // same for right shift
             
-            // row 6 (bottom row)
-            // TODO ctrl, alt will be modifier keys??
+            // row 6 - bottom row with space bar
+            // ignore ctrl. alt, other modifier keys
             { Key.Space, (' ', ' ') },
             
-            // move this
-            { Key.Delete, ((char)127, (char)127) },
-
             // numpad
             { Key.NumpadMultiply, ('*','*') },
             { Key.NumpadDivide, ('/', '/') },

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardInputActionObserver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardInputActionObserver.cs
@@ -202,6 +202,7 @@ namespace RegressionGames.StateRecorder
         });
         
         // Key -> (without-Shift, with-Shift) values
+        // This is used to convert key presses into characters for text events, where shift can modify the character
         public static readonly IReadOnlyDictionary<Key, (char, char)> KeyboardKeyToValueMap = new ReadOnlyDictionary<Key, (char,char)>(new Dictionary<Key, (char,char)>()
         {
             // row 1 (top row) is generally function keys.

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardInputActionObserver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardInputActionObserver.cs
@@ -200,6 +200,99 @@ namespace RegressionGames.StateRecorder
             { "OEM4", Key.OEM4 },
             { "OEM5", Key.OEM5 },
         });
+        
+        // Key -> (without-Shift, with-Shift) values
+        public static readonly IReadOnlyDictionary<Key, (char, char)> KeyToValueMap = new ReadOnlyDictionary<Key, (char,char)>(new Dictionary<Key, (char,char)>()
+        {
+            //row 1 (top row)
+
+            // row 2
+            { Key.Backquote, ('`', '~') },
+            { Key.Digit1, ('1','!') },
+            { Key.Digit2, ('2','@') },
+            { Key.Digit3, ('3','#') },
+            { Key.Digit4, ('4','$') },
+            { Key.Digit5, ('5','%') },
+            { Key.Digit6, ('6','^') },
+            { Key.Digit7, ('7','&') },
+            { Key.Digit8, ('8','*') },
+            { Key.Digit9, ('9','(') },
+            { Key.Digit0, ('0',')') },
+            { Key.Minus, ('-','_') },
+            { Key.Equals, ('=', '+')},
+            { Key.Backspace, ((char)8, (char)8) },
+
+            //row 3
+            // TODO: Not sure how to do back-tab
+            { Key.Tab, ((char)9, (char)9) },
+            { Key.Q, ('q','Q') },
+            { Key.W, ('w','W') },
+            { Key.E, ('e','E') },
+            { Key.R, ('r','R') },
+            { Key.T, ('t','T') },
+            { Key.Y, ('y','Y') },
+            { Key.U, ('u','u') },
+            { Key.I, ('i','I') },
+            { Key.O, ('o','O') },
+            { Key.P, ('p','P') },
+            { Key.LeftBracket, ('[','{') },
+            { Key.RightBracket, (']','}') },
+            { Key.Backslash, ('\\','|') },
+            
+            //row 4
+            { Key.A, ('a','A') },
+            { Key.S, ('s','S') },
+            { Key.D, ('d','D') },
+            { Key.F, ('f','F') },
+            { Key.G, ('g','G') },
+            { Key.H, ('h','H') },
+            { Key.J, ('j','J') },
+            { Key.K, ('k','K') },
+            { Key.L, ('l','L') },
+            { Key.Semicolon, (';',':') },
+            { Key.Quote, ('\'','"') },
+            { Key.Enter, ('\n','\n') },
+            
+            //row 5
+            // left shift modifies each of these so doesn't need its own entry
+            { Key.Z, ('z','Z') },
+            { Key.X, ('x','X') },
+            { Key.C, ('c','C') },
+            { Key.V, ('v','V') },
+            { Key.B, ('b','B') },
+            { Key.N, ('n','N') },
+            { Key.M, ('m','M') },
+            { Key.Comma, (',','<') },
+            { Key.Period, ('.','>') },
+            { Key.Slash, ('/','?') },
+            // same for right shift
+            
+            // row 6 (bottom row)
+            // TODO ctrl, alt will be modifier keys??
+            { Key.Space, (' ', ' ') },
+            
+            // move this
+            { Key.Delete, ((char)127, (char)127) },
+
+            // numpad
+            { Key.NumpadMultiply, ('*','*') },
+            { Key.NumpadDivide, ('/', '/') },
+            { Key.NumpadPlus, ('+', '+')},
+            { Key.NumpadMinus, ('-','-') },
+            { Key.Numpad7, ('7', '7') },
+            { Key.Numpad8, ('8', '8') },
+            { Key.Numpad9, ('9', '9') },
+            { Key.Numpad4, ('4', '4') },
+            { Key.Numpad5, ('5', '5') },
+            { Key.Numpad6, ('6', '6') },
+            { Key.Numpad1, ('1', '1') },
+            { Key.Numpad2, ('2', '2') },
+            { Key.Numpad3, ('3', '3') },
+            { Key.Numpad0, ('0', '0') },
+            // shift . on numpad is Delete
+            { Key.NumpadPeriod, ('.', (char)127) },
+            { Key.NumpadEnter, ('\n', '\n') },
+        });
 
         public void Awake()
         {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataContainer.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataContainer.cs
@@ -96,6 +96,8 @@ namespace RegressionGames.StateRecorder
 
         private readonly Queue<ReplayKeyboardInputEntry> _keyboardData = new();
 
+        public bool IsShiftDown = false;
+
         private readonly Dictionary<string, ReplayKeyboardInputEntry> _pendingEndKeyboardInputs = new();
 
         private readonly Queue<ReplayMouseInputEntry> _mouseData = new();

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -289,16 +289,24 @@ namespace RegressionGames.StateRecorder
             // 0f == false == un-pressed state
             using (DeltaStateEvent.From(keyboard, out var eventPtr))
             {
+                char value = (char)0;
                 eventPtr.time = InputState.currentTime;
                 var inputControl = keyboard.allControls
                     .FirstOrDefault(a => a is KeyControl kc && kc.keyCode == key) ?? keyboard.anyKey;
 
                 if (inputControl != null)
                 {
+                    // this isn't safe
+                    value = KeyboardInputActionObserver.AllKeyboardKeys.FirstOrDefault(a => a.Value == ((KeyControl)inputControl).keyCode).Key.ToCharArray()[0];
                     inputControl.WriteValueIntoEvent(upOrDown == KeyState.Down ? 1f : 0f, eventPtr);
                     RGDebug.LogInfo($"({tickNumber}) Sending Key Event: {key} - {upOrDown}");
                     InputSystem.QueueEvent(eventPtr);
                 }
+
+                // send a text event so that 'onChange' text events fire
+                // TODO: Fix this to consider modifier keys, proper text value mappings, etc
+                var inputEvent = TextEvent.Create(Keyboard.current.deviceId, value, Time.timeAsDouble);
+                InputSystem.QueueEvent(ref inputEvent);
             }
         }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -311,16 +311,24 @@ namespace RegressionGames.StateRecorder
                     inputControl.WriteValueIntoEvent(upOrDown == KeyState.Down ? 1f : 0f, eventPtr);
                     InputSystem.QueueEvent(eventPtr);
                     
-                    // send a text event so that 'onChange' text events fire
-                    if (upOrDown == KeyState.Down)
+                    if (upOrDown == KeyState.Up)
                     {
-                        // convert key to text
-                        if (KeyboardInputActionObserver.KeyboardKeyToValueMap.TryGetValue(((KeyControl)inputControl).keyCode, out var possibleValues))
+                        return;
+                    }
+                   
+                    // send a text event so that 'onChange' text events fire
+                    // convert key to text
+                    if (KeyboardInputActionObserver.KeyboardKeyToValueMap.TryGetValue(((KeyControl)inputControl).keyCode, out var possibleValues))
+                    {
+                        value = _dataContainer.IsShiftDown ? possibleValues.Item2 : possibleValues.Item1;
+                        if (value == 0x00)
                         {
-                            value = _dataContainer.IsShiftDown ? possibleValues.Item2 : possibleValues.Item1;
-                            var inputEvent = TextEvent.Create(Keyboard.current.deviceId, value, time);
-                            InputSystem.QueueEvent(ref inputEvent);
+                            RGDebug.LogError($"Found null value for keyboard input {key}");
+                            return;
                         }
+                        
+                        var inputEvent = TextEvent.Create(Keyboard.current.deviceId, value, time);
+                        InputSystem.QueueEvent(ref inputEvent);
                     }
                 }
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -296,7 +296,8 @@ namespace RegressionGames.StateRecorder
             // 0f == false == un-pressed state
             using (DeltaStateEvent.From(keyboard, out var eventPtr))
             {
-                eventPtr.time = InputState.currentTime;
+                var time = InputState.currentTime;
+                eventPtr.time = time;
 
                 char value = (char)0;
                 var inputControl = keyboard.allControls
@@ -314,11 +315,12 @@ namespace RegressionGames.StateRecorder
                     if (upOrDown == KeyState.Down)
                     {
                         // convert key to text
-                        var keyToPossibleValues = KeyboardInputActionObserver.KeyToValueMap
-                            .FirstOrDefault(a => a.Key == ((KeyControl)inputControl).keyCode).Value;
-                        value = _dataContainer.IsShiftDown ? keyToPossibleValues.Item2 : keyToPossibleValues.Item1;
-                        var inputEvent = TextEvent.Create(Keyboard.current.deviceId, value, Time.timeAsDouble);
-                        InputSystem.QueueEvent(ref inputEvent);
+                        if (KeyboardInputActionObserver.KeyboardKeyToValueMap.TryGetValue(((KeyControl)inputControl).keyCode, out var possibleValues))
+                        {
+                            value = _dataContainer.IsShiftDown ? possibleValues.Item2 : possibleValues.Item1;
+                            var inputEvent = TextEvent.Create(Keyboard.current.deviceId, value, time);
+                            InputSystem.QueueEvent(ref inputEvent);
+                        }
                     }
                 }
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -75,7 +75,7 @@ namespace RegressionGames.StateRecorder
             }
             if (inputModule == null)
             {
-                throw new Exception("Regression Games Unity SDK only supports the new InputSystem.");
+                RGDebug.LogError("Regression Games Unity SDK only supports the new InputSystem, but did not detect an instance of InputSystemUIInputModule in the scene.  If you are using a 3rd party input module like Coherent GameFace this may be expected/ok.");
             }
         }
 
@@ -295,7 +295,7 @@ namespace RegressionGames.StateRecorder
 
                 if (inputControl != null)
                 {
-                    inputControl.WriteValueIntoEvent(upOrDown == KeyState.Up ? 1f : 0f, eventPtr);
+                    inputControl.WriteValueIntoEvent(upOrDown == KeyState.Down ? 1f : 0f, eventPtr);
                     RGDebug.LogInfo($"({tickNumber}) Sending Key Event: {key} - {upOrDown}");
                     InputSystem.QueueEvent(eventPtr);
                 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -10,6 +10,7 @@ using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.UI;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngine.SceneManagement;
+using UnityEngine.UIElements;
 
 namespace RegressionGames.StateRecorder
 {
@@ -281,32 +282,45 @@ namespace RegressionGames.StateRecorder
             _keyboardQueue.RemoveAll(a => a.IsDone);
             _mouseQueue.RemoveAll(a => a.IsDone);
         }
-
+        
         private void SendKeyEvent(long tickNumber, Key key, KeyState upOrDown)
         {
             var keyboard = Keyboard.current;
+            
+            if (key == Key.LeftShift || key == Key.RightShift)
+            {
+                _dataContainer.IsShiftDown = upOrDown == KeyState.Down;
+            }
+            
             // 1f == true == pressed state
             // 0f == false == un-pressed state
             using (DeltaStateEvent.From(keyboard, out var eventPtr))
             {
-                char value = (char)0;
                 eventPtr.time = InputState.currentTime;
+
+                char value = (char)0;
                 var inputControl = keyboard.allControls
                     .FirstOrDefault(a => a is KeyControl kc && kc.keyCode == key) ?? keyboard.anyKey;
 
                 if (inputControl != null)
                 {
-                    // this isn't safe
-                    value = KeyboardInputActionObserver.AllKeyboardKeys.FirstOrDefault(a => a.Value == ((KeyControl)inputControl).keyCode).Key.ToCharArray()[0];
-                    inputControl.WriteValueIntoEvent(upOrDown == KeyState.Down ? 1f : 0f, eventPtr);
                     RGDebug.LogInfo($"({tickNumber}) Sending Key Event: {key} - {upOrDown}");
+                    
+                    // queue input event
+                    inputControl.WriteValueIntoEvent(upOrDown == KeyState.Down ? 1f : 0f, eventPtr);
                     InputSystem.QueueEvent(eventPtr);
+                    
+                    // send a text event so that 'onChange' text events fire
+                    if (upOrDown == KeyState.Down)
+                    {
+                        // convert key to text
+                        var keyToPossibleValues = KeyboardInputActionObserver.KeyToValueMap
+                            .FirstOrDefault(a => a.Key == ((KeyControl)inputControl).keyCode).Value;
+                        value = _dataContainer.IsShiftDown ? keyToPossibleValues.Item2 : keyToPossibleValues.Item1;
+                        var inputEvent = TextEvent.Create(Keyboard.current.deviceId, value, Time.timeAsDouble);
+                        InputSystem.QueueEvent(ref inputEvent);
+                    }
                 }
-
-                // send a text event so that 'onChange' text events fire
-                // TODO: Fix this to consider modifier keys, proper text value mappings, etc
-                var inputEvent = TextEvent.Create(Keyboard.current.deviceId, value, Time.timeAsDouble);
-                InputSystem.QueueEvent(ref inputEvent);
             }
         }
 


### PR DESCRIPTION
Sends text events specifically for GameFace inputs to receive characters and produce `onChange` events. This requires us to take `shift` into consideration so that we know which character to send based on whether `shift` is held at the same time as another key.

https://www.loom.com/share/1084658e11c5412e8d70b6d1fc9abd94

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
