### PR TITLE
[REG-1679] Handle world space object click position adjustments

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
@@ -175,8 +175,11 @@ namespace RegressionGames.StateRecorder
             var minWorldZ = float.MaxValue;
             var maxWorldZ = float.MinValue;
 
+            var hasVisibleRenderer = false;
+
             foreach (var nextRenderer in renderers)
             {
+                hasVisibleRenderer |= nextRenderer.isVisible;
                 if (nextRenderer.gameObject.GetComponentInParent<RGExcludeFromState>() == null)
                 {
                     var theBounds = nextRenderer.bounds;
@@ -215,7 +218,7 @@ namespace RegressionGames.StateRecorder
                 }
             }
 
-            var onCamera = minWorldX < float.MaxValue;
+            var onCamera = minWorldX < float.MaxValue && (replay || hasVisibleRenderer);
             if (onCamera)
             {
                 // convert world space to screen space

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordingAndReplayContainerTypes.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordingAndReplayContainerTypes.cs
@@ -169,6 +169,7 @@ namespace RegressionGames.StateRecorder
                                 + ",\n\"layer\":" + JsonConvert.ToString(layer)
                                 + ",\n\"rendererCount\":" + rendererCount
                                 + ",\n\"screenSpaceBounds\":" + BoundsJsonConverter.ToJsonString(screenSpaceBounds)
+                                + ",\n\"screenSpaceZOffset\":" + FloatJsonConverter.ToJsonString(screenSpaceZOffset)
                                 + ",\n\"worldSpaceBounds\":" + BoundsJsonConverter.ToJsonString(worldSpaceBounds)
                                 + ",\n\"position\":" + VectorJsonConverter.ToJsonStringVector3(position)
                                 + ",\n\"rotation\":" + QuaternionJsonConverter.ToJsonString(rotation)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -507,7 +507,7 @@ namespace RegressionGames.StateRecorder
                             // use the world space click location closest to the actual object location
                             var mouseWorldPosition = mouseInput.worldPosition.Value;
                             // uses the collider bounds on that object as colliders are what would drive world space objects' click detection in scripts / etc
-                            if (objectToCheck.colliders.FirstOrDefault(a => a.bounds.Contains(mouseWorldPosition)) != null)
+                            if ((objectToCheck.colliders.Count == 0 && objectToCheck.worldSpaceBounds.Value.Contains(mouseWorldPosition)) || objectToCheck.colliders.FirstOrDefault(a => a.bounds.Contains(mouseWorldPosition)) != null)
                             {
                                 var screenPoint = Camera.main.WorldToScreenPoint(mouseWorldPosition);
                                 if (screenPoint.x < 0 || screenPoint.x > screenWidth || screenPoint.y < 0 || screenPoint.y > screenHeight)


### PR DESCRIPTION
- Handles adjusting the click location of clicks on world space objects to handle slight positional differences of the player/view from run to run
  - This is more of a fix than new code... We were wrongly excluding duplicate path named world space objects from click adjustment consideration during replay and were using the render bounds instead of colliders to check for click hits
- Fixes an issue where non-visible world space objects were sometimes being included incorrectly in the recorded state
- Fixes an issue where we weren't including the screenSpaceZOffset in the json
  - **(This will change the Json by adding a new field to each object)**

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
