### PR TITLE
[REG-1680] Optimize performance of state for current frame

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
@@ -501,8 +501,8 @@ namespace RegressionGames.StateRecorder
                 {
                     BehaviourState cObject = new BehaviourState
                     {
-                        path = (ts ??= GetUniqueTransformPath(childTransform)).Path,
-                        name = (ts ??= GetUniqueTransformPath(childTransform)).TypeFullName,
+                        path = (ts ??= GetUniqueTransformPath(childTransform, childBehaviour)).Path,
+                        name = (ts ??= GetUniqueTransformPath(childTransform, childBehaviour)).TypeFullName,
                         state = childBehaviour
                     };
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JetBrains.Annotations;
 using StateRecorder.Types;
@@ -418,19 +419,23 @@ namespace RegressionGames.StateRecorder
                     _currentParentTransforms.Clear();
                     while (_nextParentTransforms.Count > 0)
                     {
-                        // swap the list references
+                        var nptCount = _nextParentTransforms.Count;
+                        for (var i = 0; i < nptCount; i++)
+                        {
+                            var currentTransform = _nextParentTransforms[i];
+                            ProcessChildTransformComponents(currentTransform, behaviours, collidersState, rigidbodiesState);
+                        }
+                        // swap the list references and load the next layer
                         (_currentParentTransforms, _nextParentTransforms) = (_nextParentTransforms, _currentParentTransforms);
                         _nextParentTransforms.Clear();
                         var currentCount = _currentParentTransforms.Count;
                         for (var i = 0; i < currentCount; i++)
                         {
                             var currentParentTransform = _currentParentTransforms[i];
-                            var childCount = _currentParentTransforms[i].childCount;
+                            var childCount = currentParentTransform.childCount;
                             for (var j = 0; j < childCount; j++)
                             {
-                                var currentChildTransform = currentParentTransform.GetChild(j);
-                                ProcessChildTransformComponents(currentChildTransform, behaviours, collidersState, rigidbodiesState);
-                                _nextParentTransforms.Add(currentChildTransform);
+                                _nextParentTransforms.Add(currentParentTransform.GetChild(j));
                             }
                         }
                     }
@@ -646,18 +651,24 @@ namespace RegressionGames.StateRecorder
                             _currentParentTransforms.Clear();
                             while (_nextParentTransforms.Count > 0)
                             {
-                                // swap the list references
+                                var nptCount = _nextParentTransforms.Count;
+                                for (var i = 0; i < nptCount; i++)
+                                {
+                                    var currentTransform = _nextParentTransforms[i];
+                                    ProcessChildTransformComponents(currentTransform, behaviours, null, null);
+                                }
+
+                                // swap the list references and load the next layer
                                 (_currentParentTransforms, _nextParentTransforms) = (_nextParentTransforms, _currentParentTransforms);
                                 _nextParentTransforms.Clear();
                                 var currentCount = _currentParentTransforms.Count;
                                 for (var i = 0; i < currentCount; i++)
                                 {
                                     var currentParentTransform = _currentParentTransforms[i];
-                                    var childCount = _currentParentTransforms[i].childCount;
+                                    var childCount = currentParentTransform.childCount;
                                     for (var k = 0; k < childCount; k++)
                                     {
                                         var currentChildTransform = currentParentTransform.GetChild(k);
-                                        ProcessChildTransformComponents(currentChildTransform, behaviours, null, null);
                                         _nextParentTransforms.Add(currentChildTransform);
                                     }
                                 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
@@ -329,7 +329,7 @@ namespace RegressionGames.StateRecorder
                             }
                         }
                     }
-                    else
+                    if (resultObject == null)
                     {
                         resultObject = new RecordedGameObjectState()
                         {
@@ -557,7 +557,8 @@ namespace RegressionGames.StateRecorder
                                     }
                                 }
                             }
-                            else
+
+                            if (resultObject == null)
                             {
                                 resultObject = new RecordedGameObjectState()
                                 {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
@@ -190,7 +190,6 @@ namespace RegressionGames.StateRecorder
             var psCount = priorState?.Count ?? -1;
 
             var rendererListLength = _rendererQueryList.Count;
-            // ReSharper disable once ForCanBeConvertedToForeach - faster by index; avoids enumerator
             for (var i = 0; i < rendererListLength; i++)
             {
                 var nextRenderer = _rendererQueryList[i];
@@ -279,7 +278,6 @@ namespace RegressionGames.StateRecorder
                 var minZ = float.MaxValue;
                 var maxZ = float.MinValue;
 
-                // ReSharper disable once ForCanBeConvertedToForeach - faster by index, avoids enumerator
                 var worldCornersLength = _worldCorners.Length;
                 for (var i=0; i< worldCornersLength; i++)
                 {
@@ -528,8 +526,8 @@ namespace RegressionGames.StateRecorder
             var psCount = priorState?.Count ?? -1;
 
              // we re-use this over and over instead of allocating multiple times
-            // ReSharper disable once ForCanBeConvertedToForeach - index is faster with less allocs than enumerator
-            for (var j = 0; j < canvasRenderers.Length; j++)
+            var canvasRenderersLength = canvasRenderers.Length;
+            for (var j = 0; j < canvasRenderersLength; j++)
             {
                 var canvasRenderer = canvasRenderers[j];
                 var statefulUIObject = ((CanvasRenderer)canvasRenderer).gameObject;
@@ -780,8 +778,6 @@ namespace RegressionGames.StateRecorder
                         _componentsInParentList.Clear();
                         // if we already saw that parent before, this frame or otherwise, we won't do this again
                         nextParent.GetComponentsInParent(false, _componentsInParentList);
-                        // ReSharper disable once ForCanBeConvertedToForeach - index iteration faster with less enumerator allocs
-                        // ReSharper disable once LoopCanBeConvertedToQuery - index iteration faster with less enumerator allocs
                         var componentsInParentListLength = _componentsInParentList.Count;
                         for (var i = 0; i < componentsInParentListLength; i++)
                         {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
@@ -479,7 +479,7 @@ namespace RegressionGames.StateRecorder
             return null;
         }
 
-        // pre-allocate this rather large list 1 time to avoid memory stuff on each stick
+        // pre-allocate this rather large list 1 time to avoid memory stuff on each tick
         private readonly List<Component> _childComponentsQueryList = new(100);
 
         private void ProcessChildTransformComponents(Transform childTransform, List<BehaviourState> behaviours, List<ColliderRecordState> collidersState, List<RigidbodyRecordState> rigidbodiesState)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using JetBrains.Annotations;
 using StateRecorder.Types;
 using UnityEngine;
@@ -510,12 +508,11 @@ namespace RegressionGames.StateRecorder
                     }
                     else
                     {
-                        cObject = new ColliderRecordState
-                        {
-                            path = (ts ??= GetUniqueTransformPath(childTransform)).Path,
-                            collider = colliderEntry
-                        };
+                        cObject = new ColliderRecordState();
                     }
+
+                    cObject.path = (ts ??= GetUniqueTransformPath(childTransform)).Path;
+                    cObject.collider = colliderEntry;
 
                     collidersState.Add(cObject);
                 }
@@ -531,12 +528,11 @@ namespace RegressionGames.StateRecorder
                     }
                     else
                     {
-                        cObject = new Collider2DRecordState
-                        {
-                            path = (ts ??= GetUniqueTransformPath(childTransform)).Path,
-                            collider = colliderEntry2D
-                        };
+                        cObject = new Collider2DRecordState();
                     }
+
+                    cObject.path = (ts ??= GetUniqueTransformPath(childTransform)).Path;
+                    cObject.collider = colliderEntry2D;
 
                     collidersState.Add(cObject);
                 }
@@ -552,12 +548,11 @@ namespace RegressionGames.StateRecorder
                     }
                     else
                     {
-                        cObject = new RigidbodyRecordState
-                        {
-                            path = (ts ??= GetUniqueTransformPath(childTransform)).Path,
-                            rigidbody = myRigidbody
-                        };
+                        cObject = new RigidbodyRecordState();
                     }
+
+                    cObject.path = (ts ??= GetUniqueTransformPath(childTransform)).Path;
+                    cObject.rigidbody = myRigidbody;
 
                     rigidbodiesState.Add(cObject);
                 }
@@ -573,12 +568,11 @@ namespace RegressionGames.StateRecorder
                     }
                     else
                     {
-                        cObject = new Rigidbody2DRecordState
-                        {
-                            path = (ts ??= GetUniqueTransformPath(childTransform)).Path,
-                            rigidbody = myRigidbody2D
-                        };
+                        cObject = new Rigidbody2DRecordState();
                     }
+
+                    cObject.path = (ts ??= GetUniqueTransformPath(childTransform)).Path;
+                    cObject.rigidbody = myRigidbody2D;
 
                     rigidbodiesState.Add(cObject);
                 }
@@ -594,13 +588,12 @@ namespace RegressionGames.StateRecorder
                     }
                     else
                     {
-                        cObject = new BehaviourState
-                        {
-                            path = (ts ??= GetUniqueTransformPath(childTransform, childBehaviour)).Path,
-                            name = (ts ??= GetUniqueTransformPath(childTransform, childBehaviour)).TypeFullName,
-                            state = childBehaviour
-                        };
+                        cObject = new BehaviourState();
                     }
+
+                    cObject.path = (ts ??= GetUniqueTransformPath(childTransform, childBehaviour)).Path;
+                    cObject.name = (ts ??= GetUniqueTransformPath(childTransform, childBehaviour)).TypeFullName;
+                    cObject.state = childBehaviour;
 
                     behaviours.Add(cObject);
                 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseInputActionObserver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseInputActionObserver.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Newtonsoft.Json;
 using RegressionGames.StateRecorder.JsonConverters;
 using UnityEngine;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordingAndReplayContainerTypes.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordingAndReplayContainerTypes.cs
@@ -134,8 +134,8 @@ namespace RegressionGames.StateRecorder
 
         public int rendererCount;
 
-        public List<RigidbodyState> rigidbodies;
-        public List<ColliderState> colliders;
+        public List<RigidbodyReplayState> rigidbodies;
+        public List<ColliderReplayState> colliders;
 
         public Bounds screenSpaceBounds;
 
@@ -156,8 +156,29 @@ namespace RegressionGames.StateRecorder
 
     [Serializable]
     [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class RecordedGameObjectState : BaseReplayObjectState
+    public class RecordedGameObjectState
     {
+        public int id;
+
+        public string path;
+        public string scene;
+        public string tag;
+        public string layer;
+
+        public int rendererCount;
+
+        public Bounds screenSpaceBounds;
+
+        public float screenSpaceZOffset;
+
+        [NonSerialized]
+        // keep reference to this instead of updating its fields every tick
+        public Transform transform;
+
+        public Bounds? worldSpaceBounds;
+
+        public List<RigidbodyRecordState> rigidbodies;
+        public List<ColliderRecordState> colliders;
         public List<BehaviourState> behaviours;
 
         public string ToJson()
@@ -171,8 +192,8 @@ namespace RegressionGames.StateRecorder
                                 + ",\n\"screenSpaceBounds\":" + BoundsJsonConverter.ToJsonString(screenSpaceBounds)
                                 + ",\n\"screenSpaceZOffset\":" + FloatJsonConverter.ToJsonString(screenSpaceZOffset)
                                 + ",\n\"worldSpaceBounds\":" + BoundsJsonConverter.ToJsonString(worldSpaceBounds)
-                                + ",\n\"position\":" + VectorJsonConverter.ToJsonStringVector3(position)
-                                + ",\n\"rotation\":" + QuaternionJsonConverter.ToJsonString(rotation)
+                                + ",\n\"position\":" + VectorJsonConverter.ToJsonStringVector3(transform.position)
+                                + ",\n\"rotation\":" + QuaternionJsonConverter.ToJsonString(transform.rotation)
                                 + ",\n\"rigidbodies\":[\n" + string.Join(",\n", rigidbodies.Select(a=>a.ToJson()))
                                 + "\n],\n\"colliders\":[\n" + string.Join(",\n", colliders.Select(a=>a.ToJson()))
                                 + "\n],\n\"behaviours\":[\n" + string.Join(",\n", behaviours.Select(a=>a.ToJson()))
@@ -184,6 +205,10 @@ namespace RegressionGames.StateRecorder
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public class BehaviourState
     {
+        // used as an optimization for comparing objects from tick to tick
+        [NonSerialized]
+        public int id;
+
         public string name;
         public string path;
         public Behaviour state;
@@ -195,7 +220,7 @@ namespace RegressionGames.StateRecorder
 
         public string ToJson()
         {
-            var stateJson = "{}";
+            string stateJson;
             try
             {
                 stateJson = JsonConvert.SerializeObject(state, Formatting.None, ScreenRecorder.JsonSerializerSettings);
@@ -208,6 +233,7 @@ namespace RegressionGames.StateRecorder
             catch (Exception ex)
             {
                 RGDebug.LogException(ex, "Error converting behaviour to JSON - " + state.name);
+                stateJson = "{}";
             }
 
             return "{\"name\":" + JsonConvert.ToString(name)
@@ -220,29 +246,114 @@ namespace RegressionGames.StateRecorder
 
     [Serializable]
     [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class ColliderState
+    public class ColliderRecordState
     {
-        public string path;
-        public Bounds bounds;
-        public bool isTrigger;
+        // used as an optimization for comparing objects from tick to tick
+        [NonSerialized]
+        public int id;
 
-        public string ToJson()
+        public string path;
+        public Collider collider;
+
+        public virtual string ToJson()
         {
             return "{\"path\":" + JsonConvert.ToString(path)
-                                + ",\"bounds\":" + BoundsJsonConverter.ToJsonString(bounds)
-                                + ",\"isTrigger\":" + (isTrigger ? "true" : "false")
+                                + ",\"is2D\":false"
+                                + ",\"bounds\":" + BoundsJsonConverter.ToJsonString(collider.bounds)
+                                + ",\"isTrigger\":" + (collider.isTrigger ? "true" : "false")
                                 + "}";
         }
     }
 
+    [Serializable]
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    public class Collider2DRecordState : ColliderRecordState
+    {
+        public new Collider2D collider;
+
+        public override string ToJson()
+        {
+            return "{\"path\":" + JsonConvert.ToString(path)
+                                + ",\"is2D\":true"
+                                + ",\"bounds\":" + BoundsJsonConverter.ToJsonString(collider.bounds)
+                                + ",\"isTrigger\":" + (collider.isTrigger ? "true" : "false")
+                                + "}";
+        }
+    }
 
     [Serializable]
     [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class RigidbodyState
+    public class ColliderReplayState
+    {
+        public string path;
+        public bool is2D;
+        public Bounds bounds;
+        public bool isTrigger;
+    }
+
+    [Serializable]
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    public class RigidbodyRecordState
+    {
+        // used as an optimization for comparing objects from tick to tick
+        [NonSerialized]
+        public int id;
+
+        public string path;
+
+        // keep a ref to this instead of updating fields every tick
+        public Rigidbody rigidbody;
+
+        public virtual string ToJson()
+        {
+            return "{\"path\":" + JsonConvert.ToString(path)
+                                + ",\"is2D\":false"
+                                + ",\"position\":" + VectorJsonConverter.ToJsonStringVector3(rigidbody.position)
+                                + ",\"rotation\":" + QuaternionJsonConverter.ToJsonString(rigidbody.rotation)
+                                + ",\"velocity\":" + VectorJsonConverter.ToJsonStringVector3(rigidbody.velocity)
+                                + ",\"mass\":" + FloatJsonConverter.ToJsonString(rigidbody.mass)
+                                + ",\"drag\":" + FloatJsonConverter.ToJsonString(rigidbody.drag)
+                                + ",\"angularDrag\":" + FloatJsonConverter.ToJsonString(rigidbody.angularDrag)
+                                + ",\"useGravity\":" + (rigidbody.useGravity ? "true" : "false")
+                                + ",\"isKinematic\":" + (rigidbody.isKinematic ? "true" : "false")
+                                + "}";
+        }
+    }
+
+    [Serializable]
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    public class Rigidbody2DRecordState: RigidbodyRecordState
+    {
+
+        // keep a ref to this instead of updating fields every tick
+        public new Rigidbody2D rigidbody;
+
+        public override string ToJson()
+        {
+            return "{\"path\":" + JsonConvert.ToString(path)
+                                + ",\"is2D\":true"
+                                + ",\"position\":" + VectorJsonConverter.ToJsonStringVector3(rigidbody.position)
+                                // rotation around Z
+                                + ",\"rotation\":" + QuaternionJsonConverter.ToJsonString(Quaternion.Euler(0, 0, rigidbody.rotation))
+                                + ",\"velocity\":" + VectorJsonConverter.ToJsonStringVector3(rigidbody.velocity)
+                                + ",\"mass\":" + FloatJsonConverter.ToJsonString(rigidbody.mass)
+                                + ",\"drag\":" + FloatJsonConverter.ToJsonString(rigidbody.drag)
+                                + ",\"angularDrag\":" + FloatJsonConverter.ToJsonString(rigidbody.angularDrag)
+                                + ",\"gravityScale\":" + FloatJsonConverter.ToJsonString(rigidbody.gravityScale)
+                                + ",\"isKinematic\":" + (rigidbody.isKinematic ? "true" : "false")
+                                + "}";
+        }
+    }
+
+    [Serializable]
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    public class RigidbodyReplayState
     {
         public string path;
 
         public Vector3 position;
+
+        public bool is2D;
 
         // for 3D this is rotation on Z axis
         public Quaternion rotation;
@@ -251,20 +362,7 @@ namespace RegressionGames.StateRecorder
         public float drag;
         public float angularDrag;
         public bool useGravity;
+        public float gravityScale;
         public bool isKinematic;
-
-        public string ToJson()
-        {
-            return "{\"path\":" + JsonConvert.ToString(path)
-                                + ",\"position\":" + VectorJsonConverter.ToJsonStringVector3(position)
-                                + ",\"rotation\":" + QuaternionJsonConverter.ToJsonString(rotation)
-                                + ",\"velocity\":" + VectorJsonConverter.ToJsonStringVector3(velocity)
-                                + ",\"mass\":" + FloatJsonConverter.ToJsonString(mass)
-                                + ",\"drag\":" + FloatJsonConverter.ToJsonString(drag)
-                                + ",\"angularDrag\":" + FloatJsonConverter.ToJsonString(angularDrag)
-                                + ",\"useGravity\":" + (useGravity ? "true" : "false")
-                                + ",\"isKinematic\":" + (isKinematic ? "true" : "false")
-                                + "}";
-        }
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordingAndReplayContainerTypes.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordingAndReplayContainerTypes.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 using RegressionGames.StateRecorder.JsonConverters;
 using StateRecorder;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace RegressionGames.StateRecorder
 {
@@ -161,7 +162,9 @@ namespace RegressionGames.StateRecorder
         public int id;
 
         public string path;
-        public string scene;
+        [NonSerialized] // used internally for performance, but serialized as the name
+        public Scene scene;
+
         public string tag;
         public string layer;
 
@@ -185,7 +188,7 @@ namespace RegressionGames.StateRecorder
         {
             return "{\n\"id\":" + id
                                 + ",\n\"path\":" + JsonConvert.ToString(path)
-                                + ",\n\"scene\":" + JsonConvert.ToString(scene)
+                                + ",\n\"scene\":" + JsonConvert.ToString(scene.name)
                                 + ",\n\"tag\":" + JsonConvert.ToString(tag)
                                 + ",\n\"layer\":" + JsonConvert.ToString(layer)
                                 + ",\n\"rendererCount\":" + rendererCount
@@ -205,10 +208,6 @@ namespace RegressionGames.StateRecorder
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public class BehaviourState
     {
-        // used as an optimization for comparing objects from tick to tick
-        [NonSerialized]
-        public int id;
-
         public string name;
         public string path;
         public Behaviour state;
@@ -248,10 +247,6 @@ namespace RegressionGames.StateRecorder
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public class ColliderRecordState
     {
-        // used as an optimization for comparing objects from tick to tick
-        [NonSerialized]
-        public int id;
-
         public string path;
         public Collider collider;
 
@@ -295,9 +290,6 @@ namespace RegressionGames.StateRecorder
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public class RigidbodyRecordState
     {
-        // used as an optimization for comparing objects from tick to tick
-        [NonSerialized]
-        public int id;
 
         public string path;
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataContainer.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataContainer.cs
@@ -280,8 +280,8 @@ namespace RegressionGames.StateRecorder
                         // go through the mouse input data and setup the different entries
                         string[] specificGameObjectPaths = Array.Empty<string>();
 
-                        // in the future, we may validate the object ids on mouse release.. but in early testing this creating some very bad timing issues
-                        if (keyFrame != null && mouseInputData.clickedObjectIds != null && mouseInputData.IsButtonClicked)
+                        // we also validate the object ids on mouse release to adjust click positions
+                        if (keyFrame != null && mouseInputData.clickedObjectIds != null )
                         {
                             specificGameObjectPaths = FindObjectsWithIds(mouseInputData.clickedObjectIds, frameData.state).ToArray();
                         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataContainer.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataContainer.cs
@@ -188,7 +188,7 @@ namespace RegressionGames.StateRecorder
             return null;
         }
 
-        private void ParseReplayZip(string zipFilePath)
+        public void ParseReplayZip(string zipFilePath)
         {
             using var zipArchive = ZipFile.Open(zipFilePath, ZipArchiveMode.Read);
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -687,6 +687,8 @@ namespace RegressionGames.StateRecorder
             }
         }
 
+        private List<RecordedGameObjectState> _priorStates = null;
+
         public void Update()
         {
             if (_dataContainer != null)
@@ -700,7 +702,7 @@ namespace RegressionGames.StateRecorder
 
                 if (_isPlaying)
                 {
-                    var objectStates = InGameObjectFinder.GetInstance()?.GetStateForCurrentFrame(true);
+                    var objectStates = InGameObjectFinder.GetInstance()?.GetStateForCurrentFrame(_priorStates, true);
 
                     var gameFacePixelHashObserver = GameFacePixelHashObserver.GetInstance();
                     string pixelHash = null;
@@ -714,6 +716,8 @@ namespace RegressionGames.StateRecorder
                     CheckWaitForKeyStateMatch(objectStates, pixelHash);
 
                     PlayInputs(objectStates);
+
+                    _priorStates = objectStates;
                 }
             }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -594,11 +594,12 @@ namespace RegressionGames.StateRecorder
                                 var screenPoint = mainCamera.WorldToScreenPoint(mouseWorldPosition);
                                 if (screenPoint.x < 0 || screenPoint.x > screenWidth || screenPoint.y < 0 || screenPoint.y > screenHeight)
                                 {
-                                    RGDebug.LogError($"Attempted to click at worldPosition: [{mouseWorldPosition.x},{mouseWorldPosition.y},{mouseWorldPosition.z}], which is off screen at position: [{screenPoint.x},{screenPoint.y}]");
+                                    RGDebug.LogWarning($"Attempted to click at worldPosition: [{mouseWorldPosition.x},{mouseWorldPosition.y},{mouseWorldPosition.z}], which is off screen at position: [{screenPoint.x},{screenPoint.y}]");
                                 }
                                 else
                                 {
                                     bestObject = null;
+                                    RGDebug.LogInfo($"({tickNumber}) Adjusting world click location to ensure hit on object: " + objectToCheck.path);
                                     // we hit one of our world objects, set the normalized position and stop looping
                                     normalizedPosition = new Vector2((int)screenPoint.x, (int)screenPoint.y);
                                     break; // end the for
@@ -678,10 +679,7 @@ namespace RegressionGames.StateRecorder
                 // make sure our click is on that object
                 if (!clickBounds.Contains(normalizedPosition))
                 {
-                    if (RGDebug.IsDebugEnabled)
-                    {
-                        RGDebug.LogDebug($"({tickNumber}) Adjusting click location to ensure hit on object path: " + bestObject.path);
-                    }
+                    RGDebug.LogInfo($"({tickNumber}) Adjusting click location to ensure hit on object path: " + bestObject.path);
 
                     // use the center of these bounds as our best point to click
                     normalizedPosition = new Vector2((int)clickBounds.center.x, (int)clickBounds.center.y);

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -507,7 +507,7 @@ namespace RegressionGames.StateRecorder
                             // use the world space click location closest to the actual object location
                             var mouseWorldPosition = mouseInput.worldPosition.Value;
                             // uses the collider bounds on that object as colliders are what would drive world space objects' click detection in scripts / etc
-                            if ((objectToCheck.colliders.Count == 0 && objectToCheck.worldSpaceBounds.Value.Contains(mouseWorldPosition)) || objectToCheck.colliders.FirstOrDefault(a => a.bounds.Contains(mouseWorldPosition)) != null)
+                            if ((objectToCheck.colliders.Count == 0 && objectToCheck.worldSpaceBounds.Value.Contains(mouseWorldPosition)) || objectToCheck.colliders.FirstOrDefault(a => a.collider.bounds.Contains(mouseWorldPosition)) != null)
                             {
                                 var screenPoint = Camera.main.WorldToScreenPoint(mouseWorldPosition);
                                 if (screenPoint.x < 0 || screenPoint.x > screenWidth || screenPoint.y < 0 || screenPoint.y > screenHeight)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
@@ -89,10 +89,13 @@ namespace Unity.Multiplayer.Samples.BossRoom
 
             _parsingZipFile = true;
             recordButton.SetActive(false);
+            chooseReplayButton.SetActive(false);
 
             // do this on background thread
             Task.Run(() => ProcessDataContainerZipAndSetup(filePath));
         }
+
+        private bool _justLoaded = false;
 
         private void ProcessDataContainerZipAndSetup(String filePath)
         {
@@ -109,6 +112,7 @@ namespace Unity.Multiplayer.Samples.BossRoom
             finally
             {
                 _parsingZipFile = false;
+                _justLoaded = true;
             }
         }
 
@@ -116,23 +120,28 @@ namespace Unity.Multiplayer.Samples.BossRoom
 
         private void Update()
         {
-            if (_replayLoadedNextUpdate != null)
+            if (_justLoaded)
             {
-                EndProcessContainer(_replayLoadedNextUpdate);
-                _replayLoadedNextUpdate = null;
+                _justLoaded = false;
+                if (_replayLoadedNextUpdate != null)
+                {
+                    // setup the new replay data
+                    _replayDataController.SetDataContainer(_replayLoadedNextUpdate);
+                    _replayLoadedNextUpdate = null;
+                    SetDefaultButtonStates();
+                    // set button states
+                    chooseReplayButton.SetActive(false);
+                    playButton.SetActive(true);
+                    stopButton.SetActive(true);
+                    recordButton.SetActive(false);
+                }
+                else
+                {
+                    // failed to load
+                    SetDefaultButtonStates();
+                }
+
             }
-        }
-
-        private void EndProcessContainer(ReplayDataContainer dataContainer)
-        {
-            // setup the new replay data
-            _replayDataController.SetDataContainer(dataContainer);
-
-            SetDefaultButtonStates();
-            // set button states
-            playButton.SetActive(true);
-            stopButton.SetActive(true);
-            recordButton.SetActive(false);
         }
 
         public void PlayReplay()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -17,7 +17,6 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.AI;
 using UnityEngine.Experimental.Rendering;
-using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using ErrorEventArgs = Newtonsoft.Json.Serialization.ErrorEventArgs;
 
@@ -27,6 +26,8 @@ using UnityEditor.Media;
 #endif
 
 
+// ReSharper disable once ForCanBeConvertedToForeach - Better performance using indexing vs enumerators
+// ReSharper disable once LoopCanBeConvertedToQuery - Better performance using indexing vs enumerators
 namespace RegressionGames.StateRecorder
 {
     public class ScreenRecorder : MonoBehaviour
@@ -299,8 +300,6 @@ namespace RegressionGames.StateRecorder
 
         private bool OptimizedContainsIntInList(List<int> list, int theScene)
         {
-            // ReSharper disable once ForCanBeConvertedToForeach - Better performance using indexing vs enumerators
-            // ReSharper disable once LoopCanBeConvertedToQuery - Better performance using indexing vs enumerators
             var listCount = list.Count;
             for (var i=0; i<listCount; i++)
             {
@@ -315,8 +314,6 @@ namespace RegressionGames.StateRecorder
 
         private bool OptimizedRemoveIntFromList(List<int> list, int theInt)
         {
-            // ReSharper disable once ForCanBeConvertedToForeach - Better performance using indexing vs enumerators
-            // ReSharper disable once LoopCanBeConvertedToQuery - Better performance using indexing vs enumerators
             var listCount = list.Count;
             for (var i=0; i<listCount; i++)
             {
@@ -394,8 +391,6 @@ namespace RegressionGames.StateRecorder
 
             // need to do current before previous due to the world element renderers comparisons
 
-            // ReSharper disable once ForCanBeConvertedToForeach - Better performance using indexing vs enumerators
-            // ReSharper disable once LoopCanBeConvertedToQuery - Better performance using indexing vs enumerators
             var currentStateCount = currentState.Count;
             for (var i = 0; i < currentStateCount; i++)
             {
@@ -422,8 +417,6 @@ namespace RegressionGames.StateRecorder
             bool addedRendererCount = false, addedGameElement = false;
             var worldElementsCount = 0;
             var hadDifferentUIElements = false;
-            // ReSharper disable once ForCanBeConvertedToForeach - Better performance using indexing vs enumerators
-            // ReSharper disable once LoopCanBeConvertedToQuery - Better performance using indexing vs enumerators
             var priorStateCount = priorState.Count;
             for (var i = 0; i < priorStateCount; i++)
             {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/StateRecorderUtils.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/StateRecorderUtils.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections.Generic;
+
+namespace StateRecorder
+{
+    public static class StateRecorderUtils
+    {
+        public static bool OptimizedContainsIntInList(List<int> list, int theScene)
+        {
+            var listCount = list.Count;
+            for (var i = 0; i < listCount; i++)
+            {
+                if (list[i] == theScene)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+
+        public static bool OptimizedRemoveIntFromList(List<int> list, int theInt)
+        {
+            var listCount = list.Count;
+            for (var i = 0; i < listCount; i++)
+            {
+                if (list[i] == theInt)
+                {
+                    list.RemoveAt(i);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public static bool OptimizedContainsStringInArray(string[] list, string theString)
+        {
+            if (list != null)
+            {
+                var listCount = list.Length;
+                for (var i = 0; i < listCount; i++)
+                {
+                    if (string.CompareOrdinal(list[i], theString) == 0)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public static bool OptimizedContainsStringInList(List<string> list, string theString)
+        {
+            if (list != null)
+            {
+                var listCount = list.Count;
+                for (var i = 0; i < listCount; i++)
+                {
+                    if (string.CompareOrdinal(list[i], theString) == 0)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public static bool OptimizedRemoveStringFromList(List<string> list, string theString)
+        {
+            if (list != null)
+            {
+                var listCount = list.Count;
+                for (var i = 0; i < listCount; i++)
+                {
+                    if (string.CompareOrdinal(list[i], theString) == 0)
+                    {
+                        list.RemoveAt(i);
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/StateRecorderUtils.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/StateRecorderUtils.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3f657c7417324c928d93e97d2b07dd9c
+timeCreated: 1713884024


### PR DESCRIPTION
- DOES NOT address JSON serialization performance
- Heavily micro-optimizes object constructions, pooling, reuse, loop iterations, and other code to limit GC allocs and improve performance.. kinda turns the code into a thread safety nightmare.. but luckily.. unity requires all this to run on the main thread.. so we can cheat a lot to get better performance and re-use structures
- Also handles replay performance optimization both for getting current state and for analyzing key frames and processing mouse inputs
- Fixes issues with dynamic resolution scaling on replay related to mouse click and release points <- this was actually annoying to fix :/ 
- Reduces flicker of keyframe wait text by delaying presentation of said text for a few seconds worth of frames if not matched
- Updates file loading code to load async and unblock the game ui.  I have a task for a future progress indicator here, but for now it disables the overlay buttons and lets the game resume until it finishes loading


BEFORE (Boss room main menu recording)
![OLD](https://github.com/Regression-Games/RGUnityBots/assets/112959031/9997dff7-f9c1-4f38-884e-c01cf08f9bbb)


AFTER (Boss room main menu recording)
![FINAL_AFTER](https://github.com/Regression-Games/RGUnityBots/assets/112959031/c20d9e52-a5cc-4478-a99e-c5099c576779)


---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
