### PR TITLE
[REG-1709] Remove behaviour state duplication + improve performance

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseInputActionObserver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseInputActionObserver.cs
@@ -132,7 +132,7 @@ namespace RegressionGames.StateRecorder
         // based on a few pixel shift in relative camera position
         private readonly RaycastHit[] _cachedRaycastHits = new RaycastHit[5];
 
-        public void ObserveMouse(List<RecordedGameObjectState> statefulObjects)
+        public void ObserveMouse(Dictionary<int,RecordedGameObjectState> statefulObjects)
         {
             var mousePosition = Mouse.current.position.ReadValue();
             var newMouseState = GetCurrentMouseState(mousePosition);
@@ -274,14 +274,14 @@ namespace RegressionGames.StateRecorder
             return result;
         }
 
-        private IEnumerable<RecordedGameObjectState> FindObjectsAtPosition(Vector2 position, List<RecordedGameObjectState> state, out float maxZDepth)
+        private IEnumerable<RecordedGameObjectState> FindObjectsAtPosition(Vector2 position, Dictionary<int,RecordedGameObjectState> state, out float maxZDepth)
         {
             // make sure screen space position Z is around 0
             var vec3Position = new Vector3(position.x, position.y, 0);
             List<RecordedGameObjectState> result = new();
             maxZDepth = 0f;
             var hitUIElement = false;
-            foreach (var recordedGameObjectState in state)
+            foreach (var recordedGameObjectState in state.Values)
             {
                 if (recordedGameObjectState.screenSpaceBounds.Contains(vec3Position))
                 {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordingAndReplayContainerTypes.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordingAndReplayContainerTypes.cs
@@ -20,7 +20,7 @@ namespace RegressionGames.StateRecorder
     {
 
         public PerformanceMetricData performance;
-        public new List<RecordedGameObjectState> state;
+        public new IEnumerable<RecordedGameObjectState> state;
 
         // re-usable and large enough to fit all sizes
         private static readonly StringBuilder _stringBuilder = new StringBuilder(10_000_000);
@@ -50,11 +50,12 @@ namespace RegressionGames.StateRecorder
             stringBuilder.Append(",\n\"pixelHash\":\"");
             stringBuilder.Append(pixelHash);
             stringBuilder.Append("\",\n\"state\":[\n");
-            var stateCount = state.Count;
-            for (var i = 0; i < stateCount; i++)
+            var counter = 0;
+            var stateCount = state.Count();
+            foreach( var stateEntry in state)
             {
-                state[i].WriteToStringBuilder(stringBuilder);
-                if (i + 1 < stateCount)
+                stateEntry.WriteToStringBuilder(stringBuilder);
+                if (++counter < stateCount)
                 {
                     stringBuilder.Append(",\n");
                 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -71,6 +71,9 @@ namespace RegressionGames.StateRecorder
         private MouseInputActionObserver _mouseObserver;
 
 
+        public static readonly Dictionary<int, RecordedGameObjectState> _emptyStateDictionary = new(0);
+
+
         public static ScreenRecorder GetInstance()
         {
             return _this;
@@ -249,7 +252,7 @@ namespace RegressionGames.StateRecorder
                 {
                     // get the mouse off the screen, when replay fails, we leave the virtual mouse cursor alone so they can see its location at time of failure, but on new recording, we want this gone
                     position = new Vector2Int(Screen.width +20, -20)
-                }, null, new List<RecordedGameObjectState>());
+                }, null, _emptyStateDictionary);
 
                 KeyboardInputActionObserver.GetInstance()?.StartRecording();
                 _mouseObserver.ClearBuffer();
@@ -339,7 +342,7 @@ namespace RegressionGames.StateRecorder
         private readonly List<int> _uiElementsInCurrentFrame = new(1000);
         private readonly Dictionary<int, RecordedGameObjectState> _worldElementsInCurrentFrame = new(1000);
 
-        private void GetKeyFrameType(List<RecordedGameObjectState> priorState, List<RecordedGameObjectState> currentState, string pixelHash)
+        private void GetKeyFrameType(Dictionary<int,RecordedGameObjectState> priorState, Dictionary<int,RecordedGameObjectState> currentState, string pixelHash)
         {
             _keyFrameTypeList.Clear();
             if (priorState == null)
@@ -361,11 +364,8 @@ namespace RegressionGames.StateRecorder
 
             // need to do current before previous due to the world element renderers comparisons
 
-            var currentStateCount = currentState.Count;
-            for (var i = 0; i < currentStateCount; i++)
+            foreach(var recordedGameObjectState in currentState.Values)
             {
-                var recordedGameObjectState = currentState[i];
-
                 var sceneHandle = recordedGameObjectState.scene.handle;
                 // scenes list is normally 1, and almost never beyond single digits.. this check is faster than hashing
                 if (!StateRecorderUtils.OptimizedContainsIntInList(_sceneHandlesInCurrentFrame, sceneHandle))
@@ -387,11 +387,8 @@ namespace RegressionGames.StateRecorder
             bool addedRendererCount = false, addedGameElement = false;
             var worldElementsCount = 0;
             var hadDifferentUIElements = false;
-            var priorStateCount = priorState.Count;
-            for (var i = 0; i < priorStateCount; i++)
+            foreach(var recordedGameObjectState in priorState.Values)
             {
-                var recordedGameObjectState = priorState[i];
-
                 var sceneHandle = recordedGameObjectState.scene.handle;
                 // scenes list is normally 1, and almost never beyond single digits.. this check is faster than hashing
                 if (!StateRecorderUtils.OptimizedContainsIntInList(_sceneHandlesInPriorFrame, sceneHandle))
@@ -553,7 +550,7 @@ namespace RegressionGames.StateRecorder
                             screenSize = new Vector2Int() { x = screenWidth, y = screenHeight },
                             performance = performanceMetrics,
                             pixelHash = pixelHash,
-                            state = currentStates,
+                            state = currentStates.Values,
                             inputs = new InputData()
                             {
                                 keyboard = keyboardInputData,


### PR DESCRIPTION
- Removes duplication of behaviour/collider/rigidbody states on parent objects vs child objects
  - Hand compared old and new states to ensure that things are showing up only once and that everything is still showing up for BossRoom
  - This change improved the performance of `ToJsonString` which runs only on KeyFrame ticks; the improvement is due to the reduction in behaviour json being written to the state (behaviours are the most expensive thing to convert to json)
    - new - 11.78ms , old - 16.31ms 
  - This change also reduced the GC allocs for a KeyFrame tick due to the reduction in state being recorded 
- Adapts prior state code paths to use a dictionary instead of a list to further improve performance with high object counts in a tick
  - This primarily improves the performance of `GetStateForCurrentFrame` which runs on EVERY tick
    - new - 3.04ms , old - 4.71ms

Before this Change
![JSON_AFTER](https://github.com/Regression-Games/RGUnityBots/assets/112959031/83f9536f-3fb6-450e-ae38-a8cba91b1039)

After this Change
![Dictionary_Prior_state_Perf](https://github.com/Regression-Games/RGUnityBots/assets/112959031/ca6376a6-9c09-4b32-8edd-3b34849cfbaf)


---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
