### PR TITLE
[REG-1729] Capture memory and CPU utilization

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlayCanvasV2.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlayCanvasV2.prefab
@@ -4790,6 +4790,7 @@ GameObject:
   - component: {fileID: 3883112371070943306}
   - component: {fileID: 4232611005985544413}
   - component: {fileID: 2671455581720235337}
+  - component: {fileID: 737870763864748897}
   - component: {fileID: 5707023808762380029}
   - component: {fileID: 681669965379170089}
   - component: {fileID: 6035108432500259904}
@@ -4942,6 +4943,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c3bb809bb42a4a3cb5fd77cae025afea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &737870763864748897
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7029756735420670719}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 037ecbfa24734e4dbff49f5e3d3183be, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &5707023808762380029

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ProfilerObserver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ProfilerObserver.cs
@@ -12,7 +12,7 @@ namespace StateRecorder
         // Used heap size (in bytes) that is garbage collected
         public long? gcUsedMemory;
 
-        // Time spent (in nanoseconds) by the CPU on the main thread since the last tick
+        // Time spent (in milliseconds) by the CPU on the main thread since the last tick
         public double? cpuTimeSincePreviousTick;
     }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ProfilerObserver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ProfilerObserver.cs
@@ -12,8 +12,8 @@ namespace StateRecorder
         // Used heap size (in bytes) that is garbage collected
         public long? gcUsedMemory;
 
-        // Time spent (in milliseconds) by the CPU on the main thread since the last tick
-        public double? cpuTimeSincePreviousTick;
+        // Time spent (in nanoseconds) by the CPU on the main thread since the last tick
+        public long? cpuTimeSincePreviousTick;
     }
 
     public class ProfilerObserver : MonoBehaviour
@@ -52,9 +52,9 @@ namespace StateRecorder
         /**
          * Computes the sum of the last N values of the round-robin sample buffer.
          */
-        private static double SumOfLastFrames(ProfilerRecorder recorder, List<ProfilerRecorderSample> samples, int numFrames, out int framesRead)
+        private static long SumOfLastFrames(ProfilerRecorder recorder, List<ProfilerRecorderSample> samples, int numFrames, out int framesRead)
         {
-            double sum = 0.0;
+            long sum = 0;
             framesRead = 0;
             for (int frameIndex = recorder.Count - 1; frameIndex >= 0 && framesRead < numFrames; --frameIndex)
             {
@@ -90,11 +90,11 @@ namespace StateRecorder
                 _cpuTimeSampleBuf.Clear();
                 _cpuTimeRecorder.CopyTo(_cpuTimeSampleBuf);
                 int framesRead;
-                double cpuTime = SumOfLastFrames(_cpuTimeRecorder, _cpuTimeSampleBuf, frameCountSinceLastTick,
+                long cpuTime = SumOfLastFrames(_cpuTimeRecorder, _cpuTimeSampleBuf, frameCountSinceLastTick,
                     out framesRead);
                 if (framesRead == frameCountSinceLastTick) // only report the total cpuTime if there were sufficient frames recorded for the request
                 {
-                    result.cpuTimeSincePreviousTick = cpuTime * 1e-6; // convert to milliseconds
+                    result.cpuTimeSincePreviousTick = cpuTime;
                 }
             }
             return result;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ProfilerObserver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ProfilerObserver.cs
@@ -1,4 +1,5 @@
-﻿using Unity.Profiling;
+﻿using System.Collections.Generic;
+using Unity.Profiling;
 using UnityEngine;
 
 namespace StateRecorder
@@ -8,19 +9,28 @@ namespace StateRecorder
         // Amount of memory (in bytes) the operating system reports in use by the application
         public long? systemUsedMemory;
 
-        // Time spent (in nanoseconds) by the CPU on the main thread on the current frame
-        public long? cpuTime;
+        // Used heap size (in bytes) that is garbage collected
+        public long? gcUsedMemory;
+
+        // Time spent (in nanoseconds) by the CPU on the main thread since the last tick
+        public double? cpuTimeSincePreviousTick;
     }
 
     public class ProfilerObserver : MonoBehaviour
     {
+        private const int MAX_FRAMES_ACCUM = 16384;
+
         private ProfilerRecorder _systemMemoryRecorder;
+        private ProfilerRecorder _gcMemoryRecorder;
         private ProfilerRecorder _cpuTimeRecorder;
+        private List<ProfilerRecorderSample> _cpuTimeSampleBuf;
 
         public void StartProfiling()
         {
             _systemMemoryRecorder = ProfilerRecorder.StartNew(ProfilerCategory.Memory, "System Used Memory");
-            _cpuTimeRecorder = ProfilerRecorder.StartNew(ProfilerCategory.Internal, "Main Thread");
+            _gcMemoryRecorder = ProfilerRecorder.StartNew(ProfilerCategory.Memory, "GC Used Memory");
+            _cpuTimeRecorder = ProfilerRecorder.StartNew(ProfilerCategory.Internal, "Main Thread", MAX_FRAMES_ACCUM);
+            _cpuTimeSampleBuf = new List<ProfilerRecorderSample>(MAX_FRAMES_ACCUM);
         }
 
         public void StopProfiling()
@@ -29,22 +39,63 @@ namespace StateRecorder
             {
                 _systemMemoryRecorder.Dispose();
             }
+            if (_gcMemoryRecorder.Valid)
+            {
+                _gcMemoryRecorder.Dispose();
+            }
             if (_cpuTimeRecorder.Valid)
             {
                 _cpuTimeRecorder.Dispose();
             }
         }
 
-        public ProfilerObserverResult SampleProfiler()
+        /**
+         * Computes the sum of the last N values of the round-robin sample buffer.
+         */
+        private static double SumOfLastFrames(ProfilerRecorder recorder, List<ProfilerRecorderSample> samples, int numFrames, out int framesRead)
+        {
+            double sum = 0.0;
+            framesRead = 0;
+            for (int frameIndex = recorder.Count - 1; frameIndex >= 0 && framesRead < numFrames; --frameIndex)
+            {
+                sum += samples[frameIndex].Value;
+                ++framesRead;
+            }
+            if (framesRead < numFrames && recorder.WrappedAround)
+            {
+                for (int frameIndex = samples.Count - 1, lastIndex = recorder.Count;
+                     frameIndex >= lastIndex && framesRead < numFrames;
+                     --frameIndex)
+                {
+                    sum += samples[frameIndex].Value;
+                    ++framesRead;
+                }
+            }
+            return sum;
+        }
+
+        public ProfilerObserverResult SampleProfiler(int frameCountSinceLastTick)
         {
             ProfilerObserverResult result = new ProfilerObserverResult();
-            if (_systemMemoryRecorder.Valid)
+            if (_systemMemoryRecorder.Valid && _systemMemoryRecorder.Count > 0)
             {
                 result.systemUsedMemory = _systemMemoryRecorder.LastValue;
             }
+            if (_gcMemoryRecorder.Valid && _gcMemoryRecorder.Count > 0)
+            {
+                result.gcUsedMemory = _gcMemoryRecorder.LastValue;
+            }
             if (_cpuTimeRecorder.Valid)
             {
-                result.cpuTime = _cpuTimeRecorder.LastValue;
+                _cpuTimeSampleBuf.Clear();
+                _cpuTimeRecorder.CopyTo(_cpuTimeSampleBuf);
+                int framesRead;
+                double cpuTime = SumOfLastFrames(_cpuTimeRecorder, _cpuTimeSampleBuf, frameCountSinceLastTick,
+                    out framesRead);
+                if (framesRead == frameCountSinceLastTick) // only report the total cpuTime if there were sufficient frames recorded for the request
+                {
+                    result.cpuTimeSincePreviousTick = cpuTime * 1e-6; // convert to milliseconds
+                }
             }
             return result;
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ProfilerObserver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ProfilerObserver.cs
@@ -1,0 +1,52 @@
+﻿using Unity.Profiling;
+using UnityEngine;
+
+namespace StateRecorder
+{
+    public struct ProfilerObserverResult
+    {
+        // Amount of memory (in bytes) the operating system reports in use by the application
+        public long? systemUsedMemory;
+
+        // Time spent (in nanoseconds) by the CPU on the main thread on the current frame
+        public long? cpuTime;
+    }
+
+    public class ProfilerObserver : MonoBehaviour
+    {
+        private ProfilerRecorder _systemMemoryRecorder;
+        private ProfilerRecorder _cpuTimeRecorder;
+
+        public void StartProfiling()
+        {
+            _systemMemoryRecorder = ProfilerRecorder.StartNew(ProfilerCategory.Memory, "System Used Memory");
+            _cpuTimeRecorder = ProfilerRecorder.StartNew(ProfilerCategory.Internal, "Main Thread");
+        }
+
+        public void StopProfiling()
+        {
+            if (_systemMemoryRecorder.Valid)
+            {
+                _systemMemoryRecorder.Dispose();
+            }
+            if (_cpuTimeRecorder.Valid)
+            {
+                _cpuTimeRecorder.Dispose();
+            }
+        }
+
+        public ProfilerObserverResult SampleProfiler()
+        {
+            ProfilerObserverResult result = new ProfilerObserverResult();
+            if (_systemMemoryRecorder.Valid)
+            {
+                result.systemUsedMemory = _systemMemoryRecorder.LastValue;
+            }
+            if (_cpuTimeRecorder.Valid)
+            {
+                result.cpuTime = _cpuTimeRecorder.LastValue;
+            }
+            return result;
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ProfilerObserver.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ProfilerObserver.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 037ecbfa24734e4dbff49f5e3d3183be
+timeCreated: 1715723169

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordingAndReplayContainerTypes.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordingAndReplayContainerTypes.cs
@@ -123,6 +123,8 @@ namespace RegressionGames.StateRecorder
         public double previousTickTime;
         public int framesSincePreviousTick;
         public int fps;
+        public long? cpuTime;
+        public long? memory;
         public EngineStatsData engineStats;
 
         public void WriteToStringBuilder(StringBuilder stringBuilder)
@@ -133,6 +135,16 @@ namespace RegressionGames.StateRecorder
             IntJsonConverter.WriteToStringBuilder(stringBuilder, framesSincePreviousTick);
             stringBuilder.Append(",\"fps\":");
             IntJsonConverter.WriteToStringBuilder(stringBuilder, fps);
+            if (cpuTime.HasValue)
+            {
+                stringBuilder.Append(",\"cpuTime\":");
+                LongJsonConverter.WriteToStringBuilder(stringBuilder, cpuTime.Value);
+            }
+            if (memory.HasValue)
+            {
+                stringBuilder.Append(",\"memory\":");
+                LongJsonConverter.WriteToStringBuilder(stringBuilder, memory.Value);
+            }
             stringBuilder.Append(",\"engineStats\":");
             engineStats.WriteToStringBuilder(stringBuilder);
             stringBuilder.Append("}");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordingAndReplayContainerTypes.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordingAndReplayContainerTypes.cs
@@ -123,8 +123,9 @@ namespace RegressionGames.StateRecorder
         public double previousTickTime;
         public int framesSincePreviousTick;
         public int fps;
-        public long? cpuTime;
+        public double? cpuTimeSincePreviousTick;
         public long? memory;
+        public long? gcMemory;
         public EngineStatsData engineStats;
 
         public void WriteToStringBuilder(StringBuilder stringBuilder)
@@ -135,16 +136,12 @@ namespace RegressionGames.StateRecorder
             IntJsonConverter.WriteToStringBuilder(stringBuilder, framesSincePreviousTick);
             stringBuilder.Append(",\"fps\":");
             IntJsonConverter.WriteToStringBuilder(stringBuilder, fps);
-            if (cpuTime.HasValue)
-            {
-                stringBuilder.Append(",\"cpuTime\":");
-                LongJsonConverter.WriteToStringBuilder(stringBuilder, cpuTime.Value);
-            }
-            if (memory.HasValue)
-            {
-                stringBuilder.Append(",\"memory\":");
-                LongJsonConverter.WriteToStringBuilder(stringBuilder, memory.Value);
-            }
+            stringBuilder.Append(",\"cpuTimeSincePreviousTick\":");
+            DoubleJsonConverter.WriteToStringBuilderNullable(stringBuilder, cpuTimeSincePreviousTick);
+            stringBuilder.Append(",\"memory\":");
+            LongJsonConverter.WriteToStringBuilderNullable(stringBuilder, memory);
+            stringBuilder.Append(",\"gcMemory\":");
+            LongJsonConverter.WriteToStringBuilderNullable(stringBuilder, gcMemory);
             stringBuilder.Append(",\"engineStats\":");
             engineStats.WriteToStringBuilder(stringBuilder);
             stringBuilder.Append("}");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordingAndReplayContainerTypes.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordingAndReplayContainerTypes.cs
@@ -123,7 +123,7 @@ namespace RegressionGames.StateRecorder
         public double previousTickTime;
         public int framesSincePreviousTick;
         public int fps;
-        public double? cpuTimeSincePreviousTick;
+        public long? cpuTimeSincePreviousTick;
         public long? memory;
         public long? gcMemory;
         public EngineStatsData engineStats;
@@ -137,7 +137,7 @@ namespace RegressionGames.StateRecorder
             stringBuilder.Append(",\"fps\":");
             IntJsonConverter.WriteToStringBuilder(stringBuilder, fps);
             stringBuilder.Append(",\"cpuTimeSincePreviousTick\":");
-            DoubleJsonConverter.WriteToStringBuilderNullable(stringBuilder, cpuTimeSincePreviousTick);
+            LongJsonConverter.WriteToStringBuilderNullable(stringBuilder, cpuTimeSincePreviousTick);
             stringBuilder.Append(",\"memory\":");
             LongJsonConverter.WriteToStringBuilderNullable(stringBuilder, memory);
             stringBuilder.Append(",\"gcMemory\":");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -521,7 +521,7 @@ namespace RegressionGames.StateRecorder
                     var screenWidth = Screen.width;
                     var screenHeight = Screen.height;
 
-                    ProfilerObserverResult profilerResult = _profilerObserver.SampleProfiler();
+                    ProfilerObserverResult profilerResult = _profilerObserver.SampleProfiler(_frameCountSinceLastTick);
 
                     try
                     {
@@ -532,8 +532,9 @@ namespace RegressionGames.StateRecorder
                             framesSincePreviousTick = _frameCountSinceLastTick,
                             previousTickTime = _lastCvFrameTime,
                             fps = (int)(_frameCountSinceLastTick / (time - _lastCvFrameTime)),
-                            cpuTime = profilerResult.cpuTime,
+                            cpuTimeSincePreviousTick = profilerResult.cpuTimeSincePreviousTick,
                             memory = profilerResult.systemUsedMemory,
+                            gcMemory = profilerResult.gcUsedMemory,
                             engineStats = new EngineStatsData()
                             {
 #if UNITY_EDITOR

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -68,6 +68,7 @@ namespace RegressionGames.StateRecorder
 #endif
 
         private MouseInputActionObserver _mouseObserver;
+        private ProfilerObserver _profilerObserver;
 
 
         public static readonly Dictionary<int, RecordedGameObjectState> _emptyStateDictionary = new(0);
@@ -101,6 +102,7 @@ namespace RegressionGames.StateRecorder
         public void OnEnable()
         {
             _this._mouseObserver = GetComponent<MouseInputActionObserver>();
+            _this._profilerObserver = GetComponent<ProfilerObserver>();
         }
 
         private void OnDestroy()
@@ -126,6 +128,7 @@ namespace RegressionGames.StateRecorder
                 {
                     gameFacePixelHashObserver.SetActive(false);
                 }
+                _profilerObserver.StopProfiling();
                 KeyboardInputActionObserver.GetInstance()?.StopRecording();
                 _mouseObserver.ClearBuffer();
                 _isRecording = false;
@@ -270,6 +273,7 @@ namespace RegressionGames.StateRecorder
                 }, null, _emptyStateDictionary);
 
                 KeyboardInputActionObserver.GetInstance()?.StartRecording();
+                _profilerObserver.StartProfiling();
                 _mouseObserver.ClearBuffer();
                 InGameObjectFinder.GetInstance()?.Cleanup();
                 _isRecording = true;
@@ -517,6 +521,8 @@ namespace RegressionGames.StateRecorder
                     var screenWidth = Screen.width;
                     var screenHeight = Screen.height;
 
+                    ProfilerObserverResult profilerResult = _profilerObserver.SampleProfiler();
+
                     try
                     {
                         ++_tickNumber;
@@ -526,6 +532,8 @@ namespace RegressionGames.StateRecorder
                             framesSincePreviousTick = _frameCountSinceLastTick,
                             previousTickTime = _lastCvFrameTime,
                             fps = (int)(_frameCountSinceLastTick / (time - _lastCvFrameTime)),
+                            cpuTime = profilerResult.cpuTime,
+                            memory = profilerResult.systemUsedMemory,
                             engineStats = new EngineStatsData()
                             {
 #if UNITY_EDITOR


### PR DESCRIPTION
This is the bare minimum implementation of capturing CPU utilization (in terms of time spent on the main thread), and memory utilization (amount of bytes the operating system reports in use by the application). 

This uses the [ProfilerRecorder](https://docs.unity3d.com/ScriptReference/Unity.Profiling.ProfilerRecorder.html) API available in recent versions of Unity (2021.3+). It begins profiling when the recording starts, and stops profiling when the recording ends. 

The memory usage is obtained via reading the profiler counter for *System Used Memory* (which is defined by the Unity docs as the memory usage reported by the OS: https://docs.unity3d.com/Manual/ProfilerMemory.html). 

CPU time is obtained in terms of nanoseconds spent on the main thread. The "Main Thread" stat appears to be the best one I can find for measuring this based on my read of https://docs.unity3d.com/ScriptReference/Unity.Profiling.ProfilerRecorder.html and https://docs.unity3d.com/Manual/ProfilerCPU.html.

I have tested this both in-editor and in standalone build and have been able to get the CPU time and memory to appear in the state dump JSON files. Links to example JSON files:
[In-Editor](https://github.com/Regression-Games/RGUnityBots/files/15326121/5.json)
[Standalone](https://github.com/Regression-Games/RGUnityBots/files/15326123/5.json)

Some considerations that may need further discussion:
1. Is it reasonable to require Unity 2021.3+ to support this approach to profiling, given that this is a newer API? Should macros be added to check the Unity version and conditionally disable the profiler for older versions?
2. Is "time spent on the main thread per frame" a reasonable metric for CPU usage, or were the clients looking for something more like core percentage reported by the OS? (I do not see a way to directly obtain the latter via this API, but perhaps it could be approximated).
3. The profiler gives very different results for in-editor vs standalone builds, due to its stats including both the game and editor.
4. Because the profiler is started only when the recording starts, the CPU/memory usage on the first frame is listed as zero. 
5. For CPU time, this implementation currently only reads the last frame, however this can fluctuate a lot across frames. Would it be better to instead report an average of the last N frame's times (or since the last tick)?
6. There are a *lot* of profile markers/counters available via this API. It could be worth exploring making it a configurable setting to specify which are of interest. Here is a list I extracted via the API: [profiler.txt](https://github.com/Regression-Games/RGUnityBots/files/15326168/profiler.txt)


---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
