### PR TITLE
[REG-1803] Fix parent null and fix stringbuilder corruption

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using RegressionGames.StateRecorder.JsonConverters;
 using RegressionGames.StateRecorder.BotSegments.JsonConverters;
@@ -19,7 +20,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public const int CURRENT_SDK_API_VERSION = SDK_API_VERSION_1;
 
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(10_000);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(10_000));
 
         // versioning support for bot segments in the SDK, the is for this top level schema only
         // update this if this top level schema changes
@@ -142,9 +143,9 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         public string ToJsonString()
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value);
+            return _stringBuilder.Value.ToString();
         }
 
         public void WriteToStringBuilder(StringBuilder stringBuilder)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
@@ -872,7 +872,7 @@ namespace RegressionGames.StateRecorder
                 var parentTransform = newStateEntry.transform.parent;
                 // go up the tree until we find something in our parent hierarchy existing..
                 // stop if we hit the top
-                while (parentId.HasValue && !_newStates.ContainsKey(parentId.Value))
+                while (parentId.HasValue && parentTransform != null && !_newStates.ContainsKey(parentId.Value))
                 {
                     var parentParentTransform = parentTransform.parent;
                     int? parentParentId = parentParentTransform != null ? parentParentTransform.GetInstanceID() : null;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/AnimatorJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/AnimatorJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -8,7 +9,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class AnimatorJsonConverter : Newtonsoft.Json.JsonConverter, IBehaviourStringBuilderWritable
     {
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(1_000);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(1_000));
 
         public void WriteBehaviourToStringBuilder(StringBuilder stringBuilder, Behaviour behaviour)
         {
@@ -32,9 +33,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(Animator value)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, value);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, value);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/BoundsJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/BoundsJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -8,7 +9,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class BoundsJsonConverter : Newtonsoft.Json.JsonConverter
     {
         // re-usable and large enough to fit bounds vectors of all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(1000);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(1000));
 
         public static void WriteToStringBuilderNullable(StringBuilder stringBuilder, Bounds? f)
         {
@@ -42,9 +43,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(Bounds val)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, val);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/ButtonJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/ButtonJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 using UnityEngine.UI;
@@ -9,7 +10,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class ButtonJsonConverter : Newtonsoft.Json.JsonConverter, IBehaviourStringBuilderWritable
     {
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(100);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(100));
 
         public void WriteBehaviourToStringBuilder(StringBuilder stringBuilder, Behaviour behaviour)
         {
@@ -25,9 +26,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(Button value)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, value);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, value);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/Collider2DJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/Collider2DJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -9,7 +10,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     {
 
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(1000);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(1000));
 
         public static void WriteToStringBuilder(StringBuilder stringBuilder, Collider2D val)
         {
@@ -28,9 +29,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(Collider2D val)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, val);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/ColliderJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/ColliderJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -8,7 +9,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class ColliderJsonConverter : Newtonsoft.Json.JsonConverter
     {
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(1000);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(1000));
 
         public static void WriteToStringBuilder(StringBuilder stringBuilder, Collider val)
         {
@@ -27,9 +28,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(Collider val)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, val);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/ColorJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/ColorJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -9,7 +10,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class ColorJsonConverter : Newtonsoft.Json.JsonConverter
     {
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(200);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(200));
 
         public static void WriteToStringBuilderNullable(StringBuilder stringBuilder, Color? f)
         {
@@ -36,9 +37,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(Color val)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, val);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/DecimalJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/DecimalJsonConverter.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Globalization;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 
 namespace RegressionGames.StateRecorder.JsonConverters
 {
     public class DecimalJsonConverter: JsonConverter
     {
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(80);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(80));
 
         private static readonly NumberFormatInfo NumberFormatInfo = new ()
         {
@@ -117,9 +118,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(decimal f)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, f);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, f);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/DoubleJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/DoubleJsonConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 
 namespace RegressionGames.StateRecorder.JsonConverters
@@ -8,7 +9,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class DoubleJsonConverter: JsonConverter
     {
         // re-usable and large enough to fit objects of all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(40);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(40));
 
         private static readonly NumberFormatInfo NumberFormatInfo = new ()
         {
@@ -77,9 +78,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(double f)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, f);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, f);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/FloatJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/FloatJsonConverter.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 
 namespace RegressionGames.StateRecorder.JsonConverters
@@ -9,7 +10,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class FloatJsonConverter: JsonConverter
     {
         // re-usable and large enough to fit objects of all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(20);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(20));
 
         private static readonly NumberFormatInfo NumberFormatInfo = new ()
         {
@@ -79,9 +80,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(float f)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, f);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, f);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/ImageJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/ImageJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 using UnityEngine.UI;
@@ -10,7 +11,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     {
 
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(500);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(500));
 
         public void WriteBehaviourToStringBuilder(StringBuilder stringBuilder, Behaviour behaviour)
         {
@@ -54,9 +55,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(Image val)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, val);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/IntJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/IntJsonConverter.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 
 namespace RegressionGames.StateRecorder.JsonConverters
@@ -9,7 +10,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class IntJsonConverter: JsonConverter
     {
         // re-usable and large enough to fit objects of all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(20);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(20));
 
         private static readonly NumberFormatInfo NumberFormatInfo = new ()
         {
@@ -39,9 +40,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(int f)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, f);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, f);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/LongJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/LongJsonConverter.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 
 namespace RegressionGames.StateRecorder.JsonConverters
@@ -9,7 +10,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class LongJsonConverter: JsonConverter
     {
         // re-usable and large enough to fit objects of all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(20);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(20));
 
         private static readonly NumberFormatInfo NumberFormatInfo = new ()
         {
@@ -39,9 +40,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(long f)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, f);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, f);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/MaskJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/MaskJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 using UnityEngine.UI;
@@ -9,7 +10,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class MaskJsonConverter : Newtonsoft.Json.JsonConverter, IBehaviourStringBuilderWritable
     {
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(500);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(500));
 
         public void WriteBehaviourToStringBuilder(StringBuilder stringBuilder, Behaviour behaviour)
         {
@@ -25,9 +26,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(Mask value)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, value);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, value);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/MeshFilterJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/MeshFilterJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -8,7 +9,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class MeshFilterJsonConverter : Newtonsoft.Json.JsonConverter
     {
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(500);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(500));
 
         public static void WriteToStringBuilder(StringBuilder stringBuilder, MeshFilter val)
         {
@@ -26,9 +27,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(MeshFilter value)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, value);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, value);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/MeshJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/MeshJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -8,7 +9,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class MeshJsonConverter : Newtonsoft.Json.JsonConverter
     {
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(500);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(500));
 
         public static void WriteToStringBuilder(StringBuilder stringBuilder, Mesh val)
         {
@@ -20,9 +21,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(Mesh value)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, value);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, value);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/NavMeshAgentJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/NavMeshAgentJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 using UnityEngine.AI;
@@ -9,7 +10,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class NavMeshAgentJsonConverter : Newtonsoft.Json.JsonConverter, IBehaviourStringBuilderWritable
     {
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(500);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(500));
 
         public void WriteBehaviourToStringBuilder(StringBuilder stringBuilder, Behaviour behaviour)
         {
@@ -25,9 +26,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(NavMeshAgent value)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, value);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, value);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/ParticleSystemJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/ParticleSystemJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -9,7 +10,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     {
 
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(500);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(500));
 
         public static void WriteToStringBuilder(StringBuilder stringBuilder, ParticleSystem val)
         {
@@ -22,9 +23,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(ParticleSystem value)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, value);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, value);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/QuaternionJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/QuaternionJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -8,7 +9,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class QuaternionJsonConverter : Newtonsoft.Json.JsonConverter
     {
         // re-usable and large enough to fit quaternions of all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(200);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(200));
 
         public static void WriteToStringBuilderNullable(StringBuilder stringBuilder, Quaternion? f)
         {
@@ -36,9 +37,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(Quaternion val)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, val);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/RawImageJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/RawImageJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 using UnityEngine.UI;
@@ -9,7 +10,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class RawImageJsonConverter : Newtonsoft.Json.JsonConverter, IBehaviourStringBuilderWritable
     {
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(2_000);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(2_000));
 
         public void WriteBehaviourToStringBuilder(StringBuilder stringBuilder, Behaviour behaviour)
         {
@@ -53,9 +54,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(RawImage val)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, val);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/RectJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/RectJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -9,7 +10,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     {
 
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(1000);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(500));
 
         public static void WriteToStringBuilderNullable(StringBuilder stringBuilder, Rect? f)
         {
@@ -36,9 +37,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(Rect val)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, val);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/Rigidbody2DJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/Rigidbody2DJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -8,7 +9,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class Rigidbody2DJsonConverter : Newtonsoft.Json.JsonConverter
     {
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(4_000);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(4_000));
 
         public static void WriteToStringBuilder(StringBuilder stringBuilder, Rigidbody2D val)
         {
@@ -39,9 +40,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(Rigidbody2D val)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, val);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/RigidbodyJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/RigidbodyJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -9,7 +10,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     {
 
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(4_000);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(4_000));
 
         public static void WriteToStringBuilder(StringBuilder stringBuilder, Rigidbody val)
         {
@@ -40,9 +41,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(Rigidbody val)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, val);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/ShortJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/ShortJsonConverter.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 
 namespace RegressionGames.StateRecorder.JsonConverters
@@ -9,7 +10,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class ShortJsonConverter: JsonConverter
     {
         // re-usable and large enough to fit objects of all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(20);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(20));
 
         private static readonly NumberFormatInfo NumberFormatInfo = new ()
         {
@@ -39,9 +40,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(short f)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, f);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, f);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/SkinnedMeshRendererJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/SkinnedMeshRendererJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -9,7 +10,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     {
 
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(1_000);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(1_000));
 
         public static void WriteToStringBuilder(StringBuilder stringBuilder, SkinnedMeshRenderer val)
         {
@@ -41,9 +42,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(SkinnedMeshRenderer val)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, val);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/StringJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/StringJsonConverter.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Text;
 using Newtonsoft.Json;
-using RegressionGames.StateRecorder;
-using UnityEngine;
 
 namespace RegressionGames.StateRecorder.JsonConverters
 {
@@ -23,7 +21,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
             EscapeCharReplacements['\b'] = 'b';
             EscapeCharReplacements['\\'] = '\\';
             EscapeCharReplacements['"'] = '"';
-            //Main(); - useful for testing
+            //Main(); //- useful for testing
         }
 
         // supports up to 100k char length escaped strings
@@ -44,6 +42,13 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
             var inputLength = input.Length;
 
+            /*
+             * \n a b c
+             * 0  1 2 3
+             *
+             * s = 1 , e = 1
+             */
+
             var startIndex = 0;
             var endIndex = 0;
             for (var i = 0; i < inputLength; i++)
@@ -53,14 +58,14 @@ namespace RegressionGames.StateRecorder.JsonConverters
                 if (escapeReplacement == 0)
                 {
                     // don't need to escape
-                    endIndex = i;
+                    endIndex = i + 1;
                 }
                 else
                 {
-                    // need to escape.. copy existing range to result if not the start of the string
-                    if (i != 0)
+                    // need to escape.. copy existing range to result
+                    if (startIndex != endIndex)
                     {
-                        var length = endIndex + 1 - startIndex;
+                        var length = endIndex - startIndex;
                         input.CopyTo(startIndex, _bufferArray, _currentNextIndex, length);
                         _currentNextIndex += length;
                     }
@@ -76,7 +81,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
             if (startIndex != endIndex || startIndex == inputLength - 1)
             {
                 // got to the end
-                var length = endIndex + 1 - startIndex;
+                var length = endIndex - startIndex;
                 input.CopyTo(startIndex, _bufferArray, _currentNextIndex, length);
                 _currentNextIndex += length;
             }
@@ -126,6 +131,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
         /* Useful for testing
         public static void Main()
         {
+            Debug.Log("StringJsonConverter Test Output");
             var input = "a";
             Debug.Log("Input: " + input + " , Output: " + ToJsonString(input));
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/StringJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/StringJsonConverter.cs
@@ -25,7 +25,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
             EscapeCharReplacements['\b'] = 'b';
             EscapeCharReplacements['\\'] = '\\';
             EscapeCharReplacements['"'] = '"';
-            TestCode(); //- useful for testing
+            //TestCode(); //- useful for testing
         }
 
         // supports up to 1m char length escaped strings
@@ -124,7 +124,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
             return objectType == typeof(string);
         }
 
-        ///* Useful for testing
+        /* Useful for testing
         public static void TestCode()
         {
             new Thread(StringJsonConverter.Test).Start();
@@ -191,6 +191,6 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
             Debug.Log(sb.ToString());
         }
-        //*/
+        */
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/TextJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/TextJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 using UnityEngine.UI;
@@ -9,7 +10,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class TextJsonConverter : Newtonsoft.Json.JsonConverter, IBehaviourStringBuilderWritable
     {
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(10_000);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(10_000));
 
         public void WriteBehaviourToStringBuilder(StringBuilder stringBuilder, Behaviour behaviour)
         {
@@ -41,9 +42,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(Text val)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, val);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/TextMeshProJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/TextMeshProJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using TMPro;
 using UnityEngine;
@@ -9,7 +10,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class TextMeshProJsonConverter : Newtonsoft.Json.JsonConverter
     {
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(10_000);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(10_000));
 
         public void WriteBehaviourToStringBuilder(StringBuilder stringBuilder, Behaviour behaviour)
         {
@@ -43,9 +44,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(TextMeshPro val)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, val);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/TextMeshProUGUIJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/TextMeshProUGUIJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using TMPro;
 using UnityEngine;
@@ -9,7 +10,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class TextMeshProUGUIJsonConverter : Newtonsoft.Json.JsonConverter, IBehaviourStringBuilderWritable
     {
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(10_000);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(10_000));
 
         public void WriteBehaviourToStringBuilder(StringBuilder stringBuilder, Behaviour behaviour)
         {
@@ -43,9 +44,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(TextMeshProUGUI val)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, val);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/VectorIntJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/VectorIntJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -8,7 +9,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class VectorIntJsonConverter : Newtonsoft.Json.JsonConverter
     {
         // re-usable and large enough to fit vectors of all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(200);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(200));
 
         public static void WriteToStringBuilderNullable(StringBuilder stringBuilder, Vector2Int? f)
         {
@@ -52,16 +53,16 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonString(Vector2Int val)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, val);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
         }
 
         private static string ToJsonString(Vector3Int val)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder, val);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/VectorJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/VectorJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -8,7 +9,7 @@ namespace RegressionGames.StateRecorder.JsonConverters
     public class VectorJsonConverter : Newtonsoft.Json.JsonConverter
     {
         // re-usable and large enough to fit vectors of all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(200);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(200));
 
         public static void WriteToStringBuilderVector2Nullable(StringBuilder stringBuilder, Vector2? f)
         {
@@ -32,9 +33,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonStringVector2(Vector2 val)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilderVector2(_stringBuilder, val);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilderVector2(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
         }
 
         public static void WriteToStringBuilderVector3Nullable(StringBuilder stringBuilder, Vector3? f)
@@ -60,9 +61,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonStringVector3(Vector3 val)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilderVector3(_stringBuilder, val);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilderVector3(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
         }
 
         public static void WriteToStringBuilderVector4Nullable(StringBuilder stringBuilder, Vector4? f)
@@ -90,9 +91,9 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static string ToJsonStringVector4(Vector4 val)
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilderVector4(_stringBuilder, val);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilderVector4(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
         }
 
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/KeyboardInputActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/KeyboardInputActionData.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using RegressionGames.StateRecorder.BotSegments.Models;
 using RegressionGames.StateRecorder.JsonConverters;
@@ -33,7 +34,7 @@ namespace RegressionGames.StateRecorder.Models
         public bool isPressed => duration > 0 && endTime == null;
 
         // re-usable and large enough to fit ball sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(2_000);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(5_000));
 
         public void WriteToStringBuilder(StringBuilder stringBuilder)
         {
@@ -54,9 +55,9 @@ namespace RegressionGames.StateRecorder.Models
 
         internal string ToJsonString()
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value);
+            return _stringBuilder.Value.ToString();
         }
 
         public void ReplayReset()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/MouseInputActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/MouseInputActionData.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using RegressionGames.StateRecorder.BotSegments.Models;
 using RegressionGames.StateRecorder.JsonConverters;
@@ -72,8 +73,8 @@ namespace RegressionGames.StateRecorder.Models
             Replay_OffsetTime = 0;
         }
 
-        // re-usable and large enough to fit ball sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(5_000);
+        // re-usable and large enough to fit all sizes
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(5_000));
 
         public void WriteToStringBuilder(StringBuilder stringBuilder)
         {
@@ -114,9 +115,9 @@ namespace RegressionGames.StateRecorder.Models
 
         internal string ToJsonString()
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value);
+            return _stringBuilder.Value.ToString();
         }
 
         //gives the position relative to the current screen size

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/RecordingFrameStateData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/RecordingFrameStateData.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using RegressionGames.StateRecorder.JsonConverters;
 using UnityEngine;
 
@@ -32,7 +33,7 @@ namespace RegressionGames.StateRecorder.Models
         public PerformanceMetricData performance;
 
         // re-usable and large enough to fit all sizes
-        private static readonly StringBuilder _stringBuilder = new StringBuilder(10_000_000);
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(10_000_000));
 
         public void WriteToStringBuilder(StringBuilder stringBuilder)
         {
@@ -80,9 +81,9 @@ namespace RegressionGames.StateRecorder.Models
 
         public string ToJsonString()
         {
-            _stringBuilder.Clear();
-            WriteToStringBuilder(_stringBuilder);
-            return _stringBuilder.ToString();
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value);
+            return _stringBuilder.Value.ToString();
         }
 
     }


### PR DESCRIPTION
- Fix issues with stringbuilder escaping
- Fix a null parent looping issue
- Fixes a threadsafety issue with our json converters, stringbuilder, and stringjsonconverter's buffer

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
