### PR TITLE
[REG-1818] Record profiler statistics per frame

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/PerFrameStatisticsData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/PerFrameStatisticsData.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using RegressionGames.StateRecorder.JsonConverters;
+
+namespace RegressionGames.StateRecorder.Models
+{
+    [Serializable]
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    public class PerFrameStatisticsData
+    {
+        public double frameTime;
+        public long? cpuTimeNs;
+        public long? memoryBytes;
+        public long? gcMemoryBytes;
+        public EngineStatsData engineStats;
+
+        public void WriteToStringBuilder(StringBuilder stringBuilder)
+        {
+            stringBuilder.Append("{\n\"frameTime\":");
+            DoubleJsonConverter.WriteToStringBuilder(stringBuilder, frameTime);
+            stringBuilder.Append(",\n\"cpuTimeNs\":");
+            LongJsonConverter.WriteToStringBuilderNullable(stringBuilder, cpuTimeNs);
+            stringBuilder.Append(",\n\"memoryBytes\":");
+            LongJsonConverter.WriteToStringBuilderNullable(stringBuilder, memoryBytes);
+            stringBuilder.Append(",\n\"gcMemoryBytes\":");
+            LongJsonConverter.WriteToStringBuilderNullable(stringBuilder, gcMemoryBytes);
+            stringBuilder.Append(",\n\"engineStats\":");
+            engineStats.WriteToStringBuilder(stringBuilder);
+            stringBuilder.Append("\n}");
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/PerFrameStatisticsData.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/PerFrameStatisticsData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4544cdabbaec441cbaac8e08551f2493
+timeCreated: 1719944235

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/PerformanceMetricData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/PerformanceMetricData.cs
@@ -13,49 +13,26 @@ namespace RegressionGames.StateRecorder.Models
         public double previousTickTime;
         public int framesSincePreviousTick;
         public int fps;
-        public List<long> cpuTimesPerFrame;
-        public List<long> memoryPerFrame;
-        public List<long> gcMemoryPerFrame;
-        public EngineStatsData engineStats;
+        public List<PerFrameStatisticsData> perFrameStatistics;
 
         public void WriteToStringBuilder(StringBuilder stringBuilder)
         {
-            stringBuilder.Append("{\"previousTickTime\":");
+            stringBuilder.Append("{\n\"previousTickTime\":");
             DoubleJsonConverter.WriteToStringBuilder(stringBuilder, previousTickTime);
-            stringBuilder.Append(",\"framesSincePreviousTick\":");
+            stringBuilder.Append(",\n\"framesSincePreviousTick\":");
             IntJsonConverter.WriteToStringBuilder(stringBuilder, framesSincePreviousTick);
-            stringBuilder.Append(",\"fps\":");
+            stringBuilder.Append(",\n\"fps\":");
             IntJsonConverter.WriteToStringBuilder(stringBuilder, fps);
-            stringBuilder.Append(",\n\"cpuTimesPerFrame\":[");
-            for (int i = 0, n = cpuTimesPerFrame.Count; i < n; ++i)
+            stringBuilder.Append(",\n\"perFrameStatistics\":[\n");
+            for (int i = 0, n = perFrameStatistics.Count; i < n; ++i)
             {
-                LongJsonConverter.WriteToStringBuilderNullable(stringBuilder, cpuTimesPerFrame[i]);
+                perFrameStatistics[i].WriteToStringBuilder(stringBuilder);
                 if (i < n - 1)
                 {
-                    stringBuilder.Append(",");
+                    stringBuilder.Append(",\n");
                 }
             }
-            stringBuilder.Append("],\n\"memoryPerFrame\":[");
-            for (int i = 0, n = memoryPerFrame.Count; i < n; ++i)
-            {
-                LongJsonConverter.WriteToStringBuilderNullable(stringBuilder, memoryPerFrame[i]);
-                if (i < n - 1)
-                {
-                    stringBuilder.Append(",");
-                }
-            }
-            stringBuilder.Append("],\n\"gcMemoryPerFrame\":[");
-            for (int i = 0, n = gcMemoryPerFrame.Count; i < n; ++i)
-            {
-                LongJsonConverter.WriteToStringBuilderNullable(stringBuilder, gcMemoryPerFrame[i]);
-                if (i < n - 1)
-                {
-                    stringBuilder.Append(",");
-                }
-            }
-            stringBuilder.Append("],\n\"engineStats\":");
-            engineStats.WriteToStringBuilder(stringBuilder);
-            stringBuilder.Append("}");
+            stringBuilder.Append("\n]\n}");
         }
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/PerformanceMetricData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/PerformanceMetricData.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using RegressionGames.StateRecorder.JsonConverters;
@@ -12,9 +13,9 @@ namespace RegressionGames.StateRecorder.Models
         public double previousTickTime;
         public int framesSincePreviousTick;
         public int fps;
-        public long? cpuTimeSincePreviousTick;
-        public long? memory;
-        public long? gcMemory;
+        public List<long> cpuTimesPerFrame;
+        public List<long> memoryPerFrame;
+        public List<long> gcMemoryPerFrame;
         public EngineStatsData engineStats;
 
         public void WriteToStringBuilder(StringBuilder stringBuilder)
@@ -25,13 +26,34 @@ namespace RegressionGames.StateRecorder.Models
             IntJsonConverter.WriteToStringBuilder(stringBuilder, framesSincePreviousTick);
             stringBuilder.Append(",\"fps\":");
             IntJsonConverter.WriteToStringBuilder(stringBuilder, fps);
-            stringBuilder.Append(",\"cpuTimeSincePreviousTick\":");
-            LongJsonConverter.WriteToStringBuilderNullable(stringBuilder, cpuTimeSincePreviousTick);
-            stringBuilder.Append(",\"memory\":");
-            LongJsonConverter.WriteToStringBuilderNullable(stringBuilder, memory);
-            stringBuilder.Append(",\"gcMemory\":");
-            LongJsonConverter.WriteToStringBuilderNullable(stringBuilder, gcMemory);
-            stringBuilder.Append(",\"engineStats\":");
+            stringBuilder.Append(",\n\"cpuTimesPerFrame\":[");
+            for (int i = 0, n = cpuTimesPerFrame.Count; i < n; ++i)
+            {
+                LongJsonConverter.WriteToStringBuilderNullable(stringBuilder, cpuTimesPerFrame[i]);
+                if (i < n - 1)
+                {
+                    stringBuilder.Append(",");
+                }
+            }
+            stringBuilder.Append("],\n\"memoryPerFrame\":[");
+            for (int i = 0, n = memoryPerFrame.Count; i < n; ++i)
+            {
+                LongJsonConverter.WriteToStringBuilderNullable(stringBuilder, memoryPerFrame[i]);
+                if (i < n - 1)
+                {
+                    stringBuilder.Append(",");
+                }
+            }
+            stringBuilder.Append("],\n\"gcMemoryPerFrame\":[");
+            for (int i = 0, n = gcMemoryPerFrame.Count; i < n; ++i)
+            {
+                LongJsonConverter.WriteToStringBuilderNullable(stringBuilder, gcMemoryPerFrame[i]);
+                if (i < n - 1)
+                {
+                    stringBuilder.Append(",");
+                }
+            }
+            stringBuilder.Append("],\n\"engineStats\":");
             engineStats.WriteToStringBuilder(stringBuilder);
             stringBuilder.Append("}");
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/PerformanceMetricData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/PerformanceMetricData.cs
@@ -24,10 +24,11 @@ namespace RegressionGames.StateRecorder.Models
             stringBuilder.Append(",\n\"fps\":");
             IntJsonConverter.WriteToStringBuilder(stringBuilder, fps);
             stringBuilder.Append(",\n\"perFrameStatistics\":[\n");
-            for (int i = 0, n = perFrameStatistics.Count; i < n; ++i)
+            int perFrameStatisticsCount = perFrameStatistics.Count;
+            for (int i = 0; i < perFrameStatisticsCount; ++i)
             {
                 perFrameStatistics[i].WriteToStringBuilder(stringBuilder);
-                if (i < n - 1)
+                if (i + 1 < perFrameStatisticsCount)
                 {
                     stringBuilder.Append(",\n");
                 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ProfilerObserver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ProfilerObserver.cs
@@ -1,49 +1,30 @@
 ﻿using System;
 using System.Collections.Generic;
+using RegressionGames.StateRecorder.Models;
 using Unity.Profiling;
 using UnityEngine;
 
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
 namespace RegressionGames.StateRecorder
 {
-    public struct ProfilerObserverResult
-    {
-        // Amount of memory (in bytes) the operating system reports in use by the application on each frame since the last tick
-        public List<long> systemUsedMemoryPerFrame;
-
-        // Used heap size (in bytes) that is garbage collected on each frame since the last tick
-        public List<long> gcUsedMemoryPerFrame;
-
-        // Time spent (in nanoseconds) by the CPU on the main thread on each frame since the last tick
-        public List<long> cpuTimePerFrame;
-
-        public void Clear()
-        {
-            systemUsedMemoryPerFrame.Clear();
-            gcUsedMemoryPerFrame.Clear();
-            cpuTimePerFrame.Clear();
-        }
-    }
-
     public class ProfilerObserver : MonoBehaviour
     {
-        private const int MAX_FRAMES_ACCUM = 16384;
-
         private ProfilerRecorder _systemMemoryRecorder;
         private ProfilerRecorder _gcMemoryRecorder;
         private ProfilerRecorder _cpuTimeRecorder;
-        private List<ProfilerRecorderSample> _sampleBuf;
-        private ProfilerObserverResult _resultBuf;
+        private Queue<PerFrameStatisticsData> _perFrameStatistics;
+        private double _lastTime;
 
         public void StartProfiling()
         {
-            _systemMemoryRecorder = ProfilerRecorder.StartNew(ProfilerCategory.Memory, "System Used Memory", MAX_FRAMES_ACCUM);
-            _gcMemoryRecorder = ProfilerRecorder.StartNew(ProfilerCategory.Memory, "GC Used Memory", MAX_FRAMES_ACCUM);
-            _cpuTimeRecorder = ProfilerRecorder.StartNew(ProfilerCategory.Internal, "Main Thread", MAX_FRAMES_ACCUM);
-            _sampleBuf = new List<ProfilerRecorderSample>(MAX_FRAMES_ACCUM);
-            _resultBuf = new ProfilerObserverResult();
-            _resultBuf.systemUsedMemoryPerFrame = new List<long>(MAX_FRAMES_ACCUM);
-            _resultBuf.gcUsedMemoryPerFrame = new List<long>(MAX_FRAMES_ACCUM);
-            _resultBuf.cpuTimePerFrame = new List<long>(MAX_FRAMES_ACCUM);
+            _systemMemoryRecorder = ProfilerRecorder.StartNew(ProfilerCategory.Memory, "System Used Memory");
+            _gcMemoryRecorder = ProfilerRecorder.StartNew(ProfilerCategory.Memory, "GC Used Memory");
+            _cpuTimeRecorder = ProfilerRecorder.StartNew(ProfilerCategory.Internal, "Main Thread");
+            _perFrameStatistics = new Queue<PerFrameStatisticsData>();
+            _lastTime = Time.unscaledTimeAsDouble;
         }
 
         public void StopProfiling()
@@ -63,54 +44,55 @@ namespace RegressionGames.StateRecorder
         }
 
         /// <summary>
-        /// Reads the last numFrames profiler frames into the output buffer.
+        /// Called every frame to read and store profiler values.
         /// </summary>
-        private void ReadProfilerValues(ProfilerRecorder recorder, int numFrames, List<long> outputBuf)
+        public void Observe()
         {
-            numFrames = Math.Min(numFrames, recorder.Capacity);
-            
-            _sampleBuf.Clear();
-            recorder.CopyTo(_sampleBuf);
-
-            if (recorder.WrappedAround)
+            PerFrameStatisticsData frameData = new PerFrameStatisticsData();
+            double time = Time.unscaledTimeAsDouble;
+            frameData.frameTime = time - _lastTime;
+            if (_cpuTimeRecorder.Valid && _cpuTimeRecorder.Count > 0)
             {
-                int unwrappedCount = Math.Max(numFrames - recorder.Count, 0);
-                for (int i = _sampleBuf.Count - unwrappedCount, n = _sampleBuf.Count; i < n; ++i)
-                {
-                    outputBuf.Add(_sampleBuf[i].Value);
-                }
-                for (int i = recorder.Count - (numFrames - unwrappedCount), n = recorder.Count; i < n; ++i)
-                {
-                    outputBuf.Add(_sampleBuf[i].Value);
-                }
+                frameData.cpuTimeNs = _cpuTimeRecorder.LastValue;
             }
-            else
+            if (_systemMemoryRecorder.Valid && _systemMemoryRecorder.Count > 0)
             {
-                for (int i = Math.Max(recorder.Count - numFrames, 0), n = recorder.Count; i < n; ++i)
-                {
-                    outputBuf.Add(_sampleBuf[i].Value);
-                }
+                frameData.memoryBytes = _systemMemoryRecorder.LastValue;
             }
-            
-            Debug.Assert(outputBuf.Count <= numFrames);
+            if (_gcMemoryRecorder.Valid && _gcMemoryRecorder.Count > 0)
+            {
+                frameData.gcMemoryBytes = _gcMemoryRecorder.LastValue;
+            }
+            frameData.engineStats = new EngineStatsData()
+            {
+                #if UNITY_EDITOR
+                frameTime = UnityStats.frameTime,
+                renderTime = UnityStats.renderTime,
+                triangles = UnityStats.triangles,
+                vertices = UnityStats.vertices,
+                setPassCalls = UnityStats.setPassCalls,
+                drawCalls = UnityStats.drawCalls,
+                dynamicBatchedDrawCalls = UnityStats.dynamicBatchedDrawCalls,
+                staticBatchedDrawCalls = UnityStats.staticBatchedDrawCalls,
+                instancedBatchedDrawCalls = UnityStats.instancedBatchedDrawCalls,
+                batches = UnityStats.batches,
+                dynamicBatches = UnityStats.dynamicBatches,
+                staticBatches = UnityStats.staticBatches,
+                instancedBatches = UnityStats.instancedBatches
+                #endif
+            };
+            _perFrameStatistics.Enqueue(frameData);
+            _lastTime = time;
         }
 
-        public ProfilerObserverResult SampleProfiler(int frameCountSinceLastTick)
+        public List<PerFrameStatisticsData> DequeueAll()
         {
-            _resultBuf.Clear();
-            if (_systemMemoryRecorder.Valid)
+            List<PerFrameStatisticsData> result = new List<PerFrameStatisticsData>(_perFrameStatistics.Count);
+            while (_perFrameStatistics.TryDequeue(out var frameStats))
             {
-                ReadProfilerValues(_systemMemoryRecorder, frameCountSinceLastTick, _resultBuf.systemUsedMemoryPerFrame);
+                result.Add(frameStats);
             }
-            if (_gcMemoryRecorder.Valid)
-            {
-                ReadProfilerValues(_gcMemoryRecorder, frameCountSinceLastTick, _resultBuf.gcUsedMemoryPerFrame);
-            }
-            if (_cpuTimeRecorder.Valid)
-            {
-                ReadProfilerValues(_cpuTimeRecorder, frameCountSinceLastTick, _resultBuf.cpuTimePerFrame);
-            }
-            return _resultBuf;
+            return result;
         }
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -433,6 +433,8 @@ namespace RegressionGames.StateRecorder
                 {
                     _mouseObserver.ObserveMouse(uiTransforms.Item2.Values.Concat(gameObjectTransforms.Item2.Values));
                 }
+                
+                _profilerObserver.Observe();
 
                 //Compute the delta values we need to record / evaluate to know if we need to record a key frame
                 var uiDeltas = InGameObjectFinder.GetInstance().ComputeNormalizedPathBasedDeltaCounts(uiTransforms.Item1, uiTransforms.Item2, out var hasUIDelta);
@@ -455,8 +457,6 @@ namespace RegressionGames.StateRecorder
                     // record full frame state and screenshot
                     var screenWidth = Screen.width;
                     var screenHeight = Screen.height;
-
-                    ProfilerObserverResult profilerResult = _profilerObserver.SampleProfiler(_frameCountSinceLastTick);
 
                     byte[] jsonData = null;
 
@@ -566,27 +566,7 @@ namespace RegressionGames.StateRecorder
                             framesSincePreviousTick = _frameCountSinceLastTick,
                             previousTickTime = _lastCvFrameTime > 0 ? _lastCvFrameTime : 0,
                             fps = _lastCvFrameTime > 0 ? (int)(_frameCountSinceLastTick / (now - _lastCvFrameTime)) : 0,
-                            cpuTimesPerFrame = profilerResult.cpuTimePerFrame,
-                            memoryPerFrame = profilerResult.systemUsedMemoryPerFrame,
-                            gcMemoryPerFrame = profilerResult.gcUsedMemoryPerFrame,
-                            engineStats = new EngineStatsData()
-                            {
-#if UNITY_EDITOR
-                                frameTime = UnityStats.frameTime,
-                                renderTime = UnityStats.renderTime,
-                                triangles = UnityStats.triangles,
-                                vertices = UnityStats.vertices,
-                                setPassCalls = UnityStats.setPassCalls,
-                                drawCalls = UnityStats.drawCalls,
-                                dynamicBatchedDrawCalls = UnityStats.dynamicBatchedDrawCalls,
-                                staticBatchedDrawCalls = UnityStats.staticBatchedDrawCalls,
-                                instancedBatchedDrawCalls = UnityStats.instancedBatchedDrawCalls,
-                                batches = UnityStats.batches,
-                                dynamicBatches = UnityStats.dynamicBatches,
-                                staticBatches = UnityStats.staticBatches,
-                                instancedBatches = UnityStats.instancedBatches
-#endif
-                            }
+                            perFrameStatistics = _profilerObserver.DequeueAll()
                         };
 
                         _lastCvFrameTime = now;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -566,9 +566,9 @@ namespace RegressionGames.StateRecorder
                             framesSincePreviousTick = _frameCountSinceLastTick,
                             previousTickTime = _lastCvFrameTime > 0 ? _lastCvFrameTime : 0,
                             fps = _lastCvFrameTime > 0 ? (int)(_frameCountSinceLastTick / (now - _lastCvFrameTime)) : 0,
-                            cpuTimeSincePreviousTick = profilerResult.cpuTimeSincePreviousTick,
-                            memory = profilerResult.systemUsedMemory,
-                            gcMemory = profilerResult.gcUsedMemory,
+                            cpuTimesPerFrame = profilerResult.cpuTimePerFrame,
+                            memoryPerFrame = profilerResult.systemUsedMemoryPerFrame,
+                            gcMemoryPerFrame = profilerResult.gcUsedMemoryPerFrame,
                             engineStats = new EngineStatsData()
                             {
 #if UNITY_EDITOR


### PR DESCRIPTION
This PR introduces a `perFrameStatistics` field to the performance field, which collects profiler and engine stats for every frame of the tick. This is a revised version of an earlier PR (see [here](https://github.com/Regression-Games/RGUnityBots/pull/210) for background).

This implements the format that was suggested in the prior PR. The data size is about 350 to 380 bytes per frame. Note that the first tick will have `null` values for the profiler data.

I've tested this code both in the in-editor and standalone builds of Boss Room.

Examples:
[1.json](https://github.com/user-attachments/files/16073618/1.json)
[7.json](https://github.com/user-attachments/files/16073626/7.json)



---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
