### PR TITLE
[REG-1780] Remove paths from child elements

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
@@ -92,8 +92,6 @@ namespace RegressionGames.StateRecorder
                         cObject = new ColliderRecordState();
                     }
 
-                    cObject.path = transformStatus.Path;
-                    cObject.normalizedPath = transformStatus.NormalizedPath;
                     cObject.collider = colliderEntry;
 
                     collidersState.Add(cObject);
@@ -113,8 +111,6 @@ namespace RegressionGames.StateRecorder
                         cObject = new Collider2DRecordState();
                     }
 
-                    cObject.path = transformStatus.Path;
-                    cObject.normalizedPath = transformStatus.NormalizedPath;
                     cObject.collider = colliderEntry2D;
 
                     collidersState.Add(cObject);
@@ -134,8 +130,6 @@ namespace RegressionGames.StateRecorder
                         cObject = new RigidbodyRecordState();
                     }
 
-                    cObject.path = transformStatus.Path;
-                    cObject.normalizedPath = transformStatus.NormalizedPath;
                     cObject.rigidbody = myRigidbody;
 
                     rigidbodiesState.Add(cObject);
@@ -155,8 +149,6 @@ namespace RegressionGames.StateRecorder
                         cObject = new Rigidbody2DRecordState();
                     }
 
-                    cObject.path = transformStatus.Path;
-                    cObject.normalizedPath = transformStatus.NormalizedPath;
                     cObject.rigidbody = myRigidbody2D;
 
                     rigidbodiesState.Add(cObject);
@@ -176,8 +168,6 @@ namespace RegressionGames.StateRecorder
                         cObject = new BehaviourState();
                     }
 
-                    cObject.path = transformStatus.Path;
-                    cObject.normalizedPath = transformStatus.NormalizedPath;
                     cObject.name = childBehaviour.GetType().FullName;
                     cObject.state = childBehaviour;
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/BehaviourState.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/BehaviourState.cs
@@ -11,8 +11,6 @@ namespace RegressionGames.StateRecorder.Models
     public class BehaviourState
     {
         public string name;
-        public string path;
-        public string normalizedPath;
         public Behaviour state;
 
         public override string ToString()
@@ -24,10 +22,6 @@ namespace RegressionGames.StateRecorder.Models
         {
             stringBuilder.Append("{\"name\":");
             StringJsonConverter.WriteToStringBuilder(stringBuilder, name);
-            stringBuilder.Append(",\"path\":");
-            StringJsonConverter.WriteToStringBuilder(stringBuilder, path);
-            stringBuilder.Append(",\"normalizedPath\":");
-            StringJsonConverter.WriteToStringBuilder(stringBuilder, normalizedPath);
             stringBuilder.Append(",\"state\":");
             JsonUtils.WriteBehaviourStateToStringBuilder(stringBuilder, state);
             stringBuilder.Append("}");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/Collider2DRecordState.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/Collider2DRecordState.cs
@@ -14,11 +14,7 @@ namespace RegressionGames.StateRecorder.Models
 
         public override void WriteToStringBuilder(StringBuilder stringBuilder)
         {
-            stringBuilder.Append("{\"path\":");
-            StringJsonConverter.WriteToStringBuilder(stringBuilder, path);
-            stringBuilder.Append(",\"normalizedPath\":");
-            StringJsonConverter.WriteToStringBuilder(stringBuilder, normalizedPath);
-            stringBuilder.Append(",\"is2D\":true");
+            stringBuilder.Append("{\"is2D\":true");
             stringBuilder.Append(",\"bounds\":");
             BoundsJsonConverter.WriteToStringBuilder(stringBuilder, collider.bounds);
             stringBuilder.Append(",\"isTrigger\":");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/ColliderRecordState.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/ColliderRecordState.cs
@@ -10,17 +10,11 @@ namespace RegressionGames.StateRecorder.Models
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public class ColliderRecordState
     {
-        public string path;
-        public string normalizedPath;
         public Collider collider;
 
         public virtual void WriteToStringBuilder(StringBuilder stringBuilder)
         {
-            stringBuilder.Append("{\"path\":");
-            StringJsonConverter.WriteToStringBuilder(stringBuilder, path);
-            stringBuilder.Append(",\"normalizedPath\":");
-            StringJsonConverter.WriteToStringBuilder(stringBuilder, normalizedPath);
-            stringBuilder.Append(",\"is2D\":false");
+            stringBuilder.Append("{\"is2D\":false");
             stringBuilder.Append(",\"bounds\":");
             BoundsJsonConverter.WriteToStringBuilder(stringBuilder, collider.bounds);
             stringBuilder.Append(",\"isTrigger\":");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/Rigidbody2DRecordState.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/Rigidbody2DRecordState.cs
@@ -16,11 +16,7 @@ namespace RegressionGames.StateRecorder.Models
 
         public override void WriteToStringBuilder(StringBuilder stringBuilder)
         {
-            stringBuilder.Append("{\"path\":");
-            StringJsonConverter.WriteToStringBuilder(stringBuilder, path);
-            stringBuilder.Append(",\"normalizedPath\":");
-            StringJsonConverter.WriteToStringBuilder(stringBuilder, normalizedPath);
-            stringBuilder.Append(",\"is2D\":true");
+            stringBuilder.Append("{\"is2D\":true");
             stringBuilder.Append(",\"position\":");
             VectorJsonConverter.WriteToStringBuilderVector3(stringBuilder, rigidbody.position);
             stringBuilder.Append(",\"rotation\":");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/RigidbodyRecordState.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/RigidbodyRecordState.cs
@@ -10,20 +10,12 @@ namespace RegressionGames.StateRecorder.Models
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public class RigidbodyRecordState
     {
-
-        public string path;
-        public string normalizedPath;
-
         // keep a ref to this instead of updating fields every tick
         public Rigidbody rigidbody;
 
         public virtual void WriteToStringBuilder(StringBuilder stringBuilder)
         {
-            stringBuilder.Append("{\"path\":");
-            StringJsonConverter.WriteToStringBuilder(stringBuilder, path);
-            stringBuilder.Append(",\"normalizedPath\":");
-            StringJsonConverter.WriteToStringBuilder(stringBuilder, normalizedPath);
-            stringBuilder.Append(",\"is2D\":false");
+            stringBuilder.Append("{\"is2D\":false");
             stringBuilder.Append(",\"position\":");
             VectorJsonConverter.WriteToStringBuilderVector3(stringBuilder, rigidbody.position);
             stringBuilder.Append(",\"rotation\":");


### PR DESCRIPTION
- Removes paths from child behaviours / rigidbodies / colliders as originally mentioned in this PR (https://github.com/Regression-Games/RGUnityBots/pull/193)

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
