### PR TITLE
[REG-1763] Support mouse inputs handled via MonoBehaviour methods + instrumentation bugfix

### DIFF
--- a/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
@@ -52,10 +52,9 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
             // ignore plugin packages referenced by the RG package
             if (rgAssembly != null)
             {
-                string fullAssemblyPath = Path.GetFullPath(assemblyPath);
                 foreach (string asmPath in rgAssembly.allReferences)
                 {
-                    if (Path.GetFullPath(asmPath) == fullAssemblyPath)
+                    if (Path.GetFileName(asmPath) == fileName)
                     {
                         return true;
                     }
@@ -234,12 +233,11 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
 
         private static Assembly FindRGAssembly()
         {
-            var rgAsmPath = Path.GetFullPath(typeof(RGLegacyInputWrapper).Assembly.Location);
+            var rgAsmName = Path.GetFileName(typeof(RGLegacyInputWrapper).Assembly.Location);
             Assembly[] assemblies = CompilationPipeline.GetAssemblies(AssembliesType.PlayerWithoutTestAssemblies);
             foreach (Assembly assembly in assemblies)
             {
-                string asmPath = Path.GetFullPath(assembly.outputPath);
-                if (asmPath == rgAsmPath)
+                if (Path.GetFileName(assembly.outputPath) == rgAsmName)
                 {
                     return assembly;
                 }


### PR DESCRIPTION
This PR introduces support for simulating inputs for the legacy input mouse event handlers found in MonoBehaviour methods:
`OnMouseDown()`
`OnMouseDrag()`
`OnMouseEnter()`
`OnMouseExit()`
`OnMouseOver()`
`OnMouseUp()`
`OnMouseUpAsButton()`

This emulates the same logic used by the Unity runtime for invoking these methods. The Unity engine handles these in the same module as the legacy input handling APIs, so I consider them to be part of the legacy input as well and implement their handling in the `RGLegacyInputWrapper` event loop.

Also, this PR includes a small bugfix/optimization for the legacy input instrumentation to compare assemblies by name instead of path (this was causing unnecessary assemblies to be processed when creating standalone builds, since the assembly output path changes for these).

Test cases (these games can be found in LegacyInputGames):
AngryBirds:
https://www.loom.com/share/2dccda235ab946378c771228f3abd973

Match3:
https://www.loom.com/share/d7a0c9842b354219969fbe913f84f5ca
_Caveat for Match3_: The click correction was causing the playback to miss for this game, so for this one I was just using the simple record/playback [script](https://gist.github.com/svolokh/60f3afefef35cd2d9e6cdf25273fbb11) I made a while ago. Perhaps an issue worth investigating at some point. Regardless, this illustrates that the legacy input simulation is working.

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
