### PR TITLE
[REG-1810] Render excluded click areas for mouse bot segments

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/AndKeyFrameCriteriaEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/AndKeyFrameCriteriaEvaluator.cs
@@ -5,22 +5,22 @@ namespace RegressionGames.StateRecorder.BotSegments
 {
     public static class AndKeyFrameCriteriaEvaluator
     {
-        public static bool Matched(KeyFrameCriteria criteria)
+        public static bool Matched(int segmentNumber, KeyFrameCriteria criteria)
         {
             if (criteria.data is AndKeyFrameCriteriaData { criteriaList: not null } andCriteria)
             {
                 try
                 {
-                    return KeyFrameEvaluator.Evaluator.MatchedHelper(BooleanCriteria.And, andCriteria.criteriaList);
+                    return KeyFrameEvaluator.Evaluator.MatchedHelper(segmentNumber, BooleanCriteria.And, andCriteria.criteriaList);
                 }
                 catch (Exception)
                 {
-                    RGDebug.LogError("Invalid bot segment criteria: " + andCriteria);
+                    RGDebug.LogError($"({segmentNumber}) - Bot Segment - Invalid criteria: " + andCriteria);
                 }
             }
             else
             {
-                RGDebug.LogError("Invalid bot segment criteria: " + criteria);
+                RGDebug.LogError($"({segmentNumber}) - Bot Segment - Invalid criteria: " + criteria);
             }
 
             return false;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/RandomMouseObjectActionDataJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/RandomMouseObjectActionDataJsonConverter.cs
@@ -20,6 +20,7 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
             RandomMouseObjectActionData data = new();
             data.screenSize = jObject.GetValue("screenSize").ToObject<Vector2Int>(serializer);
             data.apiVersion = jObject.GetValue("apiVersion").ToObject<int>();
+            data.allowDrag = jObject.GetValue("allowDrag").ToObject<bool>();
             data.timeBetweenClicks = jObject.GetValue("timeBetweenClicks").ToObject<float>();
             data.excludedAreas = jObject.GetValue("excludedAreas").ToObject<List<RectInt>>();
             data.excludedNormalizedPaths = jObject.GetValue("excludedNormalizedPaths").ToObject<List<string>>();

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/KeyFrameEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/KeyFrameEvaluator.cs
@@ -61,10 +61,10 @@ namespace RegressionGames.StateRecorder.BotSegments
         /**
          * <summary>Publicly callable.. caches the statuses of the last passed key frame for computing delta counts from</summary>
          */
-        public bool Matched(KeyFrameCriteria[] criteriaList)
+        public bool Matched(int segmentNumber, KeyFrameCriteria[] criteriaList)
         {
             _newUnmatchedCriteria.Clear();
-            bool matched = MatchedHelper(BooleanCriteria.And, criteriaList);
+            bool matched = MatchedHelper(segmentNumber, BooleanCriteria.And, criteriaList);
             if (matched)
             {
                 _unmatchedCriteria.Clear();
@@ -81,7 +81,7 @@ namespace RegressionGames.StateRecorder.BotSegments
         /**
          * <summary>Only to be called internally by KeyFrameEvaluator</summary>
          */
-        internal bool MatchedHelper(BooleanCriteria andOr, KeyFrameCriteria[] criteriaList)
+        internal bool MatchedHelper(int segmentNumber, BooleanCriteria andOr, KeyFrameCriteria[] criteriaList)
         {
             var uiTransforms = InGameObjectFinder.GetInstance().GetUITransformsForCurrentFrame();
             var gameObjectTransforms = InGameObjectFinder.GetInstance().GetGameObjectTransformsForCurrentFrame();
@@ -122,7 +122,7 @@ namespace RegressionGames.StateRecorder.BotSegments
             // process each list.. start with the ones for this tier
             if (normalizedPathsToMatch.Count > 0)
             {
-                var pathResults = NormalizedPathCriteriaEvaluator.Matched(normalizedPathsToMatch, _priorKeyFrameUIStatus, _priorKeyFrameGameObjectStatus, uiTransforms.Item2, gameObjectTransforms.Item2);
+                var pathResults = NormalizedPathCriteriaEvaluator.Matched(segmentNumber, normalizedPathsToMatch, _priorKeyFrameUIStatus, _priorKeyFrameGameObjectStatus, uiTransforms.Item2, gameObjectTransforms.Item2);
                 var pathResultsCount = pathResults.Count;
                 for (var j = 0; j < pathResultsCount; j++)
                 {
@@ -151,7 +151,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                 for (var j = 0; j < orCount; j++)
                 {
                     var orEntry = orsToMatch[j];
-                    var m = OrKeyFrameCriteriaEvaluator.Matched(orEntry);
+                    var m = OrKeyFrameCriteriaEvaluator.Matched(segmentNumber, orEntry);
                     if (m)
                     {
                         if (andOr == BooleanCriteria.Or)
@@ -177,7 +177,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                 for (var j = 0; j < andCount; j++)
                 {
                     var andEntry = andsToMatch[j];
-                    var m = AndKeyFrameCriteriaEvaluator.Matched(andEntry);
+                    var m = AndKeyFrameCriteriaEvaluator.Matched(segmentNumber, andEntry);
                     if (m)
                     {
                         if (andOr == BooleanCriteria.Or)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotAction.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotAction.cs
@@ -40,6 +40,11 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             data.ReplayReset();
         }
 
+        public void OnGUI(Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
+        {
+            data.OnGUI(currentUITransforms, currentGameObjectTransforms);
+        }
+
         public void WriteToStringBuilder(StringBuilder stringBuilder)
         {
             stringBuilder.Append("{\"type\":");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
@@ -51,6 +51,14 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         // returns true if botAction.IsCompleted || botAction.IsCompleted==null && Replay_Matched
         public bool Replay_ActionCompleted => botAction == null || (botAction.IsCompleted ?? Replay_Matched);
 
+        public void OnGUI(Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
+        {
+            if (botAction != null)
+            {
+                botAction.OnGUI(currentUITransforms, currentGameObjectTransforms);
+            }
+        }
+
         // Replay only - called at least once per frame
         public bool ProcessAction(Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms, out string error)
         {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
@@ -29,5 +29,11 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public bool? IsCompleted();
 
         public int EffectiveApiVersion();
+
+        // Allows the impl to draw debug elements on the screen
+        public void OnGUI(Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
+        {
+            // default to no-op impl
+        }
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
@@ -24,7 +24,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         public void StartAction(int segmentNumber, Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
         {
-            RGDebug.LogInfo($"({segmentNumber}) - Processing InputPlaybackActionData for BotSegment");
+            RGDebug.LogInfo($"({segmentNumber}) - Bot Segment - Processing InputPlaybackActionData");
 
             var now = Time.unscaledTime;
             var currentInputTimePoint = now - startTime;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
@@ -182,7 +182,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                             var rb = Random.Range(0, 2) == 0;
                             var fb = Random.Range(0, 2) == 0;
                             var bb = Random.Range(0, 2) == 0;
-                            RGDebug.LogInfo($"RandomMouseObjectClicker - {{x:{x}, y:{y}, lb:{(lb?1:0)}, mb:{(mb?1:0)}, rb:{(rb?1:0)}, fb:{(fb?1:0)}, bb:{(bb?1:0)}}} on object with NormalizedPath: {transformOption.NormalizedPath}", transformOption.Transform.gameObject);
+                            RGDebug.LogInfo($"({segmentNumber}) - Bot Segment - RandomMouseObjectClicker - {{x:{x}, y:{y}, lb:{(lb?1:0)}, mb:{(mb?1:0)}, rb:{(rb?1:0)}, fb:{(fb?1:0)}, bb:{(bb?1:0)}}} on object with NormalizedPath: {transformOption.NormalizedPath}", transformOption.Transform.gameObject);
                             MouseEventSender.SendRawPositionMouseEvent(
                                 segmentNumber,
                                 new Vector2(x, y),

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
@@ -244,6 +244,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
                         if (valid)
                         {
+                            var drag = allowDrag && Random.Range(0, 2) == 0;
                             var lb = Random.Range(0, 2) == 0;
                             var mb = Random.Range(0, 2) == 0;
                             var rb = Random.Range(0, 2) == 0;
@@ -261,17 +262,22 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                                 Vector2.zero // don't support random scrolling yet...
                             );
 
-                            // send the unclick event
-                            MouseEventSender.SendRawPositionMouseEvent(
-                                segmentNumber,
-                                new Vector2(x,y),
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                Vector2.zero // don't support random scrolling yet...
+                            if (!drag)
+                            {
+                                RGDebug.LogInfo($"({segmentNumber}) - Bot Segment - RandomMouseObjectClicker - unclick - {{x:{x}, y:{y}}}");
+                                // send the un-click event
+                                MouseEventSender.SendRawPositionMouseEvent(
+                                    segmentNumber,
+                                    new Vector2(x, y),
+                                    false,
+                                    false,
+                                    false,
+                                    false,
+                                    false,
+                                    Vector2.zero // don't support random scrolling yet...
                                 );
+                            }
+
                             Replay_LastClickTime = now;
                             error = null;
                             return true;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
@@ -130,6 +130,59 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             return false;
         }
 
+        private GUIStyle _guiStyle = null;
+
+        public void OnGUI(Dictionary<int, TransformStatus> currentUITransforms, Dictionary<int, TransformStatus> currentGameObjectTransforms)
+        {
+            if (_guiStyle == null)
+            {
+                _guiStyle = new ()
+                {
+                    alignment = TextAnchor.MiddleCenter,
+                };
+                _guiStyle.normal.background = Texture2D.whiteTexture; // must be white to tint properly
+                var textColor = Color.white;
+                textColor.a = 0.4f;
+                _guiStyle.normal.textColor = textColor;
+            }
+            var screenHeight = Screen.height;
+            var screenWidth = Screen.width;
+            var count = excludedAreas.Count;
+            for (var i = 0; i < count; i++)
+            {
+                var excludedArea = excludedAreas[i];
+                var xMin = excludedArea.xMin;
+                var xMax = excludedArea.xMax;
+                var yMin = excludedArea.yMin;
+                var yMax = excludedArea.yMax;
+
+                // normalize the location to the current resolution
+                if (screenWidth != screenSize.x)
+                {
+                    var ratio = screenWidth / (float)screenSize.x;
+                    xMin = (int) (xMin * ratio);
+                    xMax = (int) (xMax * ratio);
+                }
+
+                if (screenHeight != screenSize.y)
+                {
+                    var ratio = screenHeight / (float)screenSize.y;
+                    yMin = (int) (yMin * ratio);
+                    yMax = (int) (yMax * ratio);
+                }
+
+                var bgColor = Color.red;
+                bgColor.a = 0.4f;
+                GUI.backgroundColor = bgColor;
+
+                /*
+                 * Screen coordinates are 2D, measured in pixels and start in the lower left corner at (0,0) and go to (Screen.width, Screen.height). Screen coordinates change with the resolution of the device, and even the orientation (if you app allows it) on mobile devices.
+                 * GUI coordinates are used by the IMGUI system. They are identical to Screen coordinates except that they start at (0,0) in the upper left and go to (Screen.width, Screen.height) in the lower right.
+                 */
+                GUI.Box(new Rect(xMin, screenHeight-yMax, (xMax - xMin), (yMax - yMin)), "Excluded\nArea", _guiStyle);
+            }
+        }
+
         public void WriteToStringBuilder(StringBuilder stringBuilder)
         {
             stringBuilder.Append("{\"apiVersion\":");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/NormalizedPathCriteriaEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/NormalizedPathCriteriaEvaluator.cs
@@ -27,7 +27,7 @@ namespace RegressionGames.StateRecorder.BotSegments
         }
 
         // Track counts from the last keyframe completion and use that as the 'prior' data
-        public static List<string> Matched(List<KeyFrameCriteria> criteriaList, Dictionary<int, TransformStatus> priorUIStatus, Dictionary<int, TransformStatus> priorGameObjectStatus, Dictionary<int, TransformStatus> uiTransforms, Dictionary<int, TransformStatus> gameObjectTransforms)
+        public static List<string> Matched(int segmentNumber, List<KeyFrameCriteria> criteriaList, Dictionary<int, TransformStatus> priorUIStatus, Dictionary<int, TransformStatus> priorGameObjectStatus, Dictionary<int, TransformStatus> uiTransforms, Dictionary<int, TransformStatus> gameObjectTransforms)
         {
             UpdateDeltaCounts(priorUIStatus, priorGameObjectStatus, uiTransforms, gameObjectTransforms);
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/OrKeyFrameCriteriaEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/OrKeyFrameCriteriaEvaluator.cs
@@ -5,22 +5,22 @@ namespace RegressionGames.StateRecorder.BotSegments
 {
     public static class OrKeyFrameCriteriaEvaluator
     {
-        public static bool Matched(KeyFrameCriteria criteria)
+        public static bool Matched(int segmentNumber, KeyFrameCriteria criteria)
         {
             if (criteria.data is OrKeyFrameCriteriaData { criteriaList: not null } orCriteria)
             {
                 try
                 {
-                    return KeyFrameEvaluator.Evaluator.MatchedHelper(BooleanCriteria.Or, orCriteria.criteriaList);
+                    return KeyFrameEvaluator.Evaluator.MatchedHelper(segmentNumber, BooleanCriteria.Or, orCriteria.criteriaList);
                 }
                 catch (Exception)
                 {
-                    RGDebug.LogError("Invalid bot segment criteria: " + orCriteria);
+                    RGDebug.LogError($"({segmentNumber}) - Bot Segment - Invalid criteria: " + orCriteria);
                 }
             }
             else
             {
-                RGDebug.LogError("Invalid bot segment criteria: " + criteria);
+                RGDebug.LogError($"({segmentNumber}) - Bot Segment - Invalid criteria: " + criteria);
             }
 
             return false;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/InGameObjectFinder.cs
@@ -741,7 +741,7 @@ namespace RegressionGames.StateRecorder
             {
                 var uiObjectTransformId = tStatus.Id;
                 // only process visible objects into the state
-                if (tStatus.screenSpaceBounds.HasValue)
+                if (tStatus.Transform != null && tStatus.screenSpaceBounds.HasValue)
                 {
                     var usingOldObject = _priorStates.TryGetValue(uiObjectTransformId, out var resultObject);
 
@@ -800,7 +800,7 @@ namespace RegressionGames.StateRecorder
             {
                 var gameObjectTransformId = tStatus.Id;
                 // only process visible objects into the state
-                if (tStatus.screenSpaceBounds.HasValue)
+                if (tStatus.Transform != null && tStatus.screenSpaceBounds.HasValue)
                 {
                     var usingOldObject = _priorStates.TryGetValue(gameObjectTransformId, out var resultObject);
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayBotSegmentsContainer.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayBotSegmentsContainer.cs
@@ -93,7 +93,7 @@ namespace RegressionGames.StateRecorder
             }
             catch (Exception e)
             {
-                // Failed to parse the json.  End user doesn't really need this message.. we give them a for real exception below
+                // Failed to parse the json.  End user doesn't really need this message, this is for developers at RG creating new bot segment types.. we give them a for real exception below
                 RGDebug.LogWarning("Exception while parsing bot_segments.zip - " + e);
             }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -301,7 +301,7 @@ namespace RegressionGames.StateRecorder
                 }
                 if (error != null && _lastTimeLoggedKeyFrameConditions < now - LOG_ERROR_INTERVAL)
                 {
-                    var loggedMessage = $"({firstActionSegment.Replay_SegmentNumber}) - Error processing BotAction\r\n" + error;
+                    var loggedMessage = $"({firstActionSegment.Replay_SegmentNumber}) - Bot Segment - Error processing BotAction\r\n" + error;
                     LogPlaybackWarning(loggedMessage);
                 }
             }
@@ -311,7 +311,7 @@ namespace RegressionGames.StateRecorder
             {
                 var nextBotSegment = _nextBotSegments[i];
 
-                var matched = nextBotSegment.Replay_Matched || KeyFrameEvaluator.Evaluator.Matched(nextBotSegment.keyFrameCriteria);
+                var matched = nextBotSegment.Replay_Matched || KeyFrameEvaluator.Evaluator.Matched(nextBotSegment.Replay_SegmentNumber, nextBotSegment.keyFrameCriteria);
 
                 if (matched)
                 {
@@ -319,7 +319,7 @@ namespace RegressionGames.StateRecorder
                     {
                         nextBotSegment.Replay_Matched = true;
                         // log this the first time
-                        RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment Criteria Matched");
+                        RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment - Criteria Matched");
                         if (i == 0)
                         {
                             _lastTimeLoggedKeyFrameConditions = now;
@@ -336,7 +336,7 @@ namespace RegressionGames.StateRecorder
                         if (nextBotSegment.Replay_ActionStarted && !nextBotSegment.Replay_ActionCompleted && _lastTimeLoggedKeyFrameConditions < now - LOG_ERROR_INTERVAL)
                         {
                             _lastTimeLoggedKeyFrameConditions = now;
-                            var loggedMessage = $"({nextBotSegment.Replay_SegmentNumber}) - Waiting for actions to complete";
+                            var loggedMessage = $"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment - Waiting for actions to complete";
                             FindObjectOfType<ReplayToolbarManager>()?.SetKeyFrameWarningText(loggedMessage);
                             RGDebug.LogInfo(loggedMessage);
                         }
@@ -345,7 +345,7 @@ namespace RegressionGames.StateRecorder
                     if (nextBotSegment.Replay_ActionStarted && nextBotSegment.Replay_ActionCompleted)
                     {
                         _lastTimeLoggedKeyFrameConditions = now;
-                        RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment Completed");
+                        RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment - Completed");
                         //Process the inputs from that bot segment if necessary
                         _nextBotSegments.RemoveAt(i);
                     }
@@ -362,7 +362,7 @@ namespace RegressionGames.StateRecorder
                         var warningText = KeyFrameEvaluator.Evaluator.GetUnmatchedCriteria();
                         if (warningText != null)
                         {
-                            var loggedMessage = $"({nextBotSegment.Replay_SegmentNumber}) - Unmatched Criteria for BotSegment\r\n" + warningText;
+                            var loggedMessage = $"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment - Unmatched Criteria for \r\n" + warningText;
                             LogPlaybackWarning(loggedMessage);
                         }
                     }
@@ -382,7 +382,7 @@ namespace RegressionGames.StateRecorder
                     {
                         _lastTimeLoggedKeyFrameConditions = now;
                         FindObjectOfType<ReplayToolbarManager>()?.SetKeyFrameWarningText(null);
-                        RGDebug.LogInfo($"({next.Replay_SegmentNumber}) - Added BotSegment for Evaluation after Transient BotSegment");
+                        RGDebug.LogInfo($"({next.Replay_SegmentNumber}) - Bot Segment - Added {(next.HasTransientCriteria?"":"Non-")}Transient BotSegment for Evaluation after Transient BotSegment");
                         _nextBotSegments.Add(next);
                     }
                 }
@@ -395,7 +395,7 @@ namespace RegressionGames.StateRecorder
                 {
                     _lastTimeLoggedKeyFrameConditions = now;
                     FindObjectOfType<ReplayToolbarManager>()?.SetKeyFrameWarningText(null);
-                    RGDebug.LogInfo($"({next.Replay_SegmentNumber}) - Added BotSegment for Evaluation");
+                    RGDebug.LogInfo($"({next.Replay_SegmentNumber}) - Bot Segment - Added {(next.HasTransientCriteria?"":"Non-")}Transient BotSegment for Evaluation");
                     _nextBotSegments.Add(next);
                 }
             }
@@ -417,7 +417,7 @@ namespace RegressionGames.StateRecorder
                     // only log this if we're really stuck on it for a while
                     if (error != null && _lastTimeLoggedKeyFrameConditions < now - LOG_ERROR_INTERVAL)
                     {
-                        var loggedMessage = $"({nextSegment.Replay_SegmentNumber}) - Error processing BotAction\r\n" + error;
+                        var loggedMessage = $"({nextSegment.Replay_SegmentNumber}) - Bot Segment - Error processing BotAction\r\n" + error;
                         LogPlaybackWarning(loggedMessage);
                     }
                 }
@@ -448,6 +448,20 @@ namespace RegressionGames.StateRecorder
                         Reset();
                         _replaySuccessful = true;
                     }
+                }
+            }
+        }
+
+        public void OnGUI()
+        {
+            if (_isPlaying)
+            {
+                // render any GUI things for the first segment action
+                if (_nextBotSegments.Count > 0)
+                {
+                    var currentUiTransforms = InGameObjectFinder.GetInstance().GetUITransformsForCurrentFrame().Item2;
+                    var currentGameObjectTransforms = InGameObjectFinder.GetInstance().GetGameObjectTransformsForCurrentFrame().Item2;
+                    //_nextBotSegments[0].OnGUI(currentUiTransforms, currentGameObjectTransforms);
                 }
             }
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -461,7 +461,7 @@ namespace RegressionGames.StateRecorder
                 {
                     var currentUiTransforms = InGameObjectFinder.GetInstance().GetUITransformsForCurrentFrame().Item2;
                     var currentGameObjectTransforms = InGameObjectFinder.GetInstance().GetGameObjectTransformsForCurrentFrame().Item2;
-                    //_nextBotSegments[0].OnGUI(currentUiTransforms, currentGameObjectTransforms);
+                    _nextBotSegments[0].OnGUI(currentUiTransforms, currentGameObjectTransforms);
                 }
             }
         }


### PR DESCRIPTION
- Renders excluded areas
- Adds option to allow or disallow mouse movement with buttons held down
- Makes bot segment log message formats more consistent for easier filtering in unity
- Fixes a bug in state capture where a destroyed transform wasn't being handled

![Screenshot 2024-06-18 101416](https://github.com/Regression-Games/RGUnityBots/assets/112959031/d8ec39bb-9fcc-42a6-9018-d124507d6ac2)


---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
