### PR TITLE
[REG-1737] Enable State Recording Feature By Default

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGSettings.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGSettings.cs
@@ -29,7 +29,7 @@ namespace RegressionGames
         [SerializeField] private DebugLogLevel logLevel;
         // ReSharper disable once InconsistentNaming
         [SerializeField] private bool feature_StateRecordingAndReplay;
-        
+
         // Authentication settings
         [SerializeField] private string rgHostAddress;
         [SerializeField] private string apiKey;
@@ -64,7 +64,7 @@ namespace RegressionGames
                 _settings.rgHostAddress = "https://play.regression.gg";
                 _settings.logLevel = DebugLogLevel.Info;
 
-                _settings.feature_StateRecordingAndReplay = false;
+                _settings.feature_StateRecordingAndReplay = true;
 #if UNITY_EDITOR
                 Directory.CreateDirectory(SETTINGS_DIRECTORY);
                 AssetDatabase.CreateAsset(_settings, SETTINGS_PATH);
@@ -94,7 +94,7 @@ namespace RegressionGames
                 // if not called on main thread this will exception
             }
         }
-        
+
 #if UNITY_EDITOR
         public static SerializedObject GetSerializedSettings()
         {
@@ -122,8 +122,8 @@ namespace RegressionGames
         {
             return logLevel;
         }
-        
-        public string GetApiKey() 
+
+        public string GetApiKey()
         {
             return apiKey;
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -129,7 +129,7 @@ namespace RegressionGames.StateRecorder
                 KeyboardInputActionObserver.GetInstance()?.StopRecording();
                 _mouseObserver.ClearBuffer();
                 _isRecording = false;
-                _ = HandleEndRecording(_tickNumber, _startTime, DateTime.Now, _currentGameplaySessionDataDirectoryPrefix, _currentGameplaySessionScreenshotsDirectoryPrefix, _currentGameplaySessionThumbnailPath);
+                _ = HandleEndRecording(_tickNumber, _startTime, DateTime.Now, _currentGameplaySessionDataDirectoryPrefix, _currentGameplaySessionScreenshotsDirectoryPrefix, _currentGameplaySessionThumbnailPath, true);
             }
         }
 
@@ -141,7 +141,7 @@ namespace RegressionGames.StateRecorder
             RGDebug.LogInfo( "Supported Formats for Readback\n" + string.Join( "\n", read_formats ) );
         }
 
-        private async Task HandleEndRecording(long tickCount, DateTime startTime, DateTime endTime, string dataDirectoryPrefix, string screenshotsDirectoryPrefix, string thumbnailPath)
+        private async Task HandleEndRecording(long tickCount, DateTime startTime, DateTime endTime, string dataDirectoryPrefix, string screenshotsDirectoryPrefix, string thumbnailPath, bool onDestroy = false)
         {
             StartCoroutine(ShowUploadingIndicator(true));
 
@@ -172,10 +172,10 @@ namespace RegressionGames.StateRecorder
             Directory.Delete(dataDirectoryPrefix, true);
             Directory.Delete(screenshotsDirectoryPrefix, true);
 
-            await CreateAndUploadGameplaySession(tickCount, startTime, endTime, dataDirectoryPrefix, screenshotsDirectoryPrefix, thumbnailPath);
+            await CreateAndUploadGameplaySession(tickCount, startTime, endTime, dataDirectoryPrefix, screenshotsDirectoryPrefix, thumbnailPath, onDestroy);
         }
 
-        private async Task CreateAndUploadGameplaySession(long tickCount, DateTime startTime, DateTime endTime, string dataDirectoryPrefix, string screenshotsDirectoryPrefix, string thumbnailPath)
+        private async Task CreateAndUploadGameplaySession(long tickCount, DateTime startTime, DateTime endTime, string dataDirectoryPrefix, string screenshotsDirectoryPrefix, string thumbnailPath, bool onDestroy = false)
         {
 
             try
@@ -223,13 +223,10 @@ namespace RegressionGames.StateRecorder
             }
             finally
             {
-                try
+                if (!onDestroy)
                 {
+                    // only do this when the game object is still alive :D
                     StartCoroutine(ShowUploadingIndicator(false));
-                }
-                catch (Exception)
-                {
-                    // on destroy, this throws an error because the overlay is going away.. don't need to log that and mess-up/crash people's game
                 }
             }
         }
@@ -608,7 +605,7 @@ namespace RegressionGames.StateRecorder
 
                             _screenShotTexture = new RenderTexture(screenWidth, screenHeight, 0);
                         }
-                        
+
                         var graphicsFormat = _screenShotTexture.graphicsFormat;
 
                         // wait for end of frame before capturing screenshot

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -143,7 +143,10 @@ namespace RegressionGames.StateRecorder
 
         private async Task HandleEndRecording(long tickCount, DateTime startTime, DateTime endTime, string dataDirectoryPrefix, string screenshotsDirectoryPrefix, string thumbnailPath, bool onDestroy = false)
         {
-            StartCoroutine(ShowUploadingIndicator(true));
+            if (!onDestroy)
+            {
+                StartCoroutine(ShowUploadingIndicator(true));
+            }
 
             var zipTask1 = Task.Run(() =>
             {


### PR DESCRIPTION
- Enables state recording feature by default
- Makes another attempt at hiding the coroutine error on destroy

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
