### PR TITLE
[REG-1710] Add sessionId correlators to recording data

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/StringJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/StringJsonConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using Newtonsoft.Json;
 using StateRecorder;
 using UnityEngine;
@@ -7,6 +8,11 @@ namespace RegressionGames.StateRecorder.JsonConverters
 {
     public class StringJsonConverter : Newtonsoft.Json.JsonConverter
     {
+
+        public static void WriteToStringBuilder(StringBuilder stringBuilder, string val)
+        {
+            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder, val);
+        }
 
         public static string ToJsonString(string val)
         {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordingAndReplayContainerTypes.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordingAndReplayContainerTypes.cs
@@ -16,8 +16,12 @@ namespace RegressionGames.StateRecorder
 
     [Serializable]
     [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class FrameStateData : ReplayFrameStateData
+    public class RecordingFrameStateData : BaseFrameStateData
     {
+        /**
+         * <summary>Reference to the original recording this was created from during replay, possibly null</summary>
+         */
+        public string referenceSessionId = null;
 
         public PerformanceMetricData performance;
         public new IEnumerable<RecordedGameObjectState> state;
@@ -27,7 +31,11 @@ namespace RegressionGames.StateRecorder
 
         public void WriteToStringBuilder(StringBuilder stringBuilder)
         {
-            stringBuilder.Append("{\n\"tickNumber\":");
+            stringBuilder.Append("{\n\"sessionId\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, sessionId);
+            stringBuilder.Append(",\n\"referenceSessionId\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, referenceSessionId);
+            stringBuilder.Append(",\n\"tickNumber\":");
             LongJsonConverter.WriteToStringBuilder(stringBuilder, tickNumber);
             stringBuilder.Append(",\n\"keyFrame\":[");
             var keyFrameLength = keyFrame.Length;
@@ -188,8 +196,12 @@ namespace RegressionGames.StateRecorder
     [Serializable]
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     // replay doesn't need to deserialize everything we record
-    public class ReplayFrameStateData
+    public class BaseFrameStateData
     {
+        /**
+         * <summary>UUID of the session</summary>
+         */
+        public string sessionId;
         public long tickNumber;
         public KeyFrameType[] keyFrame;
         public double time;
@@ -198,6 +210,17 @@ namespace RegressionGames.StateRecorder
         public string pixelHash;
         public List<ReplayGameObjectState> state;
         public InputData inputs;
+    }
+
+    [Serializable]
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    // replay doesn't need to deserialize everything we record
+    public class ReplayFrameStateData :BaseFrameStateData
+    {
+        /**
+         * <summary>UUID of the session</summary>
+         */
+        public long recordingSessionId;
     }
 
     public abstract class BaseReplayObjectState

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataContainer.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataContainer.cs
@@ -111,6 +111,8 @@ namespace RegressionGames.StateRecorder
 
     public class ReplayDataContainer
     {
+        public string SessionId { get; private set; } = null;
+
         private readonly Queue<ReplayKeyFrameEntry> _keyFrames = new();
 
         private readonly Queue<ReplayKeyboardInputEntry> _keyboardData = new();
@@ -203,6 +205,11 @@ namespace RegressionGames.StateRecorder
                 var frameData = JsonConvert.DeserializeObject<ReplayFrameStateData>(sr.ReadToEnd());
 
                 firstFrame ??= frameData;
+
+                if (SessionId == null)
+                {
+                    SessionId = frameData.sessionId;
+                }
 
                 // process key frame info
                 ReplayKeyFrameEntry keyFrame = null;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -836,7 +836,7 @@ namespace RegressionGames.StateRecorder
                     _lastStartTime = Time.unscaledTime;
                     _startPlaying = false;
                     _isPlaying = true;
-                    _screenRecorder.StartRecording();
+                    _screenRecorder.StartRecording(_dataContainer.SessionId);
                 }
 
                 if (_isPlaying)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
@@ -177,7 +177,7 @@ namespace Unity.Multiplayer.Samples.BossRoom
                 chooseReplayButton.SetActive(false);
                 recordButton.SetActive(true);
                 recordingPulse.Fast();
-                ScreenRecorder.GetInstance()?.StartRecording();
+                ScreenRecorder.GetInstance()?.StartRecording(null);
             }
         }
 


### PR DESCRIPTION
- Add sessionId and referenceSessionId fields to each tick so that backend data can be queried based on related recordings and replays
- Also adds a method to the StringJsonConverter to make it more consistent with other types

Recording
![Screenshot 2024-04-29 151128](https://github.com/Regression-Games/RGUnityBots/assets/112959031/0a074a1c-6805-4097-a766-a00ff518f5cc)

Replay Recording
![Screenshot 2024-04-29 151119](https://github.com/Regression-Games/RGUnityBots/assets/112959031/ecab47d6-8fbe-48c2-bde9-186fc91d8367)



---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
