### PR TITLE
[REG-1820] Fix brief error message from input instrumentation code when first loading the RG package

### DIFF
--- a/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
@@ -188,7 +188,7 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
         {
             try
             {
-                if (IsAssemblyIgnored(assemblyPath, rgAssembly))
+                if (!File.Exists(assemblyPath) || IsAssemblyIgnored(assemblyPath, rgAssembly))
                 {
                     return;
                 }


### PR DESCRIPTION
This PR fixes an error message that occurs when first loading the RG SDK package. The error is brief and goes away after Unity restarts after installing the input system package, so this is not an urgent issue.

![image](https://github.com/Regression-Games/RGUnityBots/assets/61521182/753faecf-e1ee-4d5d-adc3-c38b1909c6c7)


---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
