### PR TITLE
[REG-1768] Change timing of keyboard inputs and input events

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -579,18 +579,18 @@ namespace RegressionGames.StateRecorder
             {
                 foreach (var replayKeyboardInputEntry in _keyboardQueue)
                 {
-                    if (!replayKeyboardInputEntry.startEndSentFlags[1] && currentTime >= replayKeyboardInputEntry.endTime)
-                    {
-                        // send end event
-                        SendKeyEvent(replayKeyboardInputEntry.tickNumber, replayKeyboardInputEntry.key, KeyState.Up);
-                        replayKeyboardInputEntry.startEndSentFlags[1] = true;
-                    }
-
                     if (!replayKeyboardInputEntry.startEndSentFlags[0] && currentTime >= replayKeyboardInputEntry.startTime)
                     {
                         // send start event
                         SendKeyEvent(replayKeyboardInputEntry.tickNumber, replayKeyboardInputEntry.key, KeyState.Down);
                         replayKeyboardInputEntry.startEndSentFlags[0] = true;
+                    }
+
+                    if (!replayKeyboardInputEntry.startEndSentFlags[1] && currentTime >= replayKeyboardInputEntry.endTime)
+                    {
+                        // send end event
+                        SendKeyEvent(replayKeyboardInputEntry.tickNumber, replayKeyboardInputEntry.key, KeyState.Up);
+                        replayKeyboardInputEntry.startEndSentFlags[1] = true;
                     }
                 }
             }
@@ -1078,7 +1078,13 @@ namespace RegressionGames.StateRecorder
                         _screenRecorder.StartRecording(_dataContainer.SessionId);
                     }
                 }
+            }
+        }
 
+        public void LateUpdate()
+        {
+            if (_dataContainer != null)
+            {
                 if (_isPlaying)
                 {
                     var states = InGameObjectFinder.GetInstance()?.GetStateForCurrentFrame(true);


### PR DESCRIPTION
- Changes things so that start and end keyboard events can be sent on same frame; also fixes the bug where sometimes they could send in the wrong order
- Moves the sending of input event from Update to LateUpdate so that they will start sending 1 frame sooner than before in most cases.

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
