### PR TITLE
[REG-1708] Use real paths for UI object clicks

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/AnimatorJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/AnimatorJsonConverter.cs
@@ -19,9 +19,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
         public static void WriteToStringBuilder(StringBuilder stringBuilder, Animator val)
         {
             stringBuilder.Append("{\"controller\":{\"x\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,val.runtimeAnimatorController.name);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, val.runtimeAnimatorController.name);
             stringBuilder.Append(",\"avatar\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,val.avatar.name);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, val.avatar.name);
             stringBuilder.Append(",\"applyRootMotion\":");
             stringBuilder.Append((val.applyRootMotion ? "true" : "false"));
             stringBuilder.Append(",\"updateMode\":\"");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/ImageJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/ImageJsonConverter.cs
@@ -27,11 +27,25 @@ namespace RegressionGames.StateRecorder.JsonConverters
             }
 
             stringBuilder.Append("{\"sourceImage\":");
-            stringBuilder.Append((val.sprite == null ? "null":JsonUtils.EscapeJsonString(val.sprite.name)));
+            if (val.sprite == null)
+            {
+                stringBuilder.Append("null");
+            }
+            else
+            {
+                StringJsonConverter.WriteToStringBuilder(stringBuilder, val.sprite.name);
+            }
             stringBuilder.Append(",\"color\":");
             ColorJsonConverter.WriteToStringBuilder(stringBuilder, val.color);
             stringBuilder.Append(",\"material\":");
-            stringBuilder.Append((val.material == null ? "null":JsonUtils.EscapeJsonString(val.material.name)));
+            if (val.material == null)
+            {
+                stringBuilder.Append("null");
+            }
+            else
+            {
+                StringJsonConverter.WriteToStringBuilder(stringBuilder, val.material.name);
+            }
             stringBuilder.Append(",\"raycastTarget\":");
             stringBuilder.Append((val.raycastTarget ? "true" : "false"));
             stringBuilder.Append(",\"preserveAspect\":");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/MeshFilterJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/MeshFilterJsonConverter.cs
@@ -15,7 +15,14 @@ namespace RegressionGames.StateRecorder.JsonConverters
         public static void WriteToStringBuilder(StringBuilder stringBuilder, MeshFilter val)
         {
             stringBuilder.Append("{\"mesh\":");
-            stringBuilder.Append((val.mesh != null ? JsonUtils.EscapeJsonString(val.mesh.name) : "null"));
+            if (val.mesh == null)
+            {
+                stringBuilder.Append("null");
+            }
+            else
+            {
+                StringJsonConverter.WriteToStringBuilder(stringBuilder, val.mesh.name);
+            }
             stringBuilder.Append("}");
         }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/NavMeshAgentJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/NavMeshAgentJsonConverter.cs
@@ -21,7 +21,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
         public static void WriteToStringBuilder(StringBuilder stringBuilder, NavMeshAgent val)
         {
             stringBuilder.Append("{\"agentType\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,NavMesh.GetSettingsNameFromID(val.agentTypeID));
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, NavMesh.GetSettingsNameFromID(val.agentTypeID));
             stringBuilder.Append("}");
         }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/ParticleSystemJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/ParticleSystemJsonConverter.cs
@@ -16,7 +16,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
         public static void WriteToStringBuilder(StringBuilder stringBuilder, ParticleSystem val)
         {
             stringBuilder.Append("{\"name\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,val.name);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, val.name);
             stringBuilder.Append(",\"isPlaying\":");
             stringBuilder.Append((val.isPlaying ? "true" : "false"));
             stringBuilder.Append("}");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/RawImageJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/RawImageJsonConverter.cs
@@ -26,11 +26,25 @@ namespace RegressionGames.StateRecorder.JsonConverters
             }
 
             stringBuilder.Append("{\"texture\":");
-            stringBuilder.Append((val.texture == null ? "null":JsonUtils.EscapeJsonString(val.texture.name)));
+            if (val.texture == null)
+            {
+                stringBuilder.Append("null");
+            }
+            else
+            {
+                StringJsonConverter.WriteToStringBuilder(stringBuilder, val.texture.name);
+            }
             stringBuilder.Append(",\"color\":");
             ColorJsonConverter.WriteToStringBuilder(stringBuilder, val.color);
             stringBuilder.Append(",\"material\":");
-            stringBuilder.Append((val.material == null ? "null":JsonUtils.EscapeJsonString(val.material.name)));
+            if (val.material == null)
+            {
+                stringBuilder.Append("null");
+            }
+            else
+            {
+                StringJsonConverter.WriteToStringBuilder(stringBuilder, val.material.name);
+            }
             stringBuilder.Append(",\"raycastTarget\":");
             stringBuilder.Append((val.raycastTarget ? "true" : "false"));
             stringBuilder.Append(",\"uvRect\":");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/SkinnedMeshRendererJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/SkinnedMeshRendererJsonConverter.cs
@@ -25,7 +25,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
             var valMaterialLength = val.materials.Length;
             for (var i = 0; i < valMaterialLength; i++)
             {
-                JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,val.materials[i].name);
+                StringJsonConverter.WriteToStringBuilder(stringBuilder, val.materials[i].name);
                 if (i + 1 < valMaterialLength)
                 {
                     stringBuilder.Append(",");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/StringJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/StringJsonConverter.cs
@@ -9,9 +9,76 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class StringJsonConverter : Newtonsoft.Json.JsonConverter
     {
 
-        public static void WriteToStringBuilder(StringBuilder stringBuilder, string val)
+        private static readonly StringBuilder _stringBuilder = new(5_000);
+
+        private static readonly char[] EscapeCharReplacements = new char[128];
+
+        static StringJsonConverter()
         {
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder, val);
+            EscapeCharReplacements['\n'] = 'n';
+            EscapeCharReplacements['\r'] = 'r';
+            EscapeCharReplacements['\t'] = 't';
+            EscapeCharReplacements['\f'] = 'f';
+            EscapeCharReplacements['\b'] = 'b';
+            EscapeCharReplacements['\\'] = '\\';
+            EscapeCharReplacements['"'] = '"';
+        }
+
+        // supports up to 100k char length escaped strings
+        private static char[] _bufferArray = new char[100_000];
+
+        private static int _currentNextIndex = 0;
+
+        public static void WriteToStringBuilder(StringBuilder stringBuilder, string input)
+        {
+            if (input == null)
+            {
+                stringBuilder.Append("null");
+                return;
+            }
+
+            _currentNextIndex = 0;
+            _bufferArray[_currentNextIndex++] = '"';
+
+            var inputLength = input.Length;
+
+            var startIndex = 0;
+            var endIndex = 0;
+            for (var i = 0; i < inputLength; i++)
+            {
+                var ch = input[i];
+                var escapeReplacement = EscapeCharReplacements[ch];
+                if (escapeReplacement == 0)
+                {
+                    // don't need to escape
+                    endIndex = i;
+                }
+                else
+                {
+                    // need to escape.. copy existing range to result
+                    var length = endIndex + 1 - startIndex;
+                    input.CopyTo(startIndex, _bufferArray, _currentNextIndex,length);
+                    _currentNextIndex += length;
+                    // update indexes
+                    endIndex = i + 1;
+                    startIndex = i + 1;
+                    // write the escaped value to the buffer
+                    _bufferArray[_currentNextIndex++] = '\\';
+                    _bufferArray[_currentNextIndex++] = escapeReplacement;
+                }
+            }
+
+            if (startIndex != endIndex)
+            {
+                // got to the end
+                var length = endIndex + 1 - startIndex;
+                input.CopyTo(startIndex, _bufferArray, _currentNextIndex, length);
+                _currentNextIndex += length;
+            }
+
+            _bufferArray[_currentNextIndex++] = '"';
+
+            stringBuilder.Append(_bufferArray, 0, _currentNextIndex);
         }
 
         public static string ToJsonString(string val)
@@ -21,7 +88,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
                 return "null";
             }
 
-            return JsonUtils.EscapeJsonString(val);
+            _stringBuilder.Clear();
+            WriteToStringBuilder(_stringBuilder, val);
+            return _stringBuilder.ToString();
         }
 
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/TextJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/TextJsonConverter.cs
@@ -26,9 +26,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
             }
 
             stringBuilder.Append("{\"text\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,val.text);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, val.text);
             stringBuilder.Append(",\"font\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,val.font.name);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, val.font.name);
             stringBuilder.Append(",\"fontStyle\":\"");
             stringBuilder.Append(val.fontStyle.ToString());
             stringBuilder.Append("\",\"fontSize\":");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/TextMeshProJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/TextMeshProJsonConverter.cs
@@ -26,11 +26,11 @@ namespace RegressionGames.StateRecorder.JsonConverters
             }
 
             stringBuilder.Append("{\"text\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,val.text);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, val.text);
             stringBuilder.Append(",\"textStyle\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,val.textStyle.name);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, val.textStyle.name);
             stringBuilder.Append(",\"font\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,val.font.name);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, val.font.name);
             stringBuilder.Append(",\"fontStyle\":\"");
             stringBuilder.Append(val.fontStyle.ToString());
             stringBuilder.Append("\",\"fontSize\":");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/TextMeshProUGUIJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/TextMeshProUGUIJsonConverter.cs
@@ -26,11 +26,11 @@ namespace RegressionGames.StateRecorder.JsonConverters
             }
 
             stringBuilder.Append("{\"text\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,val.text);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, val.text);
             stringBuilder.Append(",\"textStyle\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,val.textStyle.name);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, val.textStyle.name);
             stringBuilder.Append(",\"font\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,val.font.name);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, val.font.name);
             stringBuilder.Append(",\"fontStyle\":\"");
             stringBuilder.Append(val.fontStyle.ToString());
             stringBuilder.Append("\",\"fontSize\":");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonUtils.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonUtils.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Text;
 using JetBrains.Annotations;
@@ -21,86 +20,6 @@ namespace StateRecorder
 {
     public static class JsonUtils
     {
-
-        private static readonly char[] EscapeCharReplacements = new char[128];
-
-        static JsonUtils()
-        {
-            EscapeCharReplacements['\n'] = 'n';
-            EscapeCharReplacements['\r'] = 'r';
-            EscapeCharReplacements['\t'] = 't';
-            EscapeCharReplacements['\f'] = 'f';
-            EscapeCharReplacements['\b'] = 'b';
-            EscapeCharReplacements['\\'] = '\\';
-            EscapeCharReplacements['"'] = '"';
-        }
-
-        // supports up to 100k char length escaped strings
-        private static char[] _bufferArray = new char[100_000];
-
-        private static int _currentNextIndex = 0;
-
-        public static void EscapeJsonStringIntoStringBuilder(StringBuilder stringBuilder, string input)
-        {
-            if (input == null)
-            {
-                stringBuilder.Append("null");
-                return;
-            }
-
-            _currentNextIndex = 0;
-            _bufferArray[_currentNextIndex++] = '"';
-
-            var inputLength = input.Length;
-
-            var startIndex = 0;
-            var endIndex = 0;
-            for (var i = 0; i < inputLength; i++)
-            {
-                var ch = input[i];
-                var escapeReplacement = EscapeCharReplacements[ch];
-                if (escapeReplacement == 0)
-                {
-                    // don't need to escape
-                    endIndex = i;
-                }
-                else
-                {
-                    // need to escape.. copy existing range to result
-                    var length = endIndex + 1 - startIndex;
-                    input.CopyTo(startIndex, _bufferArray, _currentNextIndex,length);
-                    _currentNextIndex += length;
-                    // update indexes
-                    endIndex = i + 1;
-                    startIndex = i + 1;
-                    // write the escaped value to the buffer
-                    _bufferArray[_currentNextIndex++] = '\\';
-                    _bufferArray[_currentNextIndex++] = escapeReplacement;
-                }
-            }
-
-            if (startIndex != endIndex)
-            {
-                // got to the end
-                var length = endIndex + 1 - startIndex;
-                input.CopyTo(startIndex, _bufferArray, _currentNextIndex, length);
-                _currentNextIndex += length;
-            }
-
-            _bufferArray[_currentNextIndex++] = '"';
-
-            stringBuilder.Append(_bufferArray, 0, _currentNextIndex);
-        }
-
-        private static readonly StringBuilder _stringBuilder = new(5_000);
-
-        public static string EscapeJsonString([CanBeNull] string input)
-        {
-            _stringBuilder.Clear();
-            EscapeJsonStringIntoStringBuilder(_stringBuilder, input);
-            return _stringBuilder.ToString();
-        }
-
 
         private static JsonSerializer _jsonSerializer = null;
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardInputActionObserver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardInputActionObserver.cs
@@ -58,11 +58,11 @@ namespace RegressionGames.StateRecorder
             stringBuilder.Append("{\"startTime\":");
             DoubleJsonConverter.WriteToStringBuilder(stringBuilder, startTime);
             stringBuilder.Append(",\"action\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,action);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, action);
             stringBuilder.Append(",\"binding\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,binding);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, binding);
             stringBuilder.Append(",\"endTime\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,action);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, action);
             DoubleJsonConverter.WriteToStringBuilderNullable(stringBuilder, endTime);
             stringBuilder.Append(",\"isPressed\":");
             stringBuilder.Append(isPressed ? "true" : "false");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardInputActionObserver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardInputActionObserver.cs
@@ -62,7 +62,6 @@ namespace RegressionGames.StateRecorder
             stringBuilder.Append(",\"binding\":");
             StringJsonConverter.WriteToStringBuilder(stringBuilder, binding);
             stringBuilder.Append(",\"endTime\":");
-            StringJsonConverter.WriteToStringBuilder(stringBuilder, action);
             DoubleJsonConverter.WriteToStringBuilderNullable(stringBuilder, endTime);
             stringBuilder.Append(",\"isPressed\":");
             stringBuilder.Append(isPressed ? "true" : "false");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseInputActionObserver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseInputActionObserver.cs
@@ -253,6 +253,7 @@ namespace RegressionGames.StateRecorder
 
         public void ClearBuffer()
         {
+            _priorMouseState = null;
             _mouseInputActions.Clear();
         }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordingAndReplayContainerTypes.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordingAndReplayContainerTypes.cs
@@ -228,6 +228,7 @@ namespace RegressionGames.StateRecorder
         public int id;
 
         public string path;
+        public string normalizedPath;
         public string scene;
         public string tag;
         public string layer;
@@ -262,6 +263,8 @@ namespace RegressionGames.StateRecorder
         public int id;
 
         public string path;
+        public string normalizedPath;
+
         [NonSerialized] // used internally for performance, but serialized as the name
         public Scene scene;
 
@@ -289,13 +292,15 @@ namespace RegressionGames.StateRecorder
             stringBuilder.Append("{\n\"id\":");
             IntJsonConverter.WriteToStringBuilder(stringBuilder, id);
             stringBuilder.Append(",\n\"path\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,path);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, path);
+            stringBuilder.Append(",\n\"normalizedPath\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, normalizedPath);
             stringBuilder.Append(",\n\"scene\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,scene.name);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, scene.name);
             stringBuilder.Append(",\n\"tag\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,tag);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, tag);
             stringBuilder.Append(",\n\"layer\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,layer);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, layer);
             stringBuilder.Append(",\n\"rendererCount\":");
             IntJsonConverter.WriteToStringBuilder(stringBuilder, rendererCount);
             stringBuilder.Append(",\n\"screenSpaceBounds\":");
@@ -349,6 +354,7 @@ namespace RegressionGames.StateRecorder
     {
         public string name;
         public string path;
+        public string normalizedPath;
         public Behaviour state;
 
         public override string ToString()
@@ -359,9 +365,11 @@ namespace RegressionGames.StateRecorder
         public void WriteToStringBuilder(StringBuilder stringBuilder)
         {
             stringBuilder.Append("{\"name\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,name);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, name);
             stringBuilder.Append(",\"path\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,path);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, path);
+            stringBuilder.Append(",\"normalizedPath\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, normalizedPath);
             stringBuilder.Append(",\"state\":");
             JsonUtils.WriteBehaviourStateToStringBuilder(stringBuilder, state);
             stringBuilder.Append("}");
@@ -373,12 +381,15 @@ namespace RegressionGames.StateRecorder
     public class ColliderRecordState
     {
         public string path;
+        public string normalizedPath;
         public Collider collider;
 
         public virtual void WriteToStringBuilder(StringBuilder stringBuilder)
         {
             stringBuilder.Append("{\"path\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,path);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, path);
+            stringBuilder.Append(",\"normalizedPath\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, normalizedPath);
             stringBuilder.Append(",\"is2D\":false");
             stringBuilder.Append(",\"bounds\":");
             BoundsJsonConverter.WriteToStringBuilder(stringBuilder, collider.bounds);
@@ -397,7 +408,9 @@ namespace RegressionGames.StateRecorder
         public override void WriteToStringBuilder(StringBuilder stringBuilder)
         {
             stringBuilder.Append("{\"path\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,path);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, path);
+            stringBuilder.Append(",\"normalizedPath\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, normalizedPath);
             stringBuilder.Append(",\"is2D\":true");
             stringBuilder.Append(",\"bounds\":");
             BoundsJsonConverter.WriteToStringBuilder(stringBuilder, collider.bounds);
@@ -413,6 +426,7 @@ namespace RegressionGames.StateRecorder
     public class ColliderReplayState
     {
         public string path;
+        public string normalizedPath;
         public bool is2D;
         public Bounds bounds;
         public bool isTrigger;
@@ -424,6 +438,7 @@ namespace RegressionGames.StateRecorder
     {
 
         public string path;
+        public string normalizedPath;
 
         // keep a ref to this instead of updating fields every tick
         public Rigidbody rigidbody;
@@ -431,7 +446,9 @@ namespace RegressionGames.StateRecorder
         public virtual void WriteToStringBuilder(StringBuilder stringBuilder)
         {
             stringBuilder.Append("{\"path\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,path);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, path);
+            stringBuilder.Append(",\"normalizedPath\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, normalizedPath);
             stringBuilder.Append(",\"is2D\":false");
             stringBuilder.Append(",\"position\":");
             VectorJsonConverter.WriteToStringBuilderVector3(stringBuilder, rigidbody.position);
@@ -464,7 +481,9 @@ namespace RegressionGames.StateRecorder
         public override void WriteToStringBuilder(StringBuilder stringBuilder)
         {
             stringBuilder.Append("{\"path\":");
-            JsonUtils.EscapeJsonStringIntoStringBuilder(stringBuilder,path);
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, path);
+            stringBuilder.Append(",\"normalizedPath\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, normalizedPath);
             stringBuilder.Append(",\"is2D\":true");
             stringBuilder.Append(",\"position\":");
             VectorJsonConverter.WriteToStringBuilderVector3(stringBuilder, rigidbody.position);
@@ -491,6 +510,7 @@ namespace RegressionGames.StateRecorder
     public class RigidbodyReplayState
     {
         public string path;
+        public string normalizedPath;
 
         public Vector3 position;
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -339,10 +339,10 @@ namespace RegressionGames.StateRecorder
         private readonly List<int> _uiElementsInCurrentFrame = new(1000);
         private readonly Dictionary<int, RecordedGameObjectState> _worldElementsInCurrentFrame = new(1000);
 
-        private void GetKeyFrameType(Dictionary<int,RecordedGameObjectState> priorState, Dictionary<int,RecordedGameObjectState> currentState, string pixelHash)
+        private void GetKeyFrameType(bool firstFrame, Dictionary<int,RecordedGameObjectState> priorState, Dictionary<int,RecordedGameObjectState> currentState, string pixelHash)
         {
             _keyFrameTypeList.Clear();
-            if (priorState == null)
+            if (firstFrame)
             {
                 _keyFrameTypeList.Add(KeyFrameType.FIRST_FRAME );
                 return;
@@ -484,7 +484,7 @@ namespace RegressionGames.StateRecorder
                 var pixelHash = gameFacePixelHashObserver != null ? gameFacePixelHashObserver.GetPixelHash(true) : null;
 
                 // tell if the new frame is a key frame or the first frame (always a key frame)
-                GetKeyFrameType(priorStates, currentStates, pixelHash);
+                GetKeyFrameType(_tickNumber ==0, priorStates, currentStates, pixelHash);
 
                 // estimating the time in int milliseconds .. won't exactly match target FPS.. but will be close
                 if (_keyFrameTypeList.Count > 0


### PR DESCRIPTION
- Now writes the 'true' path to `path` and the 'normalized' path (what we had before without uniqueness numbers) to `normalizedPath`...
  **- This is NOT strictly backwards compatible, but in a non-breaking way... The data in `path` is similar, but not the same from the client UI perspective**
  - This negatively impacts performance as we are now computing and writing out 2 similar strings for every object... if we determine that we don't need this on the Client UI, I'd LOVE to remove `normalizedPath` as I can compute it on replay load easily for handling mouse clicks ... if we remove it though.. similar game objects cloned from prefabs will no longer have the same `normalizedPath` to work from in the client UI validations
- Uses the `normalizedPath` for game object and `path` for UI objects to properly handle weird UI resolution scaling changes like BossRoom has
- Further cleans up String to Json patterns
- Fixes some bugs on mouse replay clicks when doing multiple recordings or replays in the same game engine run 
- Fixes a copy/pasta issue with the JSON for keyboard inputs

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
