### PR TITLE
[REG-1778] Bot Segments for Clicking random pixels or random objects

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlayCanvasV2.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlayCanvasV2.prefab
@@ -5259,7 +5259,7 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_VertexColorAlwaysGammaSpace: 0
-  m_AdditionalShaderChannelsFlag: 0
+  m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 32767
@@ -6841,6 +6841,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 77fc1e88a9b44c159e04099241437fe5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  pauseEditorOnPlaybackWarning: 1
 --- !u!114 &5122435472915985299
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlayCanvasV2.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlayCanvasV2.prefab
@@ -31,7 +31,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 130924262344969576}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -109,7 +108,6 @@ RectTransform:
   m_Children:
   - {fileID: 3141922717576822039}
   m_Father: {fileID: 6746351550061287240}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -234,7 +232,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1094668923711103164}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -371,7 +368,6 @@ RectTransform:
   m_Children:
   - {fileID: 7961718474796200068}
   m_Father: {fileID: 6746351550061287240}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -460,7 +456,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 47554025908246306}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
@@ -536,7 +531,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1452189883864539947}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -671,7 +665,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 47554025908246306}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -812,7 +805,6 @@ RectTransform:
   - {fileID: 2517803416891369262}
   - {fileID: 6648679281401812096}
   m_Father: {fileID: 5224021696837641672}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -887,7 +879,6 @@ RectTransform:
   m_Children:
   - {fileID: 1508444460829567942}
   m_Father: {fileID: 3393945995968011374}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -925,7 +916,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1775505273637563011}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -1005,7 +995,6 @@ RectTransform:
   m_Children:
   - {fileID: 6986221192224276067}
   m_Father: {fileID: 7825146823198246843}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -1139,7 +1128,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1294,7 +1282,6 @@ RectTransform:
   - {fileID: 4362780102445503521}
   - {fileID: 4911149214502031902}
   m_Father: {fileID: 1452189883864539947}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -1386,7 +1373,9 @@ Canvas:
   m_OverrideSorting: 1
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
   m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 30000
   m_TargetDisplay: 0
@@ -1421,7 +1410,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1094668923711103164}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -1499,7 +1487,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1652,7 +1639,6 @@ RectTransform:
   m_Children:
   - {fileID: 266832984541047860}
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1786,7 +1772,6 @@ RectTransform:
   m_Children:
   - {fileID: 130924262344969576}
   m_Father: {fileID: 8326409972815191664}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1912,7 +1897,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2067,7 +2051,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2219,7 +2202,6 @@ RectTransform:
   m_Children:
   - {fileID: 1593904811034481552}
   m_Father: {fileID: 5849487789424347138}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -2295,7 +2277,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2163531068832325664}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -2371,7 +2352,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5849487789424347138}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -2453,7 +2433,6 @@ RectTransform:
   - {fileID: 4515592992782609972}
   - {fileID: 536196743177323916}
   m_Father: {fileID: 2530510026482189899}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
@@ -2541,7 +2520,6 @@ RectTransform:
   m_Children:
   - {fileID: 2530510026482189899}
   m_Father: {fileID: 8326409972815191664}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -2630,7 +2608,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2163531068832325664}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
@@ -2710,7 +2687,6 @@ RectTransform:
   - {fileID: 4334941368482101610}
   - {fileID: 3393945995968011374}
   m_Father: {fileID: 8587920458476045062}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -2802,7 +2778,9 @@ Canvas:
   m_OverrideSorting: 1
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
   m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 30000
   m_TargetDisplay: 0
@@ -2837,7 +2815,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1094668923711103164}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.75}
   m_AnchorMax: {x: 0, y: 0.75}
@@ -2972,12 +2949,11 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6927235806806861544}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: -1.5, y: -15}
-  m_SizeDelta: {x: 135, y: 100}
+  m_SizeDelta: {x: 150, y: 130}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8565215197663429023
 CanvasRenderer:
@@ -3003,11 +2979,11 @@ MonoBehaviour:
   m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 0
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 2ef5568d380cdc04f8a6a676ca65d8d5, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 6ed40dec3af864cce92c46e517196ebf, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -3049,7 +3025,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3204,7 +3179,6 @@ RectTransform:
   m_Children:
   - {fileID: 1852812869902392873}
   m_Father: {fileID: 6648679281401812096}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3293,7 +3267,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3141922717576822039}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3369,7 +3342,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3446,7 +3418,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5630640976557725279}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3627,7 +3598,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3780,7 +3750,6 @@ RectTransform:
   m_Children:
   - {fileID: 3152240568156906031}
   m_Father: {fileID: 1094668923711103164}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -3912,7 +3881,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4046,7 +4014,6 @@ RectTransform:
   m_Children:
   - {fileID: 2163531068832325664}
   m_Father: {fileID: 4362780102445503521}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -4086,7 +4053,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4237,7 +4203,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 47554025908246306}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -4313,7 +4278,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1452189883864539947}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -4448,7 +4412,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8587920458476045062}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
@@ -4529,7 +4492,6 @@ RectTransform:
   - {fileID: 6746351550061287240}
   - {fileID: 2953817864760835568}
   m_Father: {fileID: 4901750364568730873}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -4662,7 +4624,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2943620597921803164}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4759,7 +4720,6 @@ RectTransform:
   - {fileID: 5248371518487353189}
   - {fileID: 5849487789424347138}
   m_Father: {fileID: 7825146823198246843}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -4895,7 +4855,6 @@ RectTransform:
   - {fileID: 8587920458476045062}
   - {fileID: 7825146823198246843}
   m_Father: {fileID: 1094668923711103164}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.8}
   m_AnchorMax: {x: 1, y: 0.8}
@@ -4997,7 +4956,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8587920458476045062}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -5132,7 +5090,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8587920458476045062}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -5278,7 +5235,6 @@ RectTransform:
   - {fileID: 1090041802443136416}
   - {fileID: 1094668923711103164}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -5302,7 +5258,9 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 25
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 32767
   m_TargetDisplay: 0
@@ -5416,8 +5374,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 88d7e0b66bd64408ae00f392e7077223, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  collapseRenderersIntoTopLevelGameObject: 1
-  includeOnlyOnCameraObjects: 1
   collectStateFromBehaviours: 1
 --- !u!114 &681669965379170089
 MonoBehaviour:
@@ -5487,7 +5443,6 @@ RectTransform:
   m_Children:
   - {fileID: 985415874430226196}
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -5564,7 +5519,6 @@ RectTransform:
   m_Children:
   - {fileID: 6616899866124984948}
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -5640,7 +5594,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6128659421540762060}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -5777,7 +5730,6 @@ RectTransform:
   - {fileID: 1276465453068283002}
   - {fileID: 1092592833771759674}
   m_Father: {fileID: 7961718474796200068}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
@@ -5863,7 +5815,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2065522685927686854}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -6003,7 +5954,6 @@ RectTransform:
   - {fileID: 8326409972815191664}
   - {fileID: 2387824098431642500}
   m_Father: {fileID: 4901750364568730873}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -6135,7 +6085,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2163531068832325664}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -6271,7 +6220,6 @@ RectTransform:
   m_Children:
   - {fileID: 1775505273637563011}
   m_Father: {fileID: 1094668923711103164}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0.7}
@@ -6347,7 +6295,6 @@ RectTransform:
   - {fileID: 6128659421540762060}
   - {fileID: 2065522685927686854}
   m_Father: {fileID: 4901750364568730873}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -6384,7 +6331,6 @@ RectTransform:
   m_Children:
   - {fileID: 7980167310545832456}
   m_Father: {fileID: 4911149214502031902}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -6422,7 +6368,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1452189883864539947}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
@@ -6497,7 +6442,6 @@ RectTransform:
   m_Children:
   - {fileID: 47554025908246306}
   m_Father: {fileID: 4334941368482101610}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -6536,7 +6480,6 @@ RectTransform:
   - {fileID: 6280591337693800581}
   - {fileID: 5080053995929809686}
   m_Father: {fileID: 6128659421540762060}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -6634,7 +6577,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6280591337693800581}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -6710,7 +6652,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6033063948165999297}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -6858,7 +6799,6 @@ RectTransform:
   - {fileID: 5789129086972528656}
   - {fileID: 6927235806806861544}
   m_Father: {fileID: 5224021696837641672}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -6901,7 +6841,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 77fc1e88a9b44c159e04099241437fe5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  uiReplayEnforcement: 1
 --- !u!114 &5122435472915985299
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotActionJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotActionJsonConverter.cs
@@ -37,6 +37,8 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
             return action;
         }
 
+        public override bool CanWrite => false;
+
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             throw new NotImplementedException();

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotActionJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotActionJsonConverter.cs
@@ -23,7 +23,12 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
                 case BotActionType.InputPlayback:
                     data = jObject["data"].ToObject<InputPlaybackActionData>(serializer);
                     break;
-
+                case BotActionType.RandomMouse_ClickPixel:
+                    data = jObject["data"].ToObject<RandomMousePixelActionData>(serializer);
+                    break;
+                case BotActionType.RandomMouse_ClickObject:
+                    data = jObject["data"].ToObject<RandomMouseObjectActionData>(serializer);
+                    break;
                 default:
                     throw new JsonSerializationException($"Unsupported BotAction type: '{action.type}'");
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotSegmentJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotSegmentJsonConverter.cs
@@ -25,6 +25,8 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
             return actionModel;
         }
 
+        public override bool CanWrite => false;
+
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             throw new NotImplementedException();

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/KeyFrameCriteriaJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/KeyFrameCriteriaJsonConverter.cs
@@ -33,6 +33,8 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
             return criteria;
         }
 
+        public override bool CanWrite => false;
+
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             throw new NotImplementedException();

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/RandomMouseObjectActionDataJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/RandomMouseObjectActionDataJsonConverter.cs
@@ -23,6 +23,7 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
             data.timeBetweenClicks = jObject.GetValue("timeBetweenClicks").ToObject<float>();
             data.excludedAreas = jObject.GetValue("excludedAreas").ToObject<List<RectInt>>();
             data.excludedNormalizedPaths = jObject.GetValue("excludedNormalizedPaths").ToObject<List<string>>();
+            data.preconditionNormalizedPaths = jObject.GetValue("preconditionNormalizedPaths").ToObject<List<string>>();
             return data;
         }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/RandomMouseObjectActionDataJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/RandomMouseObjectActionDataJsonConverter.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using RegressionGames.StateRecorder.BotSegments.Models;
+using UnityEngine;
+
+namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
+{
+    public sealed class RandomMouseObjectActionDataJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(RandomMouseObjectActionData).IsAssignableFrom(objectType);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JObject jObject = JObject.Load(reader);
+            RandomMouseObjectActionData data = new();
+            data.screenSize = jObject.GetValue("screenSize").ToObject<Vector2Int>(serializer);
+            data.apiVersion = jObject.GetValue("apiVersion").ToObject<int>();
+            data.timeBetweenClicks = jObject.GetValue("timeBetweenClicks").ToObject<float>();
+            data.excludedAreas = jObject.GetValue("excludedAreas").ToObject<List<RectInt>>();
+            data.excludedNormalizedPaths = jObject.GetValue("excludedNormalizedPaths").ToObject<List<string>>();
+            return data;
+        }
+
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/RandomMouseObjectActionDataJsonConverter.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/RandomMouseObjectActionDataJsonConverter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e8910e6dfff9456a88f082c08030e57c
+timeCreated: 1718224353

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/RandomMousePixelActionDataJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/RandomMousePixelActionDataJsonConverter.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using RegressionGames.StateRecorder.BotSegments.Models;
+using UnityEngine;
+
+namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
+{
+    public sealed class RandomMousePixelActionDataJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(RandomMousePixelActionData).IsAssignableFrom(objectType);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JObject jObject = JObject.Load(reader);
+            RandomMousePixelActionData data = new();
+            data.screenSize = jObject.GetValue("screenSize").ToObject<Vector2Int>(serializer);
+            data.apiVersion = jObject.GetValue("apiVersion").ToObject<int>();
+            data.timeBetweenClicks = jObject.GetValue("timeBetweenClicks").ToObject<float>();
+            data.excludedAreas = jObject.GetValue("excludedAreas").ToObject<List<RectInt>>();
+            return data;
+        }
+
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/RandomMousePixelActionDataJsonConverter.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/RandomMousePixelActionDataJsonConverter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: abea8b475fe64218ac5aa00f914135e5
+timeCreated: 1718224082

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotAction.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotAction.cs
@@ -15,9 +15,15 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         public BotActionType type;
         public IBotActionData data;
-        public bool IsCompleted => data.IsCompleted();
+        public bool? IsCompleted => data.IsCompleted(); // returns null if this action runs until the keyframecriteria are met
 
         public int EffectiveApiVersion => Math.Max(apiVersion, data?.EffectiveApiVersion() ?? 0);
+
+        // called at least once per frame
+        public void ProcessAction()
+        {
+            data.ProcessAction();
+        }
 
         public void ReplayReset()
         {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotAction.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotAction.cs
@@ -27,11 +27,12 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             data.StartAction(segmentNumber, currentUITransforms, currentGameObjectTransforms);
         }
 
-        // called at least once per frame
-        // bool firstCall tracks if this is the first call for this botaction
-        public string ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
+        // called once per frame
+        // returns true if an action was performed
+        // out error will have an error string or null if no action performed or no error
+        public bool ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms, out string error)
         {
-            return data.ProcessAction(segmentNumber, currentUITransforms, currentGameObjectTransforms);
+            return data.ProcessAction(segmentNumber, currentUITransforms, currentGameObjectTransforms, out error);
         }
 
         public void ReplayReset()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotAction.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotAction.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text;
 using Newtonsoft.Json;
 using RegressionGames.StateRecorder.JsonConverters;
 using RegressionGames.StateRecorder.BotSegments.JsonConverters;
+using RegressionGames.StateRecorder.Models;
 
 namespace RegressionGames.StateRecorder.BotSegments.Models
 {
@@ -20,9 +22,9 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public int EffectiveApiVersion => Math.Max(apiVersion, data?.EffectiveApiVersion() ?? 0);
 
         // called at least once per frame
-        public void ProcessAction()
+        public void ProcessAction(int segmentNumber, IEnumerable<TransformStatus> currentTransformStatus)
         {
-            data.ProcessAction();
+            data.ProcessAction(segmentNumber, currentTransformStatus);
         }
 
         public void ReplayReset()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotAction.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotAction.cs
@@ -21,10 +21,17 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         public int EffectiveApiVersion => Math.Max(apiVersion, data?.EffectiveApiVersion() ?? 0);
 
-        // called at least once per frame
-        public void ProcessAction(int segmentNumber, IEnumerable<TransformStatus> currentTransformStatus)
+        // Called before the first call to ProcessAction to allow data setup by the action code
+        public void StartAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
         {
-            data.ProcessAction(segmentNumber, currentTransformStatus);
+            data.StartAction(segmentNumber, currentUITransforms, currentGameObjectTransforms);
+        }
+
+        // called at least once per frame
+        // bool firstCall tracks if this is the first call for this botaction
+        public void ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
+        {
+            data.ProcessAction(segmentNumber, currentUITransforms, currentGameObjectTransforms);
         }
 
         public void ReplayReset()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotAction.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotAction.cs
@@ -29,9 +29,9 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         // called at least once per frame
         // bool firstCall tracks if this is the first call for this botaction
-        public void ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
+        public string ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
         {
-            data.ProcessAction(segmentNumber, currentUITransforms, currentGameObjectTransforms);
+            return data.ProcessAction(segmentNumber, currentUITransforms, currentGameObjectTransforms);
         }
 
         public void ReplayReset()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotActionType.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotActionType.cs
@@ -4,6 +4,8 @@
     {
         None,
         InputPlayback,
+        RandomMouse_ClickPixel,
+        RandomMouse_ClickObject,
 
         //FUTURE
         //Timer,
@@ -11,8 +13,6 @@
         //Behaviour,
         //AgentBuilder,
         //OrchestratedInput,
-        //RandomMouse_ClickPixel,
-        //RandomMouse_ClickObject,
         //RandomKeyboard_Key,
         //RandomKeyboard_ActionableKey,
         //RandomJoystick_Axis1|Axis2|Axis3,Key

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
@@ -52,9 +52,21 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public bool Replay_ActionCompleted => botAction == null || (botAction.IsCompleted ?? Replay_Matched);
 
         // Replay only - called at least once per frame
-        public void ProcessAction(IEnumerable<TransformStatus> currentTransformStatus)
+        public void ProcessAction(Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
         {
-            botAction?.ProcessAction(Replay_SegmentNumber, currentTransformStatus);
+            if (botAction == null)
+            {
+                Replay_ActionStarted = true;
+            }
+            else
+            {
+                if (!Replay_ActionStarted)
+                {
+                    botAction.StartAction(Replay_SegmentNumber, currentUITransforms, currentGameObjectTransforms);
+                    Replay_ActionStarted = true;
+                }
+                botAction.ProcessAction(Replay_SegmentNumber, currentUITransforms, currentGameObjectTransforms);
+            }
         }
 
         // Replay only

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
@@ -52,7 +52,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public bool Replay_ActionCompleted => botAction == null || (botAction.IsCompleted ?? Replay_Matched);
 
         // Replay only - called at least once per frame
-        public void ProcessAction(Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
+        public string ProcessAction(Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
         {
             if (botAction == null)
             {
@@ -65,8 +65,9 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                     botAction.StartAction(Replay_SegmentNumber, currentUITransforms, currentGameObjectTransforms);
                     Replay_ActionStarted = true;
                 }
-                botAction.ProcessAction(Replay_SegmentNumber, currentUITransforms, currentGameObjectTransforms);
+                return botAction.ProcessAction(Replay_SegmentNumber, currentUITransforms, currentGameObjectTransforms);
             }
+            return null;
         }
 
         // Replay only

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Newtonsoft.Json;
 using RegressionGames.StateRecorder.JsonConverters;
 using RegressionGames.StateRecorder.BotSegments.JsonConverters;
+using RegressionGames.StateRecorder.Models;
 
 namespace RegressionGames.StateRecorder.BotSegments.Models
 {
@@ -51,9 +52,9 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public bool Replay_ActionCompleted => botAction == null || (botAction.IsCompleted ?? Replay_Matched);
 
         // Replay only - called at least once per frame
-        public void ProcessAction()
+        public void ProcessAction(IEnumerable<TransformStatus> currentTransformStatus)
         {
-            botAction?.ProcessAction();
+            botAction?.ProcessAction(Replay_SegmentNumber, currentTransformStatus);
         }
 
         // Replay only

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
@@ -52,7 +52,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public bool Replay_ActionCompleted => botAction == null || (botAction.IsCompleted ?? Replay_Matched);
 
         // Replay only - called at least once per frame
-        public string ProcessAction(Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
+        public bool ProcessAction(Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms, out string error)
         {
             if (botAction == null)
             {
@@ -65,9 +65,11 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                     botAction.StartAction(Replay_SegmentNumber, currentUITransforms, currentGameObjectTransforms);
                     Replay_ActionStarted = true;
                 }
-                return botAction.ProcessAction(Replay_SegmentNumber, currentUITransforms, currentGameObjectTransforms);
+                return botAction.ProcessAction(Replay_SegmentNumber, currentUITransforms, currentGameObjectTransforms, out error);
             }
-            return null;
+
+            error = null;
+            return false;
         }
 
         // Replay only

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
@@ -15,9 +15,10 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
     {
         // these values reference key moments in the development of the SDK for bot segments
         public const int SDK_API_VERSION_1 = 1; // initial version with and/or/normalizedPath criteria and mouse/keyboard input actions
+        public const int SDK_API_VERSION_2 = 2; // added mouse pixel and object random clicking actions
 
         // Update this when new features are used in the SDK
-        public const int CURRENT_SDK_API_VERSION = SDK_API_VERSION_1;
+        public const int CURRENT_SDK_API_VERSION = SDK_API_VERSION_2;
 
         // re-usable and large enough to fit all sizes
         private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(10_000));
@@ -46,7 +47,14 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public bool Replay_ActionStarted;
 
         // Replay only - tracks if we have completed the action for this bot segment
-        public bool Replay_ActionCompleted => botAction == null || botAction.IsCompleted;
+        // returns true if botAction.IsCompleted || botAction.IsCompleted==null && Replay_Matched
+        public bool Replay_ActionCompleted => botAction == null || (botAction.IsCompleted ?? Replay_Matched);
+
+        // Replay only - called at least once per frame
+        public void ProcessAction()
+        {
+            botAction?.ProcessAction();
+        }
 
         // Replay only
         public void ReplayReset()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
@@ -14,9 +14,10 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         /**
          * Called at least once per frame
+         * returns true if an action was performed
          * Returns null or an error message string
          */
-        public string ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms);
+        public bool ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms, out string error);
 
         public void WriteToStringBuilder(StringBuilder stringBuilder);
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
@@ -14,8 +14,9 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         /**
          * Called at least once per frame
+         * Returns null or an error message string
          */
-        public void ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms);
+        public string ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms);
 
         public void WriteToStringBuilder(StringBuilder stringBuilder);
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿using System.Collections.Generic;
+using System.Text;
+using RegressionGames.StateRecorder.Models;
 
 namespace RegressionGames.StateRecorder.BotSegments.Models
 {
@@ -7,7 +9,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         /**
          * Called at least once per frame
          */
-        public void ProcessAction();
+        public void ProcessAction(int segmentNumber, IEnumerable<TransformStatus> currentTransformStatus);
 
         public void WriteToStringBuilder(StringBuilder stringBuilder);
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
@@ -6,10 +6,16 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 {
     public interface IBotActionData
     {
+
+        /**
+         * Called before the first call to ProcessAction to allow data setup by the action
+         */
+        public void StartAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms);
+
         /**
          * Called at least once per frame
          */
-        public void ProcessAction(int segmentNumber, IEnumerable<TransformStatus> currentTransformStatus);
+        public void ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms);
 
         public void WriteToStringBuilder(StringBuilder stringBuilder);
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
@@ -4,11 +4,19 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 {
     public interface IBotActionData
     {
+        /**
+         * Called at least once per frame
+         */
+        public void ProcessAction();
+
         public void WriteToStringBuilder(StringBuilder stringBuilder);
 
         public void ReplayReset();
 
-        public bool IsCompleted();
+        /**
+         * Returns null if the action runs until the keyframecriteria match
+         */
+        public bool? IsCompleted();
 
         public int EffectiveApiVersion();
     }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
@@ -40,14 +40,16 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             }
         }
 
-        public string ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
+        public bool ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms, out string error)
         {
+            var result = false;
             var currentTime = Time.unscaledTime;
             foreach (var replayKeyboardInputEntry in inputData.keyboard)
             {
                 if (!replayKeyboardInputEntry.Replay_StartEndSentFlags[0] && currentTime >= replayKeyboardInputEntry.Replay_StartTime)
                 {
                     // send start event
+                    result = true;
                     KeyboardEventSender.SendKeyEvent(segmentNumber, replayKeyboardInputEntry, KeyState.Down);
                     replayKeyboardInputEntry.Replay_StartEndSentFlags[0] = true;
                 }
@@ -55,6 +57,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                 if (!replayKeyboardInputEntry.Replay_StartEndSentFlags[1] && currentTime >= replayKeyboardInputEntry.Replay_EndTime)
                 {
                     // send end event
+                    result = true;
                     KeyboardEventSender.SendKeyEvent(segmentNumber, replayKeyboardInputEntry, KeyState.Up);
                     replayKeyboardInputEntry.Replay_StartEndSentFlags[1] = true;
                 }
@@ -69,12 +72,14 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                     var gameObjectTransforms = InGameObjectFinder.GetInstance().GetGameObjectTransformsForCurrentFrame();
 
                     // send event
+                    result = true;
                     MouseEventSender.SendMouseEvent(segmentNumber, replayMouseInputEntry, uiTransforms.Item1, gameObjectTransforms.Item1, uiTransforms.Item2, gameObjectTransforms.Item2);
                     replayMouseInputEntry.Replay_IsDone = true;
                 }
             }
 
-            return null;
+            error = null;
+            return result;
         }
 
         public bool? IsCompleted()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
@@ -40,7 +40,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             }
         }
 
-        public void ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
+        public string ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
         {
             var currentTime = Time.unscaledTime;
             foreach (var replayKeyboardInputEntry in inputData.keyboard)
@@ -73,6 +73,8 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                     replayMouseInputEntry.Replay_IsDone = true;
                 }
             }
+
+            return null;
         }
 
         public bool? IsCompleted()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text;
 using RegressionGames.StateRecorder.JsonConverters;
 using RegressionGames.StateRecorder.Models;
@@ -21,7 +22,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public double startTime;
         public InputData inputData;
 
-        public void ProcessAction()
+        public void ProcessAction(int segmentNumbe, IEnumerable<TransformStatus> currentTransformStatus)
         {
             var currentTime = Time.unscaledTime;
             foreach (var replayKeyboardInputEntry in inputData.keyboard)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
@@ -22,7 +22,25 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public double startTime;
         public InputData inputData;
 
-        public void ProcessAction(int segmentNumbe, IEnumerable<TransformStatus> currentTransformStatus)
+        public void StartAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
+        {
+            RGDebug.LogInfo($"({segmentNumber}) - Processing InputPlaybackActionData for BotSegment");
+
+            var now = Time.unscaledTime;
+            var currentInputTimePoint = now - startTime;
+
+            foreach (var keyboardInputActionData in inputData.keyboard)
+            {
+                keyboardInputActionData.Replay_OffsetTime = currentInputTimePoint;
+            }
+
+            foreach (var mouseInputActionData in inputData.mouse)
+            {
+                mouseInputActionData.Replay_OffsetTime = currentInputTimePoint;
+            }
+        }
+
+        public void ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
         {
             var currentTime = Time.unscaledTime;
             foreach (var replayKeyboardInputEntry in inputData.keyboard)
@@ -30,28 +48,28 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                 if (!replayKeyboardInputEntry.Replay_StartEndSentFlags[0] && currentTime >= replayKeyboardInputEntry.Replay_StartTime)
                 {
                     // send start event
-                    KeyboardEventSender.SendKeyEvent(replayKeyboardInputEntry, KeyState.Down);
+                    KeyboardEventSender.SendKeyEvent(segmentNumber, replayKeyboardInputEntry, KeyState.Down);
                     replayKeyboardInputEntry.Replay_StartEndSentFlags[0] = true;
                 }
 
                 if (!replayKeyboardInputEntry.Replay_StartEndSentFlags[1] && currentTime >= replayKeyboardInputEntry.Replay_EndTime)
                 {
                     // send end event
-                    KeyboardEventSender.SendKeyEvent(replayKeyboardInputEntry, KeyState.Up);
+                    KeyboardEventSender.SendKeyEvent(segmentNumber, replayKeyboardInputEntry, KeyState.Up);
                     replayKeyboardInputEntry.Replay_StartEndSentFlags[1] = true;
                 }
             }
 
             foreach (var replayMouseInputEntry in inputData.mouse)
             {
-                if (currentTime >= replayMouseInputEntry.Replay_StartTime)
+                if (!replayMouseInputEntry.Replay_IsDone && currentTime >= replayMouseInputEntry.Replay_StartTime)
                 {
                     //Need the statuses for the mouse to click correctly when things move a bit or resolution changes
                     var uiTransforms = InGameObjectFinder.GetInstance().GetUITransformsForCurrentFrame();
                     var gameObjectTransforms = InGameObjectFinder.GetInstance().GetGameObjectTransformsForCurrentFrame();
 
                     // send event
-                    MouseEventSender.SendMouseEvent(replayMouseInputEntry.Replay_SegmentNumber, replayMouseInputEntry, uiTransforms.Item1, gameObjectTransforms.Item1, uiTransforms.Item2, gameObjectTransforms.Item2);
+                    MouseEventSender.SendMouseEvent(segmentNumber, replayMouseInputEntry, uiTransforms.Item1, gameObjectTransforms.Item1, uiTransforms.Item2, gameObjectTransforms.Item2);
                     replayMouseInputEntry.Replay_IsDone = true;
                 }
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
@@ -1,9 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using RegressionGames.StateRecorder.BotSegments.JsonConverters;
 using RegressionGames.StateRecorder.JsonConverters;
 using RegressionGames.StateRecorder.Models;
+using Unity.Plastic.Newtonsoft.Json;
 using UnityEngine;
+using Random = UnityEngine.Random;
 
 namespace RegressionGames.StateRecorder.BotSegments.Models
 {
@@ -11,6 +15,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
      * <summary>Data for clicking on a random renderable object in the frame</summary>
      */
     [Serializable]
+    [JsonConverter(typeof(RandomMouseObjectActionDataJsonConverter))]
     public class RandomMouseObjectActionData : IBotActionData
     {
         // api version for this object, update if object format changes
@@ -19,10 +24,19 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         [NonSerialized]
         public static readonly BotActionType Type = BotActionType.RandomMouse_ClickObject;
 
+        [NonSerialized]
+        private float Replay_LastClickTime = float.MinValue;
+
         /**
          * <summary>The minimum time gap between clicks, 0 means click once per frame.</summary>
          */
         public float timeBetweenClicks;
+
+        /**
+         * <summary>Used to normalize the excluded areas values to the current screen size</summary>
+         */
+        public Vector2Int screenSize;
+
         /**
          * <summary>The screen pixel rects to avoid clicking in</summary>
          */
@@ -41,15 +55,94 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         {
         }
 
-        public void ProcessAction()
+        public void ProcessAction(int segmentNumber, IEnumerable<TransformStatus> currentTransformStatus)
         {
-            throw new NotImplementedException();
+            var now = Time.unscaledTime;
+            if (now - timeBetweenClicks > Replay_LastClickTime)
+            {
+                var screenHeight = Screen.height;
+                var screenWidth = Screen.width;
+
+                var possibleTransformsToClick = currentTransformStatus.Where(a => a.screenSpaceBounds != null).ToList();
+                var possibleTransformsCount = possibleTransformsToClick.Count;
+                var RESTART_LIMIT = 20;
+                var restartCount = 0;
+                // try up to 20 times per frame to find a valid click object, but after that, give up till the next frame as none may be available
+                // helps prevent long searches, or cases where the user excludes the whole screen
+                do
+                {
+                    var transformOption = possibleTransformsToClick[Random.Range(0, possibleTransformsCount)];
+                    if (StateRecorderUtils.OptimizedStringStartsWithStringInList(excludedNormalizedPaths, transformOption.NormalizedPath))
+                    {
+                        // not allowed object .. pick another
+                        continue; // while
+                    }
+
+                    var ssbCenter = transformOption.screenSpaceBounds.Value.center;
+                    var x = (int)ssbCenter.x;
+                    var y = (int)ssbCenter.y;
+
+                    var valid = true;
+                    var count = excludedAreas.Count;
+                    for (var i = 0; i < count; i++)
+                    {
+                        var excludedArea = excludedAreas[i];
+                        var xMin = excludedArea.xMin;
+                        var xMax = excludedArea.xMax;
+                        var yMin = excludedArea.yMin;
+                        var yMax = excludedArea.yMax;
+
+                        // normalize the location to the current resolution
+                        if (screenWidth != screenSize.x)
+                        {
+                            var ratio = screenWidth / screenSize.x;
+                            xMin *= ratio;
+                            xMax *= ratio;
+                        }
+
+                        if (screenHeight != screenSize.y)
+                        {
+                            var ratio = screenHeight / screenSize.y;
+                            yMin *= ratio;
+                            yMax *= ratio;
+                        }
+
+                        if (x >= xMin && x <= xMax)
+                        {
+                            valid = false;
+                            break; // for
+                        }
+
+                        if (y >= yMin && y <= yMax)
+                        {
+                            valid = false;
+                            break; // for
+                        }
+                    }
+
+                    if (valid)
+                    {
+                        MouseEventSender.SendMouseEvent(segmentNumber, new MouseInputActionData()
+                        {
+                            position = new Vector2Int(x, y),
+                            leftButton = Random.Range(0, 2) == 0,
+                            middleButton = Random.Range(0, 2) == 0,
+                            rightButton = Random.Range(0, 2) == 0,
+                        }, null, null, null, null);
+                        Replay_LastClickTime = now;
+                        break; // while
+                    }
+
+                } while (++restartCount < RESTART_LIMIT);
+            }
         }
 
         public void WriteToStringBuilder(StringBuilder stringBuilder)
         {
             stringBuilder.Append("{\"apiVersion\":");
             IntJsonConverter.WriteToStringBuilder(stringBuilder, apiVersion);
+            stringBuilder.Append(",\"screenSize\":");
+            VectorIntJsonConverter.WriteToStringBuilder(stringBuilder, screenSize);
             stringBuilder.Append(",\"timeBetweenClicks\":");
             FloatJsonConverter.WriteToStringBuilder(stringBuilder, timeBetweenClicks);
             stringBuilder.Append(",\"excludedAreas\":[");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
@@ -176,15 +176,20 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
                         if (valid)
                         {
-                            RGDebug.LogInfo($"RandomMouseObjectClicker - Mouse action at point x: {x}, y: {y} on object with NormalizedPath: {transformOption.NormalizedPath}");
+                            var lb = Random.Range(0, 2) == 0;
+                            var mb = Random.Range(0, 2) == 0;
+                            var rb = Random.Range(0, 2) == 0;
+                            var fb = Random.Range(0, 2) == 0;
+                            var bb = Random.Range(0, 2) == 0;
+                            RGDebug.LogInfo($"RandomMouseObjectClicker - {{x:{x}, y:{y}, lb:{(lb?1:0)}, mb:{(mb?1:0)}, rb:{(rb?1:0)}, fb:{(fb?1:0)}, bb:{(bb?1:0)}}} on object with NormalizedPath: {transformOption.NormalizedPath}", transformOption.Transform.gameObject);
                             MouseEventSender.SendRawPositionMouseEvent(
                                 segmentNumber,
                                 new Vector2(x, y),
-                                Random.Range(0, 2) == 0,
-                                Random.Range(0, 2) == 0,
-                                Random.Range(0, 2) == 0,
-                                Random.Range(0, 2) == 0,
-                                Random.Range(0, 2) == 0,
+                                lb,
+                                mb,
+                                rb,
+                                fb,
+                                bb,
                                 new Vector2(0,0) // don't support random scrolling yet...
                             );
                             Replay_LastClickTime = now;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
@@ -66,7 +66,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             // no-op
         }
 
-        public string ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
+        public bool ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms, out string error)
         {
             var now = Time.unscaledTime;
             if (now - timeBetweenClicks > Replay_LastClickTime)
@@ -91,20 +91,21 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                 if (!preconditionsMet)
                 {
                     //TODO: Someday make this only log the ones that weren't matched instead of all the preconditions
-                    StringBuilder error = new StringBuilder(500);
-                    error.Append("RandomMouseClicker - Missing one or more precondition normalized paths\r\n");
+                    StringBuilder theError = new StringBuilder(500);
+                    theError.Append("RandomMouseClicker - Missing one or more precondition normalized paths\r\n");
                     var preconditionNormalizedPathsCount = preconditionNormalizedPaths.Count;
                     for (var i = 0; i < preconditionNormalizedPathsCount; i++)
                     {
                         var pc = preconditionNormalizedPaths[i];
-                        error.Append(pc);
+                        theError.Append(pc);
                         if (i + 1 < preconditionNormalizedPathsCount)
                         {
-                            error.Append("\r\n");
+                            theError.Append("\r\n");
                         }
                     }
 
-                    return error.ToString();
+                    error = theError.ToString();
+                    return false;
                 }
 
                 if (currentGameObjectTransforms.Count == 0 || uiOrGameObject && currentUITransforms.Count > 0)
@@ -193,14 +194,16 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                                 new Vector2(0,0) // don't support random scrolling yet...
                             );
                             Replay_LastClickTime = now;
-                            break; // while
+                            error = null;
+                            return true;
                         }
 
                     } while (++restartCount < RESTART_LIMIT);
                 }
             }
 
-            return null;
+            error = null;
+            return false;
         }
 
         public void WriteToStringBuilder(StringBuilder stringBuilder)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using RegressionGames.StateRecorder.JsonConverters;
+using RegressionGames.StateRecorder.Models;
+using UnityEngine;
+
+namespace RegressionGames.StateRecorder.BotSegments.Models
+{
+    /**
+     * <summary>Data for clicking on a random renderable object in the frame</summary>
+     */
+    [Serializable]
+    public class RandomMouseObjectActionData : IBotActionData
+    {
+        // api version for this object, update if object format changes
+        public int apiVersion = BotSegment.SDK_API_VERSION_2;
+
+        [NonSerialized]
+        public static readonly BotActionType Type = BotActionType.RandomMouse_ClickObject;
+
+        /**
+         * <summary>The minimum time gap between clicks, 0 means click once per frame.</summary>
+         */
+        public float timeBetweenClicks;
+        /**
+         * <summary>The screen pixel rects to avoid clicking in</summary>
+         */
+        public List<RectInt> excludedAreas = new();
+        /**
+         * <summary>The object paths to avoid clicking on</summary>
+         */
+        public List<string> excludedNormalizedPaths = new();
+
+        public bool? IsCompleted()
+        {
+            return null;
+        }
+
+        public void ReplayReset()
+        {
+        }
+
+        public void ProcessAction()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteToStringBuilder(StringBuilder stringBuilder)
+        {
+            stringBuilder.Append("{\"apiVersion\":");
+            IntJsonConverter.WriteToStringBuilder(stringBuilder, apiVersion);
+            stringBuilder.Append(",\"timeBetweenClicks\":");
+            FloatJsonConverter.WriteToStringBuilder(stringBuilder, timeBetweenClicks);
+            stringBuilder.Append(",\"excludedAreas\":[");
+            var excludedAreasCount = excludedAreas.Count;
+            for (var i = 0; i < excludedAreasCount; i++)
+            {
+                var excludedArea = excludedAreas[i];
+                RectIntJsonConverter.WriteToStringBuilder(stringBuilder, excludedArea);
+                if (i + 1 < excludedAreasCount)
+                {
+                    stringBuilder.Append(",");
+                }
+            }
+
+            stringBuilder.Append("],\"excludedNormalizedPaths\":[");
+            var excludedNormalizedPathsCount = excludedNormalizedPaths.Count;
+            for (var i = 0; i < excludedNormalizedPathsCount; i++)
+            {
+                var excludedNormalizedPath = excludedNormalizedPaths[i];
+                StringJsonConverter.WriteToStringBuilder(stringBuilder, excludedNormalizedPath);
+                if (i + 1 < excludedAreasCount)
+                {
+                    stringBuilder.Append(",");
+                }
+            }
+
+            stringBuilder.Append("]}");
+        }
+
+        public int EffectiveApiVersion()
+        {
+            return apiVersion;
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 426eea057aa54deb8c20a0a830ce9933
+timeCreated: 1718203771

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
@@ -55,7 +55,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             // no-op
         }
 
-        public string ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
+        public bool ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms, out string error)
         {
             var now = Time.unscaledTime;
             if (now - timeBetweenClicks > Replay_LastClickTime)
@@ -114,6 +114,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
                 if (restartCount < RESTART_LIMIT)
                 {
+                    error = null;
                     MouseEventSender.SendMouseEvent(segmentNumber, new MouseInputActionData()
                     {
                         position = new Vector2Int(x, y),
@@ -121,10 +122,12 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                         middleButton = Random.Range(0, 2) == 0,
                         rightButton = Random.Range(0, 2) == 0,
                     }, null, null, currentUITransforms, currentGameObjectTransforms);
+                    return true;
                 }
             }
 
-            return null;
+            error = null;
+            return false;
         }
 
         public void WriteToStringBuilder(StringBuilder stringBuilder)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
@@ -50,7 +50,12 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         {
         }
 
-        public void ProcessAction(int segmentNumber, IEnumerable<TransformStatus> currentTransformStatus)
+        public void StartAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
+        {
+            // no-op
+        }
+
+        public void ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
         {
             var now = Time.unscaledTime;
             if (now - timeBetweenClicks > Replay_LastClickTime)
@@ -115,7 +120,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                         leftButton = Random.Range(0, 2) == 0,
                         middleButton = Random.Range(0, 2) == 0,
                         rightButton = Random.Range(0, 2) == 0,
-                    }, null, null, null, null);
+                    }, null, null, currentUITransforms, currentGameObjectTransforms);
                 }
             }
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
@@ -1,8 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Newtonsoft.Json;
+using RegressionGames.StateRecorder.BotSegments.JsonConverters;
 using RegressionGames.StateRecorder.JsonConverters;
+using RegressionGames.StateRecorder.Models;
 using UnityEngine;
+using Random = UnityEngine.Random;
 
 namespace RegressionGames.StateRecorder.BotSegments.Models
 {
@@ -10,6 +14,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
      * <summary>Data for clicking on a random pixel in the frame</summary>
      */
     [Serializable]
+    [JsonConverter(typeof(RandomMousePixelActionDataJsonConverter))]
     public class RandomMousePixelActionData : IBotActionData
     {
         // api version for this object, update if object format changes
@@ -18,10 +23,19 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         [NonSerialized]
         public static readonly BotActionType Type = BotActionType.RandomMouse_ClickPixel;
 
+        [NonSerialized]
+        private float Replay_LastClickTime = float.MinValue;
+
         /**
          * <summary>The minimum time gap between clicks, 0 means click once per frame.</summary>
          */
         public float timeBetweenClicks;
+
+        /**
+         * <summary>Used to normalize the excluded areas values to the current screen size</summary>
+         */
+        public Vector2Int screenSize;
+
         /**
          * <summary>The screen pixel rects to avoid clicking in</summary>
          */
@@ -36,15 +50,82 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         {
         }
 
-        public void ProcessAction()
+        public void ProcessAction(int segmentNumber, IEnumerable<TransformStatus> currentTransformStatus)
         {
-            throw new NotImplementedException();
+            var now = Time.unscaledTime;
+            if (now - timeBetweenClicks > Replay_LastClickTime)
+            {
+                var screenWidth = Screen.width;
+                var screenHeight = Screen.height;
+
+                var x = Random.Range(0, screenWidth);
+                var y = Random.Range(0, screenHeight);
+
+                var RESTART_LIMIT = 20;
+
+                var count = excludedAreas.Count;
+                var restartCount = 0;
+                // try up to 20 times per frame to find a valid click spot, but after that, give up till the next frame as none may be available
+                // helps prevent long searches, or cases where the user excludes the whole screen
+                for (var i = 0; i < count && restartCount < RESTART_LIMIT; i++)
+                {
+                    var excludedArea = excludedAreas[i];
+                    var xMin = excludedArea.xMin;
+                    var xMax = excludedArea.xMax;
+                    var yMin = excludedArea.yMin;
+                    var yMax = excludedArea.yMax;
+
+                    // normalize the location to the current resolution
+                    if (screenWidth != screenSize.x)
+                    {
+                        var ratio = screenWidth / screenSize.x;
+                        xMin *= ratio;
+                        xMax *= ratio;
+                    }
+
+                    if (screenHeight != screenSize.y)
+                    {
+                        var ratio = screenHeight / screenSize.y;
+                        yMin *= ratio;
+                        yMax *= ratio;
+                    }
+
+                    if (x >= xMin && x <= xMax)
+                    {
+                        x = Random.Range(0, screenWidth);
+                        // restart the loop
+                        i = -1;
+                        restartCount++;
+                    }
+
+                    if (y >= yMin && y <= yMax)
+                    {
+                        y = Random.Range(0, screenHeight);
+                        // restart the loop
+                        i = -1;
+                        restartCount++;
+                    }
+                }
+
+                if (restartCount < RESTART_LIMIT)
+                {
+                    MouseEventSender.SendMouseEvent(segmentNumber, new MouseInputActionData()
+                    {
+                        position = new Vector2Int(x, y),
+                        leftButton = Random.Range(0, 2) == 0,
+                        middleButton = Random.Range(0, 2) == 0,
+                        rightButton = Random.Range(0, 2) == 0,
+                    }, null, null, null, null);
+                }
+            }
         }
 
         public void WriteToStringBuilder(StringBuilder stringBuilder)
         {
             stringBuilder.Append("{\"apiVersion\":");
             IntJsonConverter.WriteToStringBuilder(stringBuilder, apiVersion);
+            stringBuilder.Append(",\"screenSize\":");
+            VectorIntJsonConverter.WriteToStringBuilder(stringBuilder, screenSize);
             stringBuilder.Append(",\"timeBetweenClicks\":");
             FloatJsonConverter.WriteToStringBuilder(stringBuilder, timeBetweenClicks);
             stringBuilder.Append(",\"excludedAreas\":[");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using RegressionGames.StateRecorder.JsonConverters;
+using UnityEngine;
+
+namespace RegressionGames.StateRecorder.BotSegments.Models
+{
+    /**
+     * <summary>Data for clicking on a random pixel in the frame</summary>
+     */
+    [Serializable]
+    public class RandomMousePixelActionData : IBotActionData
+    {
+        // api version for this object, update if object format changes
+        public int apiVersion = BotSegment.SDK_API_VERSION_2;
+
+        [NonSerialized]
+        public static readonly BotActionType Type = BotActionType.RandomMouse_ClickPixel;
+
+        /**
+         * <summary>The minimum time gap between clicks, 0 means click once per frame.</summary>
+         */
+        public float timeBetweenClicks;
+        /**
+         * <summary>The screen pixel rects to avoid clicking in</summary>
+         */
+        public List<RectInt> excludedAreas = new();
+
+        public bool? IsCompleted()
+        {
+            return null;
+        }
+
+        public void ReplayReset()
+        {
+        }
+
+        public void ProcessAction()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteToStringBuilder(StringBuilder stringBuilder)
+        {
+            stringBuilder.Append("{\"apiVersion\":");
+            IntJsonConverter.WriteToStringBuilder(stringBuilder, apiVersion);
+            stringBuilder.Append(",\"timeBetweenClicks\":");
+            FloatJsonConverter.WriteToStringBuilder(stringBuilder, timeBetweenClicks);
+            stringBuilder.Append(",\"excludedAreas\":[");
+            var excludedAreasCount = excludedAreas.Count;
+            for (var i = 0; i < excludedAreasCount; i++)
+            {
+                var excludedArea = excludedAreas[i];
+                RectIntJsonConverter.WriteToStringBuilder(stringBuilder, excludedArea);
+                if (i + 1 < excludedAreasCount)
+                {
+                    stringBuilder.Append(",");
+                }
+            }
+
+            stringBuilder.Append("]}");
+        }
+
+        public int EffectiveApiVersion()
+        {
+            return apiVersion;
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
@@ -55,7 +55,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             // no-op
         }
 
-        public void ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
+        public string ProcessAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
         {
             var now = Time.unscaledTime;
             if (now - timeBetweenClicks > Replay_LastClickTime)
@@ -123,6 +123,8 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                     }, null, null, currentUITransforms, currentGameObjectTransforms);
                 }
             }
+
+            return null;
         }
 
         public void WriteToStringBuilder(StringBuilder stringBuilder)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e2366c7839814d7ea244db1f3b79d5d8
+timeCreated: 1718203108

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/RectIntJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/RectIntJsonConverter.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using RegressionGames.StateRecorder.BotSegments.Models;
+using UnityEngine;
+
+namespace RegressionGames.StateRecorder.JsonConverters
+{
+    public class RectIntJsonConverter : Newtonsoft.Json.JsonConverter
+    {
+
+        // re-usable and large enough to fit all sizes
+        private static readonly StringBuilder _stringBuilder = new StringBuilder(1000);
+
+        public static void WriteToStringBuilderNullable(StringBuilder stringBuilder, RectInt? f)
+        {
+            if (!f.HasValue)
+            {
+                stringBuilder.Append("null");
+                return;
+            }
+            WriteToStringBuilder(stringBuilder, f.Value);
+        }
+
+        public static void WriteToStringBuilder(StringBuilder stringBuilder, RectInt value)
+        {
+            stringBuilder.Append("{\"x\":");
+            IntJsonConverter.WriteToStringBuilder(stringBuilder, value.x);
+            stringBuilder.Append(",\"y\":");
+            IntJsonConverter.WriteToStringBuilder(stringBuilder, value.y);
+            stringBuilder.Append(",\"width\":");
+            IntJsonConverter.WriteToStringBuilder(stringBuilder, value.width);
+            stringBuilder.Append(",\"height\":");
+            IntJsonConverter.WriteToStringBuilder(stringBuilder, value.height);
+            stringBuilder.Append("}");
+        }
+
+        private static string ToJsonString(RectInt val)
+        {
+            _stringBuilder.Clear();
+            WriteToStringBuilder(_stringBuilder, val);
+            return _stringBuilder.ToString();
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+            }
+            else
+            {
+                // raw is way faster than using the libraries
+                writer.WriteRawValue(ToJsonString((RectInt)value));
+            }
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JObject jObject = JObject.Load(reader);
+            // ReSharper disable once UseObjectOrCollectionInitializer - easier to debug without using this
+            RectInt rect = new();
+            rect.x = jObject["x"].ToObject<int>();
+            rect.y = jObject["y"].ToObject<int>();
+            rect.width = jObject["width"].ToObject<int>();
+            rect.height = jObject["height"].ToObject<int>();
+            return rect;
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(RectInt) || objectType == typeof(RectInt?);
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/RectIntJsonConverter.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/RectIntJsonConverter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b0df7f9fa71d4b11a6725ff8ea69e4d8
+timeCreated: 1718203929

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonUtils.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonUtils.cs
@@ -166,6 +166,10 @@ namespace RegressionGames.StateRecorder
             {
                 converter = new RectJsonConverter();
             }
+            else if (objectType == typeof(RectInt))
+            {
+                converter = new RectIntJsonConverter();
+            }
             else if (objectType == typeof(RawImage))
             {
                 converter = new RawImageJsonConverter();

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardEventSender.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardEventSender.cs
@@ -16,9 +16,8 @@ namespace RegressionGames.StateRecorder
             _isShiftDown = false;
         }
 
-        public static void SendKeyEvent(KeyboardInputActionData keyboardData, KeyState upOrDown)
+        public static void SendKeyEvent(int replaySegment, KeyboardInputActionData keyboardData, KeyState upOrDown)
         {
-            var replaySegment = keyboardData.Replay_SegmentNumber;
             var key = keyboardData.Key;
             #if ENABLE_LEGACY_INPUT_MANAGER
             SendKeyEventLegacy(key, upOrDown);

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardEventSender.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardEventSender.cs
@@ -1,0 +1,99 @@
+﻿using System.Linq;
+using RegressionGames.RGLegacyInputUtility;
+using RegressionGames.StateRecorder.Models;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Controls;
+using UnityEngine.InputSystem.LowLevel;
+
+namespace RegressionGames.StateRecorder
+{
+    public static class KeyboardEventSender
+    {
+        private static bool _isShiftDown;
+
+        public static void Reset()
+        {
+            _isShiftDown = false;
+        }
+
+        public static void SendKeyEvent(KeyboardInputActionData keyboardData, KeyState upOrDown)
+        {
+            var replaySegment = keyboardData.Replay_SegmentNumber;
+            var key = keyboardData.Key;
+            #if ENABLE_LEGACY_INPUT_MANAGER
+            SendKeyEventLegacy(key, upOrDown);
+            #endif
+
+            var keyboard = Keyboard.current;
+
+            if (key == Key.LeftShift || key == Key.RightShift)
+            {
+                _isShiftDown = upOrDown == KeyState.Down;
+            }
+
+            // 1f == true == pressed state
+            // 0f == false == un-pressed state
+            using (DeltaStateEvent.From(keyboard, out var eventPtr))
+            {
+                var time = InputState.currentTime;
+                eventPtr.time = time;
+
+                var inputControl = keyboard.allControls
+                    .FirstOrDefault(a => a is KeyControl kc && kc.keyCode == key) ?? keyboard.anyKey;
+
+                if (inputControl != null)
+                {
+                    RGDebug.LogInfo($"({replaySegment}) Sending Key Event: [{keyboardData.Replay_StartTime}] [{keyboardData.Replay_EndTime}] - {key} - {upOrDown}");
+
+                    // queue input event
+                    inputControl.WriteValueIntoEvent(upOrDown == KeyState.Down ? 1f : 0f, eventPtr);
+                    InputSystem.QueueEvent(eventPtr);
+
+                    if (upOrDown == KeyState.Up)
+                    {
+                        return;
+                    }
+
+                    // send a text event so that 'onChange' text events fire
+                    // convert key to text
+                    if (KeyboardInputActionObserver.KeyboardKeyToValueMap.TryGetValue(((KeyControl)inputControl).keyCode, out var possibleValues))
+                    {
+                        var value = _isShiftDown ? possibleValues.Item2 : possibleValues.Item1;
+                        if (value == 0x00)
+                        {
+                            RGDebug.LogError($"Found null value for keyboard input {key}");
+                            return;
+                        }
+
+                        var inputEvent = TextEvent.Create(Keyboard.current.deviceId, value, time);
+                        InputSystem.QueueEvent(ref inputEvent);
+                    }
+                }
+            }
+        }
+
+#if ENABLE_LEGACY_INPUT_MANAGER
+        private static void SendKeyEventLegacy(Key key, KeyState upOrDown)
+        {
+            if (RGLegacyInputWrapper.IsPassthrough)
+            {
+                // simulation not started
+                return;
+            }
+
+            switch (upOrDown)
+            {
+                case KeyState.Down:
+                    RGLegacyInputWrapper.SimulateKeyPress(RGLegacyInputUtils.InputSystemKeyToKeyCode(key));
+                    break;
+                case KeyState.Up:
+                    RGLegacyInputWrapper.SimulateKeyRelease(RGLegacyInputUtils.InputSystemKeyToKeyCode(key));
+                    break;
+                default:
+                    RGDebug.LogError($"Unexpected key state {upOrDown}");
+                    break;
+            }
+        }
+#endif
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardEventSender.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardEventSender.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 402d2ee500d346b1a48a7d27a8d98c1e
+timeCreated: 1718207480

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/KeyState.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/KeyState.cs
@@ -1,0 +1,8 @@
+﻿namespace RegressionGames.StateRecorder.Models
+{
+    public enum KeyState
+    {
+        Up,
+        Down
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/KeyState.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/KeyState.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4396a969ca8641da8d27a88ef9062f8d
+timeCreated: 1718206913

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/KeyboardInputActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/KeyboardInputActionData.cs
@@ -71,10 +71,6 @@ namespace RegressionGames.StateRecorder.Models
         [NonSerialized]
         public readonly bool[] Replay_StartEndSentFlags = { false, false };
 
-        // Replay only - used for logging
-        [NonSerialized]
-        public int Replay_SegmentNumber;
-
         // Replay only
         [NonSerialized]
         public double Replay_OffsetTime;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseEventSender.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseEventSender.cs
@@ -27,14 +27,12 @@ namespace RegressionGames.StateRecorder
             _mouseEventHandler = null;
         }
 
-        public static InputDevice GetMouse(bool forceListener = false)
+        public static InputDevice GetMouse()
         {
             var mouse = InputSystem.devices.FirstOrDefault(a => a.name == "RGVirtualMouse");
-            var created = false;
             if (mouse == null)
             {
                 mouse = InputSystem.AddDevice<Mouse>("RGVirtualMouse");
-                created = true;
             }
 
             if (!mouse.enabled)
@@ -42,7 +40,7 @@ namespace RegressionGames.StateRecorder
                 InputSystem.EnableDevice(mouse);
             }
 
-            if (forceListener || created)
+            if (_mouseEventHandler == null)
             {
                 _mouseEventHandler = InputSystem.onEvent.ForDevice(mouse).Call(e =>
                 {
@@ -54,7 +52,8 @@ namespace RegressionGames.StateRecorder
                     ) != null;
                     RGDebug.LogDebug("Mouse event at: " + position.x + "," + position.y + "  buttonsClicked: " + buttonsClicked);
                     // need to use the static accessor here as this anonymous function's parent gameObject instance could get destroyed
-                    UnityEngine.Object.FindObjectOfType<VirtualMouseCursor>()?.SetPosition(position, buttonsClicked);
+                    var virtualMouseCursors = UnityEngine.Object.FindObjectsOfType<VirtualMouseCursor>();
+                    virtualMouseCursors.FirstOrDefault()?.SetPosition(position, buttonsClicked);
                 });
             }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseEventSender.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseEventSender.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3450e6f9986c45a5828d152d3a3a6813
+timeCreated: 1718207030

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordedGameObjectStatePathEqualityComparer.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordedGameObjectStatePathEqualityComparer.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using RegressionGames.StateRecorder.Models;
+
+namespace RegressionGames.StateRecorder
+{
+    public class RecordedGameObjectStatePathEqualityComparer : IEqualityComparer<TransformStatus>
+    {
+        public bool Equals(TransformStatus x, TransformStatus y)
+        {
+            if (x?.worldSpaceBounds != null || y?.worldSpaceBounds != null)
+            {
+                // for world space objects, we don't want to unique-ify based on path
+                return false;
+            }
+
+            return x?.Path == y?.Path;
+        }
+
+        public int GetHashCode(TransformStatus obj)
+        {
+            return obj.Path.GetHashCode();
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordedGameObjectStatePathEqualityComparer.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/RecordedGameObjectStatePathEqualityComparer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9b3c94dc1dbe4e1392cd104980786fd6
+timeCreated: 1718207427

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayBotSegmentsContainer.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayBotSegmentsContainer.cs
@@ -4,10 +4,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using Newtonsoft.Json;
-using RegressionGames.StateRecorder;
 using RegressionGames.StateRecorder.BotSegments.Models;
-using UnityEngine;
-using UnityEngine.InputSystem;
 
 namespace RegressionGames.StateRecorder
 {
@@ -18,7 +15,6 @@ namespace RegressionGames.StateRecorder
         private int _botSegmentIndex = 0;
 
         public string SessionId { get; private set; }
-        public bool IsShiftDown;
 
         public ReplayBotSegmentsContainer(string zipFilePath)
         {
@@ -29,8 +25,6 @@ namespace RegressionGames.StateRecorder
         {
             // sets indexes back to 0
             _botSegmentIndex = 0;
-
-            IsShiftDown = false;
 
             // reset all the tracking flags
             foreach (var botSegment in _botSegments)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-
+using System.Linq;
 using RegressionGames.StateRecorder.BotSegments;
 using RegressionGames.StateRecorder.BotSegments.Models;
 using RegressionGames.StateRecorder.Models;
@@ -237,15 +237,17 @@ namespace RegressionGames.StateRecorder
         private void EvaluateBotSegments()
         {
             var now = Time.unscaledTime;
-            // PlayInputs will occur 2 times in this method
+
+            IEnumerable<TransformStatus> transformStatus = InGameObjectFinder.GetInstance().GetUITransformsForCurrentFrame().Item2.Values.Concat(InGameObjectFinder.GetInstance().GetGameObjectTransformsForCurrentFrame().Item2.Values);
+
+            // ProcessAction will occur up to 2 times in this method
             // once after checking if new inputs need to be processed, and one last time after checking if we need to get the next bot segment
             // the goal being to always play the inputs as quickly as possible
-
             BotSegment firstActionSegment = null;
             if (_nextBotSegments.Count > 0)
             {
                 firstActionSegment = _nextBotSegments[0];
-                firstActionSegment.ProcessAction();
+                firstActionSegment.ProcessAction(transformStatus);
             }
 
             // check count each loop because we remove from it during the loop
@@ -346,7 +348,7 @@ namespace RegressionGames.StateRecorder
                 var nextSegment = _nextBotSegments[0];
                 if (nextSegment != firstActionSegment)
                 {
-                    nextSegment.ProcessAction();
+                    nextSegment.ProcessAction(transformStatus);
                 }
             }
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -245,7 +245,15 @@ namespace RegressionGames.StateRecorder
             if (_nextBotSegments.Count > 0)
             {
                 firstActionSegment = _nextBotSegments[0];
-                firstActionSegment.ProcessAction(currentUiTransforms, currentGameObjectTransforms);
+                var error = firstActionSegment.ProcessAction(currentUiTransforms, currentGameObjectTransforms);
+                // only log this if we're really stuck on it
+                if (error != null && _lastTimeLoggedKeyFrameConditions < now - 5)
+                {
+                    var loggedMessage = $"({firstActionSegment.Replay_SegmentNumber}) - Error processing BotAction\r\n" + error;
+                    _lastTimeLoggedKeyFrameConditions = now;
+                    RGDebug.LogInfo(loggedMessage);
+                    FindObjectOfType<ReplayToolbarManager>()?.SetKeyFrameWarningText(loggedMessage);
+                }
             }
 
             // check count each loop because we remove from it during the loop
@@ -347,11 +355,13 @@ namespace RegressionGames.StateRecorder
                 if (nextSegment != firstActionSegment)
                 {
                     var error = nextSegment.ProcessAction(currentUiTransforms, currentGameObjectTransforms);
-                    if (error != null)
+                    // only log this if we're really stuck on it
+                    if (error != null && _lastTimeLoggedKeyFrameConditions < now - 5)
                     {
                         var loggedMessage = $"({nextSegment.Replay_SegmentNumber}) - Error processing BotAction\r\n" + error;
                         _lastTimeLoggedKeyFrameConditions = now;
                         RGDebug.LogInfo(loggedMessage);
+                        FindObjectOfType<ReplayToolbarManager>()?.SetKeyFrameWarningText(loggedMessage);
                     }
                 }
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -66,7 +66,7 @@ namespace RegressionGames.StateRecorder
         {
             _screenRecorder = GetComponentInParent<ScreenRecorder>();
             SetupEventSystem();
-            MouseEventSender.GetMouse(true);
+            MouseEventSender.GetMouse();
         }
 
         private void OnDisable()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -262,6 +262,11 @@ namespace RegressionGames.StateRecorder
                 firstActionSegment = _nextBotSegments[0];
                 var error = firstActionSegment.ProcessAction(currentUiTransforms, currentGameObjectTransforms);
                 // only log this if we're really stuck on it
+                if (error == null)
+                {
+                    // for every non error action, reset the timer
+                    _lastTimeLoggedKeyFrameConditions = now;
+                }
                 if (error != null && _lastTimeLoggedKeyFrameConditions < now - LOG_ERROR_INTERVAL)
                 {
                     var loggedMessage = $"({firstActionSegment.Replay_SegmentNumber}) - Error processing BotAction\r\n" + error;
@@ -307,6 +312,7 @@ namespace RegressionGames.StateRecorder
 
                     if (nextBotSegment.Replay_ActionStarted && nextBotSegment.Replay_ActionCompleted)
                     {
+                        _lastTimeLoggedKeyFrameConditions = now;
                         RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment Completed");
                         //Process the inputs from that bot segment if necessary
                         _nextBotSegments.RemoveAt(i);
@@ -370,6 +376,11 @@ namespace RegressionGames.StateRecorder
                 if (nextSegment != firstActionSegment)
                 {
                     var error = nextSegment.ProcessAction(currentUiTransforms, currentGameObjectTransforms);
+                    if (error == null)
+                    {
+                        // for every non error action, reset the timer
+                        _lastTimeLoggedKeyFrameConditions = now;
+                    }
                     // only log this if we're really stuck on it for a while
                     if (error != null && _lastTimeLoggedKeyFrameConditions < now - LOG_ERROR_INTERVAL)
                     {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 using RegressionGames.StateRecorder.BotSegments;
 using RegressionGames.StateRecorder.BotSegments.Models;
@@ -9,22 +8,13 @@ using RegressionGames.StateRecorder.Models;
 using RegressionGames.RGLegacyInputUtility;
 #endif
 using UnityEngine;
-using UnityEngine.EventSystems;
-using UnityEngine.InputSystem;
-using UnityEngine.InputSystem.Controls;
-using UnityEngine.InputSystem.LowLevel;
-using UnityEngine.InputSystem.UI;
-using UnityEngine.InputSystem.Utilities;
 using UnityEngine.SceneManagement;
 // ReSharper disable MergeIntoPattern
 
 namespace RegressionGames.StateRecorder
 {
-    public class ReplayDataPlaybackController : MonoBehaviour
+    public partial class ReplayDataPlaybackController : MonoBehaviour
     {
-        [Tooltip("UI Element keyframe enforcement mode during replay.  Default is 'Delta'")]
-        public UIReplayEnforcement uiReplayEnforcement = UIReplayEnforcement.Delta;
-
         private ReplayBotSegmentsContainer _dataContainer;
 
         // flag to indicate the next update loop should start playing
@@ -43,17 +33,10 @@ namespace RegressionGames.StateRecorder
         // This is done this way to allow situations like when loading screens (UI) are changing while game objects are loading in the background and the process is not consistent/deterministic between the 2
         private readonly List<BotSegment> _nextBotSegments = new();
 
-        private readonly List<KeyboardInputActionData> _keyboardQueue = new();
-        private readonly List<MouseInputActionData> _mouseQueue = new();
-
         // helps indicate if we made it through the full replay successfully
         private bool? _replaySuccessful;
 
-        private static IDisposable _mouseEventHandler;
-
         public string WaitingForKeyFrameConditions { get; private set; }
-
-        public bool KeyFrameInputComplete { get; private set; }
 
         private ScreenRecorder _screenRecorder;
 
@@ -65,8 +48,7 @@ namespace RegressionGames.StateRecorder
 
         private void OnDestroy()
         {
-            _mouseEventHandler?.Dispose();
-            _mouseEventHandler = null;
+            MouseEventSender.Reset();
         }
 
         void OnSceneLoad(Scene s, LoadSceneMode m)
@@ -84,13 +66,12 @@ namespace RegressionGames.StateRecorder
         {
             _screenRecorder = GetComponentInParent<ScreenRecorder>();
             SetupEventSystem();
-            GetMouse(true);
+            MouseEventSender.GetMouse(true);
         }
 
         private void OnDisable()
         {
-            _mouseEventHandler?.Dispose();
-            _mouseEventHandler = null;
+            MouseEventSender.Reset();
         }
 
         public void SetDataContainer(ReplayBotSegmentsContainer dataContainer)
@@ -98,7 +79,7 @@ namespace RegressionGames.StateRecorder
             Stop();
             _replaySuccessful = null;
 
-            SendMouseEvent(-1, new MouseInputActionData()
+            MouseEventSender.SendMouseEvent(-1, new MouseInputActionData()
             {
                 // get the mouse off the screen, when replay fails, we leave the virtual mouse cursor alone so they can see its location at time of failure, but on new file, we want this gone
                 position = new Vector2Int(Screen.width +20, -20),
@@ -154,8 +135,6 @@ namespace RegressionGames.StateRecorder
 
         public void Stop()
         {
-            _keyboardQueue.Clear();
-            _mouseQueue.Clear();
             _nextBotSegments.Clear();
             _startPlaying = false;
             _isPlaying = false;
@@ -169,6 +148,8 @@ namespace RegressionGames.StateRecorder
             #endif
 
             _dataContainer = null;
+            KeyboardEventSender.Reset();
+            MouseEventSender.Reset();
 
             TransformStatus.Reset();
             KeyFrameEvaluator.Evaluator.Reset();
@@ -178,8 +159,6 @@ namespace RegressionGames.StateRecorder
 
         public void Reset()
         {
-            _keyboardQueue.Clear();
-            _mouseQueue.Clear();
             _nextBotSegments.Clear();
             _startPlaying = false;
             _isPlaying = false;
@@ -194,6 +173,8 @@ namespace RegressionGames.StateRecorder
 
             // similar to Stop, but assumes will play again
             _dataContainer?.Reset();
+            KeyboardEventSender.Reset();
+            MouseEventSender.Reset();
 
             TransformStatus.Reset();
             KeyFrameEvaluator.Evaluator.Reset();
@@ -203,8 +184,6 @@ namespace RegressionGames.StateRecorder
 
         public void ResetForLooping()
         {
-            _keyboardQueue.Clear();
-            _mouseQueue.Clear();
             _nextBotSegments.Clear();
             _startPlaying = true;
             _isPlaying = false;
@@ -218,6 +197,8 @@ namespace RegressionGames.StateRecorder
 
             // similar to Stop, but assumes continued looping .. doesn't stop recording
             _dataContainer?.Reset();
+            KeyboardEventSender.Reset();
+            MouseEventSender.Reset();
 
             TransformStatus.Reset();
             KeyFrameEvaluator.Evaluator.Reset();
@@ -228,580 +209,6 @@ namespace RegressionGames.StateRecorder
         public bool IsPlaying()
         {
             return _isPlaying;
-        }
-
-        private enum KeyState
-        {
-            Up,
-            Down
-        }
-        private void PlayInputs()
-        {
-            var currentTime = Time.unscaledTime;
-            if (_keyboardQueue.Count > 0)
-            {
-                foreach (var replayKeyboardInputEntry in _keyboardQueue)
-                {
-                    if (!replayKeyboardInputEntry.Replay_StartEndSentFlags[0] && currentTime >= replayKeyboardInputEntry.Replay_StartTime)
-                    {
-                        // send start event
-                        SendKeyEvent(replayKeyboardInputEntry, KeyState.Down);
-                        replayKeyboardInputEntry.Replay_StartEndSentFlags[0] = true;
-                    }
-
-                    if (!replayKeyboardInputEntry.Replay_StartEndSentFlags[1] && currentTime >= replayKeyboardInputEntry.Replay_EndTime)
-                    {
-                        // send end event
-                        SendKeyEvent(replayKeyboardInputEntry, KeyState.Up);
-                        replayKeyboardInputEntry.Replay_StartEndSentFlags[1] = true;
-                    }
-                }
-            }
-
-            if (_mouseQueue.Count > 0)
-            {
-                foreach (var replayMouseInputEntry in _mouseQueue)
-                {
-                    if (currentTime >= replayMouseInputEntry.Replay_StartTime)
-                    {
-                        //Need the statuses for the mouse to click correctly when things move a bit or resolution changes
-                        var uiTransforms = InGameObjectFinder.GetInstance().GetUITransformsForCurrentFrame();
-                        var gameObjectTransforms = InGameObjectFinder.GetInstance().GetGameObjectTransformsForCurrentFrame();
-
-                        // send event
-                        SendMouseEvent(replayMouseInputEntry.Replay_SegmentNumber, replayMouseInputEntry, uiTransforms.Item1, gameObjectTransforms.Item1, uiTransforms.Item2, gameObjectTransforms.Item2);
-                        replayMouseInputEntry.Replay_IsDone = true;
-                    }
-                }
-            }
-
-            // clean out any inputs that are done
-            _keyboardQueue.RemoveAll(a => a.Replay_IsDone);
-            _mouseQueue.RemoveAll(a => a.Replay_IsDone);
-        }
-
-#if ENABLE_LEGACY_INPUT_MANAGER
-        private void SendKeyEventLegacy(Key key, KeyState upOrDown)
-        {
-            if (RGLegacyInputWrapper.IsPassthrough)
-            {
-                // simulation not started
-                return;
-            }
-
-            switch (upOrDown)
-            {
-                case KeyState.Down:
-                    RGLegacyInputWrapper.SimulateKeyPress(RGLegacyInputUtils.InputSystemKeyToKeyCode(key));
-                    break;
-                case KeyState.Up:
-                    RGLegacyInputWrapper.SimulateKeyRelease(RGLegacyInputUtils.InputSystemKeyToKeyCode(key));
-                    break;
-                default:
-                    RGDebug.LogError($"Unexpected key state {upOrDown}");
-                    break;
-            }
-        }
-#endif
-
-        private void SendKeyEvent(KeyboardInputActionData keyboardData, KeyState upOrDown)
-        {
-            var replaySegment = keyboardData.Replay_SegmentNumber;
-            var key = keyboardData.Key;
-            #if ENABLE_LEGACY_INPUT_MANAGER
-            SendKeyEventLegacy(key, upOrDown);
-            #endif
-
-            var keyboard = Keyboard.current;
-
-            if (key == Key.LeftShift || key == Key.RightShift)
-            {
-                _dataContainer.IsShiftDown = upOrDown == KeyState.Down;
-            }
-
-            // 1f == true == pressed state
-            // 0f == false == un-pressed state
-            using (DeltaStateEvent.From(keyboard, out var eventPtr))
-            {
-                var time = InputState.currentTime;
-                eventPtr.time = time;
-
-                var inputControl = keyboard.allControls
-                    .FirstOrDefault(a => a is KeyControl kc && kc.keyCode == key) ?? keyboard.anyKey;
-
-                if (inputControl != null)
-                {
-                    RGDebug.LogInfo($"({replaySegment}) Sending Key Event: [{keyboardData.Replay_StartTime}] [{keyboardData.Replay_EndTime}] - {key} - {upOrDown}");
-
-                    // queue input event
-                    inputControl.WriteValueIntoEvent(upOrDown == KeyState.Down ? 1f : 0f, eventPtr);
-                    InputSystem.QueueEvent(eventPtr);
-
-                    if (upOrDown == KeyState.Up)
-                    {
-                        return;
-                    }
-
-                    // send a text event so that 'onChange' text events fire
-                    // convert key to text
-                    if (KeyboardInputActionObserver.KeyboardKeyToValueMap.TryGetValue(((KeyControl)inputControl).keyCode, out var possibleValues))
-                    {
-                        var value = _dataContainer.IsShiftDown ? possibleValues.Item2 : possibleValues.Item1;
-                        if (value == 0x00)
-                        {
-                            RGDebug.LogError($"Found null value for keyboard input {key}");
-                            return;
-                        }
-
-                        var inputEvent = TextEvent.Create(Keyboard.current.deviceId, value, time);
-                        InputSystem.QueueEvent(ref inputEvent);
-                    }
-                }
-            }
-        }
-
-        private static InputDevice GetMouse(bool forceListener = false)
-        {
-            var mouse = InputSystem.devices.FirstOrDefault(a => a.name == "RGVirtualMouse");
-            var created = false;
-            if (mouse == null)
-            {
-                mouse = InputSystem.AddDevice<Mouse>("RGVirtualMouse");
-                created = true;
-            }
-
-            if (!mouse.enabled)
-            {
-                InputSystem.EnableDevice(mouse);
-            }
-
-            if (forceListener || created)
-            {
-                _mouseEventHandler = InputSystem.onEvent.ForDevice(mouse).Call(e =>
-                {
-                    var positionControl = mouse.allControls.First(a => a is Vector2Control && a.name == "position") as Vector2Control;
-                    var position = positionControl.ReadValueFromEvent(e);
-
-                    var buttonsClicked = mouse.allControls.FirstOrDefault(a =>
-                        a is ButtonControl abc && abc.ReadValueFromEvent(e) > 0.1f
-                    ) != null;
-                    RGDebug.LogDebug("Mouse event at: " + position.x + "," + position.y + "  buttonsClicked: " + buttonsClicked);
-                    // need to use the static accessor here as this anonymous function's parent gameObject instance could get destroyed
-                    FindObjectOfType<VirtualMouseCursor>()?.SetPosition(position, buttonsClicked);
-                });
-            }
-
-            return mouse;
-        }
-
-        public class RecordedGameObjectStatePathEqualityComparer : IEqualityComparer<TransformStatus>
-        {
-            public bool Equals(TransformStatus x, TransformStatus y)
-            {
-                if (x?.worldSpaceBounds != null || y?.worldSpaceBounds != null)
-                {
-                    // for world space objects, we don't want to unique-ify based on path
-                    return false;
-                }
-                return x?.Path == y?.Path;
-            }
-
-            public int GetHashCode(TransformStatus obj)
-            {
-                return obj.Path.GetHashCode();
-            }
-        }
-
-        // ReSharper disable once InconsistentNaming
-        private static readonly RecordedGameObjectStatePathEqualityComparer _recordedGameObjectStatePathEqualityComparer = new();
-
-        private static Vector2? _lastMousePosition;
-
-        // Finds the best object to adjust our click position to for a given mouse input
-        // Uses the exact path for UI clicks, but the normalized path for world space clicks
-        // Returns (the object, whether it was world space, the suggested mouse position)
-        private static (TransformStatus, bool, Vector2, IEnumerable<TransformStatus>) FindBestClickObject(Camera mainCamera, MouseInputActionData mouseInput, Dictionary<int, TransformStatus> priorUiTransforms, Dictionary<int, TransformStatus> priorGameObjectTransforms, Dictionary<int, TransformStatus> uiTransforms, Dictionary<int, TransformStatus> gameObjectTransforms)
-        {
-
-            // Mouse is hard... we can't use the raw position, we need to use the position relative to the current resolution
-            // but.. it gets tougher than that.  Some UI elements scale differently with resolution (only horizontal, only vertical, preserve aspect, expand, etc)
-            // so we have to take the bounding space of the original object(s) clicked on into consideration
-            var normalizedPosition = mouseInput.NormalizedPosition;
-
-            // note that if this mouse input wasn't a click, there will be no possible objects
-            if (mouseInput.clickedObjectNormalizedPaths == null || mouseInput.clickedObjectNormalizedPaths.Length == 0)
-            {
-                // bail out early, no click
-                return (null, false, normalizedPosition, uiTransforms.Values.Concat(gameObjectTransforms.Values));
-            }
-
-            var theNp = new Vector3(normalizedPosition.x, normalizedPosition.y, 0f);
-
-            // find possible objects prioritizing the currentState, falling back to the priorState
-
-            // copy so we can remove
-            var mousePaths = mouseInput.clickedObjectNormalizedPaths;
-            var pathsToFind = mousePaths.ToList();
-
-            var possibleObjects = new List<TransformStatus>();
-
-            foreach (var os in uiTransforms)
-            {
-                var val = os.Value;
-                if (StateRecorderUtils.OptimizedContainsStringInArray(mousePaths, val.Path))
-                {
-                    possibleObjects.Add(val);
-                    StateRecorderUtils.OptimizedRemoveStringFromList(pathsToFind, val.Path);
-                }
-            }
-
-            foreach (var os in gameObjectTransforms)
-            {
-                var val = os.Value;
-                if (StateRecorderUtils.OptimizedContainsStringInArray(mousePaths, val.NormalizedPath))
-                {
-                    possibleObjects.Add(val);
-                    StateRecorderUtils.OptimizedRemoveStringFromList(pathsToFind, val.NormalizedPath);
-                }
-            }
-
-            // still have some objects we didnt' find in the current state, check previous state
-            // this is used primarly for mouse up event processing
-            if (pathsToFind.Count > 0)
-            {
-                foreach (var os in priorUiTransforms)
-                {
-                    var val = os.Value;
-                    if (StateRecorderUtils.OptimizedContainsStringInArray(mousePaths, val.Path))
-                    {
-                        possibleObjects.Add(val);
-                    }
-                }
-
-                foreach (var os in priorGameObjectTransforms)
-                {
-                    var val = os.Value;
-                    if (StateRecorderUtils.OptimizedContainsStringInArray(mousePaths, val.NormalizedPath))
-                    {
-                        possibleObjects.Add(val);
-                    }
-                }
-            }
-
-            var cos = possibleObjects.Where(a=>a.screenSpaceBounds.HasValue).OrderBy(a =>
-            {
-                var closestPointInA = a.screenSpaceBounds.Value.ClosestPoint(theNp);
-                return (theNp - closestPointInA).sqrMagnitude;
-            });
-            possibleObjects = cos.Distinct(_recordedGameObjectStatePathEqualityComparer)
-                .ToList(); // select only the first entry of each path for ui elements; uses ToList due to multiple iterations of this structure later in the code to avoid multiple enumeration
-
-            var screenWidth = Screen.width;
-            var screenHeight = Screen.height;
-            float smallestSize = screenWidth * screenHeight;
-
-            TransformStatus bestObject = null;
-            var worldSpaceObject = false;
-
-            var possibleObjectsCount = possibleObjects.Count;
-            for (var j = 0; j < possibleObjectsCount; j++)
-            {
-                var objectToCheck = possibleObjects[j];
-                var ssb = objectToCheck.screenSpaceBounds.Value;
-                var size = ssb.size.x * ssb.size.y;
-
-                if (objectToCheck.worldSpaceBounds != null)
-                {
-                    if (bestObject != null && bestObject.worldSpaceBounds == null)
-                    {
-                        //do nothing, prefer ui elements
-                    }
-                    else
-                    {
-                        if (mouseInput.worldPosition != null)
-                        {
-                            // use the world space click location closest to the actual object location
-                            var mouseWorldPosition = mouseInput.worldPosition.Value;
-                            // uses the collider bounds on that object as colliders are what would drive world space objects' click detection in scripts / etc
-                            var colliders = objectToCheck.Transform.GetComponentsInChildren<Collider>();
-                            if (colliders.FirstOrDefault(a => a.bounds.Contains(mouseWorldPosition)) != null)
-                            {
-                                var screenPoint = mainCamera.WorldToScreenPoint(mouseWorldPosition);
-                                if (screenPoint.x < 0 || screenPoint.x > screenWidth || screenPoint.y < 0 || screenPoint.y > screenHeight)
-                                {
-                                    RGDebug.LogWarning($"Attempted to click at worldPosition: [{mouseWorldPosition.x},{mouseWorldPosition.y},{mouseWorldPosition.z}], which is off screen at position: [{screenPoint.x},{screenPoint.y}]");
-                                }
-                                else
-                                {
-                                    bestObject = objectToCheck;
-                                    worldSpaceObject = true;
-                                    var old = normalizedPosition;
-                                    // we hit one of our world objects, set the normalized position and stop looping
-                                    normalizedPosition = new Vector2Int((int)screenPoint.x, (int)screenPoint.y);
-                                    RGDebug.LogInfo($"Adjusting world click location to ensure hit on object: " + objectToCheck.Path + " oldPosition: (" + old.x + "," + old.y + "), newPosition: (" + normalizedPosition.x + "," + normalizedPosition.y + ")");
-                                    break; // end the for
-                                }
-                            }
-                            else
-                            {
-                                // didn't hit a collider on this object, we fall back to the renderer bounds bestObject evaluation method, similar to ui elements
-
-                                // compare elements bounds for best match
-                                // give some threshold variance here for floating point math on sizes
-                                // if 2 objects are very similarly sized, we want the one closest, not picking
-                                // one based on some floating point rounding error
-                                if (size * 1.02f < smallestSize)
-                                {
-                                    bestObject = objectToCheck;
-                                    smallestSize = size;
-                                }
-                            }
-                        }
-                        else
-                        {
-                            // mouse input didn't capture a world position, so we weren't clicking on a world space object.. ignore anything not UI related from consideration
-                            if (objectToCheck.worldSpaceBounds == null)
-                            {
-                                // compare elements bounds for best match
-                                // give some threshold variance here for floating point math on sizes
-                                // if 2 objects are very similarly sized, we want the one closest, not picking
-                                // one based on some floating point rounding error
-                                if (size * 1.02f < smallestSize)
-                                {
-                                    bestObject = objectToCheck;
-                                    smallestSize = size;
-                                }
-                            }
-                        }
-                    }
-                }
-                else // objectToCheck.worldSpaceBounds == null
-                {
-                    if (bestObject != null && bestObject.worldSpaceBounds == null)
-                    {
-                        // compare ui elements for best match
-                        // give some threshold variance here for floating point math on sizes
-                        // if 2 objects are very similarly sized, we want the one closest, not picking
-                        // one based on some floating point rounding error
-                        if (size * 1.02f < smallestSize)
-                        {
-                            bestObject = objectToCheck;
-                            smallestSize = size;
-                        }
-                    }
-                    else //bestObject.worldSpaceBounds != null
-                    {
-                        // prefer UI elements when overlaps occur with game objects
-                        bestObject = objectToCheck;
-                        smallestSize = size;
-                    }
-                }
-            }
-
-            return (bestObject, worldSpaceObject, normalizedPosition, possibleObjects);
-        }
-
-#if ENABLE_LEGACY_INPUT_MANAGER
-        public static void SendMouseEventLegacy(Vector2 position, Vector2 delta, Vector2 scroll,
-            bool leftButton, bool middleButton, bool rightButton, bool forwardButton, bool backButton)
-        {
-            if (RGLegacyInputWrapper.IsPassthrough)
-            {
-                return;
-            }
-
-            RGLegacyInputWrapper.SimulateMouseMovement(new Vector3(position.x, position.y, 0.0f), new Vector3(delta.x, delta.y, 0.0f));
-            RGLegacyInputWrapper.SimulateMouseScrollWheel(scroll);
-
-            if (leftButton)
-                RGLegacyInputWrapper.SimulateKeyPress(KeyCode.Mouse0);
-            else
-                RGLegacyInputWrapper.SimulateKeyRelease(KeyCode.Mouse0);
-
-            if (middleButton)
-                RGLegacyInputWrapper.SimulateKeyPress(KeyCode.Mouse2);
-            else
-                RGLegacyInputWrapper.SimulateKeyRelease(KeyCode.Mouse2);
-
-            if (rightButton)
-                RGLegacyInputWrapper.SimulateKeyPress(KeyCode.Mouse1);
-            else
-                RGLegacyInputWrapper.SimulateKeyRelease(KeyCode.Mouse1);
-
-            if (forwardButton)
-                RGLegacyInputWrapper.SimulateKeyPress(KeyCode.Mouse3);
-            else
-                RGLegacyInputWrapper.SimulateKeyRelease(KeyCode.Mouse3);
-
-            if (backButton)
-                RGLegacyInputWrapper.SimulateKeyPress(KeyCode.Mouse4);
-            else
-                RGLegacyInputWrapper.SimulateKeyRelease(KeyCode.Mouse4);
-        }
-#endif
-
-        public static void SendMouseEvent(int replaySegment, MouseInputActionData mouseInput, Dictionary<int, TransformStatus> priorUiTransforms, Dictionary<int, TransformStatus> priorGameObjectTransforms, Dictionary<int, TransformStatus> uiTransforms, Dictionary<int, TransformStatus> gameObjectTransforms)
-        {
-            var clickObjectResult = FindBestClickObject(Camera.main, mouseInput, priorUiTransforms, priorGameObjectTransforms,uiTransforms, gameObjectTransforms);
-
-            var bestObject = clickObjectResult.Item1;
-            var normalizedPosition = clickObjectResult.Item3;
-
-            // non-world space object found, make sure we hit the object
-            if (bestObject != null && bestObject.screenSpaceBounds.HasValue && !clickObjectResult.Item2)
-            {
-                var clickBounds = bestObject.screenSpaceBounds.Value;
-
-                var possibleObjects = clickObjectResult.Item4;
-                foreach (var objectToCheck in possibleObjects)
-                {
-                    if (objectToCheck.screenSpaceBounds.HasValue)
-                    {
-                        var ssb = objectToCheck.screenSpaceBounds.Value;
-                        if (clickBounds.Intersects(ssb))
-                        {
-                            // max of the mins; and min of the maxes
-                            clickBounds.SetMinMax(
-                                Vector3.Max(clickBounds.min, ssb.min),
-                                Vector3.Min(clickBounds.max, ssb.max)
-                            );
-                        }
-                    }
-                }
-
-                // make sure our click is on that object
-                if (!clickBounds.Contains(normalizedPosition))
-                {
-                    var old = normalizedPosition;
-                    // use the center of these bounds as our best point to click
-                    normalizedPosition = new Vector2((int)clickBounds.center.x, (int)clickBounds.center.y);
-
-                    RGDebug.LogInfo($"({replaySegment}) Adjusting click location to ensure hit on object path: " + bestObject.Path + " oldPosition: (" + old.x + "," + old.y + "), newPosition: (" + normalizedPosition.x + "," + normalizedPosition.y + ")");
-                }
-            }
-
-            var mouse = GetMouse();
-
-            using (DeltaStateEvent.From(mouse, out var eventPtr))
-            {
-                eventPtr.time = InputState.currentTime;
-
-                var mouseControls = mouse.allControls;
-                var mouseEventString = "";
-
-                // 1f == true == clicked state
-                // 0f == false == un-clicked state
-                foreach (var mouseControl in mouseControls)
-                {
-                    switch (mouseControl.name)
-                    {
-                        case "delta":
-                            if (_lastMousePosition != null)
-                            {
-                                var delta = normalizedPosition - _lastMousePosition.Value;
-                                if (RGDebug.IsDebugEnabled)
-                                {
-                                    mouseEventString += $"delta: {delta.x},{delta.y}  ";
-                                }
-
-                                ((Vector2Control)mouseControl).WriteValueIntoEvent(delta, eventPtr);
-                            }
-                            break;
-                        case "position":
-                            if (RGDebug.IsDebugEnabled)
-                            {
-                                mouseEventString += $"position: {normalizedPosition.x},{normalizedPosition.y}  ";
-                            }
-
-                            ((Vector2Control)mouseControl).WriteValueIntoEvent(normalizedPosition, eventPtr);
-                            break;
-                        case "scroll":
-                            if (RGDebug.IsDebugEnabled)
-                            {
-                                if (mouseInput.scroll.x < -0.1f || mouseInput.scroll.x > 0.1f || mouseInput.scroll.y < -0.1f || mouseInput.scroll.y > 0.1f)
-                                {
-                                    mouseEventString += $"scroll: {mouseInput.scroll.x},{mouseInput.scroll.y}  ";
-                                }
-                            }
-
-                            ((DeltaControl)mouseControl).WriteValueIntoEvent(mouseInput.scroll, eventPtr);
-                            break;
-                        case "leftButton":
-                            if (RGDebug.IsDebugEnabled)
-                            {
-                                if (mouseInput.leftButton)
-                                {
-                                    mouseEventString += $"leftButton  ";
-                                }
-                            }
-
-                            ((ButtonControl)mouseControl).WriteValueIntoEvent(mouseInput.leftButton ? 1f : 0f, eventPtr);
-                            break;
-                        case "middleButton":
-                            if (RGDebug.IsDebugEnabled)
-                            {
-                                if (mouseInput.middleButton)
-                                {
-                                    mouseEventString += $"middleButton  ";
-                                }
-                            }
-
-                            ((ButtonControl)mouseControl).WriteValueIntoEvent(mouseInput.middleButton ? 1f : 0f, eventPtr);
-                            break;
-                        case "rightButton":
-                            if (RGDebug.IsDebugEnabled)
-                            {
-                                if (mouseInput.rightButton)
-                                {
-                                    mouseEventString += $"rightButton  ";
-                                }
-                            }
-
-                            ((ButtonControl)mouseControl).WriteValueIntoEvent(mouseInput.rightButton ? 1f : 0f, eventPtr);
-                            break;
-                        case "forwardButton":
-                            if (RGDebug.IsDebugEnabled)
-                            {
-                                if (mouseInput.forwardButton)
-                                {
-                                    mouseEventString += $"forwardButton  ";
-                                }
-                            }
-
-                            ((ButtonControl)mouseControl).WriteValueIntoEvent(mouseInput.forwardButton ? 1f : 0f, eventPtr);
-                            break;
-                        case "backButton":
-                            if (RGDebug.IsDebugEnabled)
-                            {
-                                if (mouseInput.backButton)
-                                {
-                                    mouseEventString += $"backButton  ";
-                                }
-                            }
-
-                            ((ButtonControl)mouseControl).WriteValueIntoEvent(mouseInput.backButton ? 1f : 0f, eventPtr);
-                            break;
-                    }
-                }
-
-                #if ENABLE_LEGACY_INPUT_MANAGER
-                {
-                    Vector2 delta = _lastMousePosition.HasValue ? (normalizedPosition - _lastMousePosition.Value) : Vector2.zero;
-                    SendMouseEventLegacy(position: normalizedPosition, delta: delta, scroll: mouseInput.scroll,
-                        leftButton: mouseInput.leftButton, middleButton: mouseInput.middleButton, rightButton: mouseInput.rightButton,
-                        forwardButton: mouseInput.forwardButton, backButton: mouseInput.backButton);
-                }
-                #endif
-
-                _lastMousePosition = normalizedPosition;
-
-                if (RGDebug.IsDebugEnabled)
-                {
-                    RGDebug.LogDebug($"({replaySegment}) Sending Mouse Event [{mouseInput.Replay_StartTime}] - {mouseEventString}");
-                }
-
-                InputSystem.QueueEvent(eventPtr);
-            }
         }
 
         public void Update()
@@ -827,49 +234,6 @@ namespace RegressionGames.StateRecorder
 
         private float _lastTimeLoggedKeyFrameConditions = 0;
 
-        private void StartNewActions()
-        {
-            var now = Time.unscaledTime;
-            // only look at actions for the first pending segment.. don't start actions for future segments until the current one ends
-            if (_nextBotSegments.Count > 0)
-            {
-                var nextBotSegment = _nextBotSegments[0];
-                // start processing the action for this segment before evaluating the end condition
-                // the thinking here is 1... less replay lag... 2 the inputs led to the key frame in the first place
-
-                // only process if we haven't processed it already
-                var botAction = nextBotSegment.botAction;
-                if (botAction == null)
-                {
-                    nextBotSegment.Replay_ActionStarted = true;
-                }
-                if (!nextBotSegment.Replay_ActionStarted)
-                {
-                    nextBotSegment.Replay_ActionStarted = true;
-                    if (botAction.data is InputPlaybackActionData ipad)
-                    {
-                        RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Processing InputPlaybackActionData for BotSegment");
-
-                        var currentInputTimePoint = now - ipad.startTime;
-
-                        foreach (var keyboardInputActionData in ipad.inputData.keyboard)
-                        {
-                            keyboardInputActionData.Replay_OffsetTime = currentInputTimePoint;
-                            keyboardInputActionData.Replay_SegmentNumber = nextBotSegment.Replay_SegmentNumber;
-                            _keyboardQueue.Add(keyboardInputActionData);
-                        }
-
-                        foreach (var mouseInputActionData in ipad.inputData.mouse)
-                        {
-                            mouseInputActionData.Replay_OffsetTime = currentInputTimePoint;
-                            mouseInputActionData.Replay_SegmentNumber = nextBotSegment.Replay_SegmentNumber;
-                            _mouseQueue.Add(mouseInputActionData);
-                        }
-                    }
-                }
-            }
-        }
-
         private void EvaluateBotSegments()
         {
             var now = Time.unscaledTime;
@@ -877,11 +241,12 @@ namespace RegressionGames.StateRecorder
             // once after checking if new inputs need to be processed, and one last time after checking if we need to get the next bot segment
             // the goal being to always play the inputs as quickly as possible
 
-            // start / queue up any new actions from bot segments
-            StartNewActions();
-
-            // handle the inputs before checking the result
-            PlayInputs();
+            BotSegment firstActionSegment = null;
+            if (_nextBotSegments.Count > 0)
+            {
+                firstActionSegment = _nextBotSegments[0];
+                firstActionSegment.ProcessAction();
+            }
 
             // check count each loop because we remove from it during the loop
             for (var i = 0; i < _nextBotSegments.Count; /* do not increment here*/)
@@ -974,11 +339,16 @@ namespace RegressionGames.StateRecorder
                 }
             }
 
-            // start / queue up any new actions from bot segments
-            StartNewActions();
-
-            // see if there are any inputs we can play
-            PlayInputs();
+            // if we moved to a new first segment in this frame, process its actions
+            // if we didnt' move to a new frame, then the time hasn't changed within the same frame so no need to call this again
+            if (_nextBotSegments.Count > 0)
+            {
+                var nextSegment = _nextBotSegments[0];
+                if (nextSegment != firstActionSegment)
+                {
+                    nextSegment.ProcessAction();
+                }
+            }
         }
 
         public void LateUpdate()
@@ -992,7 +362,7 @@ namespace RegressionGames.StateRecorder
 
                 if (_nextBotSegments.Count == 0)
                 {
-                    SendMouseEvent(-1, new MouseInputActionData()
+                    MouseEventSender.SendMouseEvent(-1, new MouseInputActionData()
                     {
                         // get the mouse off the screen, when replay fails, we leave the virtual mouse cursor alone so they can see its location at time of failure
                         position = new Vector2Int(Screen.width + 20, -20)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -292,9 +292,9 @@ namespace RegressionGames.StateRecorder
             if (_nextBotSegments.Count > 0)
             {
                 firstActionSegment = _nextBotSegments[0];
-                var error = firstActionSegment.ProcessAction(currentUiTransforms, currentGameObjectTransforms);
+                var didAction = firstActionSegment.ProcessAction(currentUiTransforms, currentGameObjectTransforms, out var error);
                 // only log this if we're really stuck on it
-                if (error == null)
+                if (error == null && didAction)
                 {
                     // for every non error action, reset the timer
                     _lastTimeLoggedKeyFrameConditions = now;
@@ -407,8 +407,9 @@ namespace RegressionGames.StateRecorder
                 var nextSegment = _nextBotSegments[0];
                 if (nextSegment != firstActionSegment)
                 {
-                    var error = nextSegment.ProcessAction(currentUiTransforms, currentGameObjectTransforms);
-                    if (error == null)
+                    var didAction = nextSegment.ProcessAction(currentUiTransforms, currentGameObjectTransforms, out var error);
+                    // only log this if we're really stuck on it
+                    if (error == null && didAction)
                     {
                         // for every non error action, reset the timer
                         _lastTimeLoggedKeyFrameConditions = now;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -249,7 +249,7 @@ namespace RegressionGames.StateRecorder
                 firstActionSegment = _nextBotSegments[0];
                 var error = firstActionSegment.ProcessAction(currentUiTransforms, currentGameObjectTransforms);
                 // only log this if we're really stuck on it
-                if (error != null && _lastTimeLoggedKeyFrameConditions < now - 5)
+                if (error != null && _lastTimeLoggedKeyFrameConditions < now - LOG_ERROR_INTERVAL)
                 {
                     var loggedMessage = $"({firstActionSegment.Replay_SegmentNumber}) - Error processing BotAction\r\n" + error;
                     _lastTimeLoggedKeyFrameConditions = now;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -346,7 +346,13 @@ namespace RegressionGames.StateRecorder
                 var nextSegment = _nextBotSegments[0];
                 if (nextSegment != firstActionSegment)
                 {
-                    nextSegment.ProcessAction(currentUiTransforms, currentGameObjectTransforms);
+                    var error = nextSegment.ProcessAction(currentUiTransforms, currentGameObjectTransforms);
+                    if (error != null)
+                    {
+                        var loggedMessage = $"({nextSegment.Replay_SegmentNumber}) - Error processing BotAction\r\n" + error;
+                        _lastTimeLoggedKeyFrameConditions = now;
+                        RGDebug.LogInfo(loggedMessage);
+                    }
                 }
             }
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using RegressionGames.StateRecorder.BotSegments;
 using RegressionGames.StateRecorder.BotSegments.Models;
 using RegressionGames.StateRecorder.Models;
@@ -13,8 +12,10 @@ using UnityEngine.SceneManagement;
 
 namespace RegressionGames.StateRecorder
 {
-    public partial class ReplayDataPlaybackController : MonoBehaviour
+    public class ReplayDataPlaybackController : MonoBehaviour
     {
+        public bool pauseEditorOnPlaybackWarning = true;
+
         private ReplayBotSegmentsContainer _dataContainer;
 
         // flag to indicate the next update loop should start playing
@@ -233,6 +234,18 @@ namespace RegressionGames.StateRecorder
 
         private const int LOG_ERROR_INTERVAL = 10;
 
+        private void LogPlaybackWarning(string loggedMessage)
+        {
+            var now = Time.unscaledTime;
+            _lastTimeLoggedKeyFrameConditions = now;
+            RGDebug.LogWarning(loggedMessage);
+            FindObjectOfType<ReplayToolbarManager>()?.SetKeyFrameWarningText(loggedMessage);
+            if (pauseEditorOnPlaybackWarning)
+            {
+                Debug.Break();
+            }
+        }
+
         private void EvaluateBotSegments()
         {
             var now = Time.unscaledTime;
@@ -252,9 +265,7 @@ namespace RegressionGames.StateRecorder
                 if (error != null && _lastTimeLoggedKeyFrameConditions < now - LOG_ERROR_INTERVAL)
                 {
                     var loggedMessage = $"({firstActionSegment.Replay_SegmentNumber}) - Error processing BotAction\r\n" + error;
-                    _lastTimeLoggedKeyFrameConditions = now;
-                    RGDebug.LogWarning(loggedMessage);
-                    FindObjectOfType<ReplayToolbarManager>()?.SetKeyFrameWarningText(loggedMessage);
+                    LogPlaybackWarning(loggedMessage);
                 }
             }
 
@@ -314,9 +325,7 @@ namespace RegressionGames.StateRecorder
                         if (warningText != null)
                         {
                             var loggedMessage = $"({nextBotSegment.Replay_SegmentNumber}) - Unmatched Criteria for BotSegment\r\n" + warningText;
-                            _lastTimeLoggedKeyFrameConditions = now;
-                            RGDebug.LogWarning(loggedMessage);
-                            FindObjectOfType<ReplayToolbarManager>()?.SetKeyFrameWarningText(loggedMessage);
+                            LogPlaybackWarning(loggedMessage);
                         }
                     }
 
@@ -365,9 +374,7 @@ namespace RegressionGames.StateRecorder
                     if (error != null && _lastTimeLoggedKeyFrameConditions < now - LOG_ERROR_INTERVAL)
                     {
                         var loggedMessage = $"({nextSegment.Replay_SegmentNumber}) - Error processing BotAction\r\n" + error;
-                        _lastTimeLoggedKeyFrameConditions = now;
-                        RGDebug.LogInfo(loggedMessage);
-                        FindObjectOfType<ReplayToolbarManager>()?.SetKeyFrameWarningText(loggedMessage);
+                        LogPlaybackWarning(loggedMessage);
                     }
                 }
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -79,11 +79,8 @@ namespace RegressionGames.StateRecorder
             Stop();
             _replaySuccessful = null;
 
-            MouseEventSender.SendMouseEvent(-1, new MouseInputActionData()
-            {
-                // get the mouse off the screen, when replay fails, we leave the virtual mouse cursor alone so they can see its location at time of failure, but on new file, we want this gone
-                position = new Vector2Int(Screen.width +20, -20),
-            }, ScreenRecorder._emptyTransformStatusDictionary, ScreenRecorder._emptyTransformStatusDictionary, ScreenRecorder._emptyTransformStatusDictionary, ScreenRecorder._emptyTransformStatusDictionary);
+            // get the mouse off the screen, when replay fails, we leave the virtual mouse cursor alone so they can see its location at time of failure, but on new file, we want this gone
+            MouseEventSender.SendRawPositionMouseEvent(-1, new Vector2(Screen.width+20, -20));
 
             _dataContainer = dataContainer;
         }
@@ -238,7 +235,8 @@ namespace RegressionGames.StateRecorder
         {
             var now = Time.unscaledTime;
 
-            IEnumerable<TransformStatus> transformStatus = InGameObjectFinder.GetInstance().GetUITransformsForCurrentFrame().Item2.Values.Concat(InGameObjectFinder.GetInstance().GetGameObjectTransformsForCurrentFrame().Item2.Values);
+            var currentUiTransforms = InGameObjectFinder.GetInstance().GetUITransformsForCurrentFrame().Item2;
+            var currentGameObjectTransforms = InGameObjectFinder.GetInstance().GetGameObjectTransformsForCurrentFrame().Item2;
 
             // ProcessAction will occur up to 2 times in this method
             // once after checking if new inputs need to be processed, and one last time after checking if we need to get the next bot segment
@@ -247,7 +245,7 @@ namespace RegressionGames.StateRecorder
             if (_nextBotSegments.Count > 0)
             {
                 firstActionSegment = _nextBotSegments[0];
-                firstActionSegment.ProcessAction(transformStatus);
+                firstActionSegment.ProcessAction(currentUiTransforms, currentGameObjectTransforms);
             }
 
             // check count each loop because we remove from it during the loop
@@ -348,7 +346,7 @@ namespace RegressionGames.StateRecorder
                 var nextSegment = _nextBotSegments[0];
                 if (nextSegment != firstActionSegment)
                 {
-                    nextSegment.ProcessAction(transformStatus);
+                    nextSegment.ProcessAction(currentUiTransforms, currentGameObjectTransforms);
                 }
             }
         }
@@ -364,11 +362,7 @@ namespace RegressionGames.StateRecorder
 
                 if (_nextBotSegments.Count == 0)
                 {
-                    MouseEventSender.SendMouseEvent(-1, new MouseInputActionData()
-                    {
-                        // get the mouse off the screen, when replay fails, we leave the virtual mouse cursor alone so they can see its location at time of failure
-                        position = new Vector2Int(Screen.width + 20, -20)
-                    }, ScreenRecorder._emptyTransformStatusDictionary, ScreenRecorder._emptyTransformStatusDictionary, ScreenRecorder._emptyTransformStatusDictionary, ScreenRecorder._emptyTransformStatusDictionary);
+                    MouseEventSender.SendRawPositionMouseEvent(-1, new Vector2(Screen.width+20, -20));
 
                     // we hit the end of the replay
                     if (_loopCount > -1)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -258,7 +258,7 @@ namespace RegressionGames.StateRecorder
             yield return null;
             if (!_isRecording)
             {
-                ReplayDataPlaybackController.SendMouseEvent(-1,new MouseInputActionData()
+                MouseEventSender.SendMouseEvent(-1,new MouseInputActionData()
                 {
                     // get the mouse off the screen, when replay fails, we leave the virtual mouse cursor alone so they can see its location at time of failure, but on new recording, we want this gone
                     position = new Vector2Int(Screen.width +20, -20)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -232,7 +232,7 @@ namespace RegressionGames.StateRecorder
         private void LateUpdate()
         {
             _gpuReadbackRequests.RemoveAll(a => a.done);
-            _fileWriteTasks.RemoveAll(a => a.Item2.IsCompleted);
+            _fileWriteTasks.RemoveAll(a => a.Item2 == null || a.Item2.IsCompleted);
 
             while (_texture2Ds.TryDequeue(out var tex))
             {
@@ -258,11 +258,8 @@ namespace RegressionGames.StateRecorder
             yield return null;
             if (!_isRecording)
             {
-                MouseEventSender.SendMouseEvent(-1,new MouseInputActionData()
-                {
-                    // get the mouse off the screen, when replay fails, we leave the virtual mouse cursor alone so they can see its location at time of failure, but on new recording, we want this gone
-                    position = new Vector2Int(Screen.width +20, -20)
-                }, _emptyTransformStatusDictionary, _emptyTransformStatusDictionary, _emptyTransformStatusDictionary, _emptyTransformStatusDictionary);
+                // get the mouse off the screen, when replay fails, we leave the virtual mouse cursor alone so they can see its location at time of failure, but on new recording, we want this gone
+                MouseEventSender.SendRawPositionMouseEvent(-1, new Vector2(Screen.width+20, -20));
 
                 _lastCvFrameTime = -1;
                 KeyboardInputActionObserver.GetInstance()?.StartRecording();

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -529,7 +529,7 @@ namespace RegressionGames.StateRecorder
                         //record bot segment data for action replay
                         botSegment = new BotSegment()
                         {
-                            sessionId = System.Guid.NewGuid().ToString(),
+                            sessionId = _currentSessionId,
                             keyFrameCriteria = keyFrameCriteria,
                             botAction = new BotAction()
                             {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/StateRecorderUtils.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/StateRecorderUtils.cs
@@ -51,6 +51,24 @@ namespace RegressionGames.StateRecorder
             return false;
         }
 
+        public static bool OptimizedStringStartsWithStringInList(List<string> list, string theString)
+        {
+            if (list != null)
+            {
+                var listCount = list.Count;
+                for (var i = 0; i < listCount; i++)
+                {
+                    // if the string being checked starts with any of the strings in the list
+                    if (theString.StartsWith(list[i]))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
         public static bool OptimizedContainsStringInList(List<string> list, string theString)
         {
             if (list != null)


### PR DESCRIPTION
- Update BotSegment SDK version to 2 so that new features are only available on that version
- Adds 2 new bot segment action types, Random Mouse Object click AND Random Mouse Pixel click
- Refactors the code so Input playback action types have their implementation isolated and not interleaved with the main code path
- Refactors the code so that keyboard and mouse input event sending are not interleaved with the main code path
- Adds error reporting to bot segment actions
- Fixes a bug in screen space camera object bounds computation
- Fixes a bug where the virtual mouse cursor wasn't showing in Parhelion Project Steel line
- Added feature to pause the editor on playback warnings
- Has sample bot segment file for Project Steelline (https://github.com/Parhelion-Studio-Co/project-sl-demo/pull/1)

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
