### PR TITLE
[REG-1848] Gracefully handle IO errors during legacy input instrumentation

### DIFF
--- a/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
@@ -302,6 +302,7 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
             }
             if (done)
             {
+                _numInstrumentationAttempts = 0;
                 EditorApplication.update -= ScheduledInstrumentationLoop;
             }
         }

--- a/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
@@ -285,7 +285,7 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
                     // if the instrumentation failed, attempt a couple more times with exponential backoff timeout
                     if (_numInstrumentationAttempts < MaxAttempts-1)
                     {
-                        double timeout = 1.0 * Math.Pow(2.0, _numInstrumentationAttempts); // 3 sec, 6 sec, 12 sec
+                        double timeout = 3.0 * Math.Pow(2.0, _numInstrumentationAttempts); // 3 sec, 6 sec, 12 sec
                         _scheduledInstrumentationTime = EditorApplication.timeSinceStartup + timeout;
                         ++_numInstrumentationAttempts;
                         done = false;

--- a/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
@@ -266,7 +266,7 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
             }
             catch (IOException e)
             {
-                // If the instrumentation failed here, then there is nothing w can o
+                // If the instrumentation failed here, then there is nothing we can do since this could be part of a player build process
                 RGDebug.Log($"Instrumentation of legacy input APIs failed for {assemblyAssetPath}. Simulating legacy inputs may not work, try re-building the game assemblies.\n{e.Message}\n{e.StackTrace}");
             }
         }

--- a/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
@@ -20,21 +20,20 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
      */
     public class RGLegacyInputInstrumentation
     {
+        private const int MaxAttempts = 4;
+        
+        private static double _scheduledInstrumentationTime;
+        private static int _numInstrumentationAttempts;
+        
         [InitializeOnLoadMethod]
         static void OnStartup()
         {
-            // Safer to do any initial instrumentation within the editor update loop.
-            // Initial experiments with running directly from static initializers
-            // caused errors sometimes.
-            EditorApplication.update += SetUpHooks;
-        }
-
-        static void SetUpHooks()
-        {
-            EditorApplication.update -= SetUpHooks;
             CompilationPipeline.compilationStarted += UpdateAssemblyResolver;
             CompilationPipeline.assemblyCompilationFinished += OnAssemblyCompiled;
-            InstrumentExistingAssemblies();
+            
+            _numInstrumentationAttempts = 0;
+            _scheduledInstrumentationTime = EditorApplication.timeSinceStartup;
+            EditorApplication.update += ScheduledInstrumentationLoop;
         }
 
         private static bool IsAssemblyIgnored(string assemblyPath, Assembly rgAssembly)
@@ -260,17 +259,77 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
 
         private static void OnAssemblyCompiled(string assemblyAssetPath, CompilerMessage[] messages)
         {
-            Assembly rgAssembly = FindRGAssembly();
-            InstrumentAssemblyIfNeeded(assemblyAssetPath, rgAssembly);
+            try
+            {
+                Assembly rgAssembly = FindRGAssembly();
+                InstrumentAssemblyIfNeeded(assemblyAssetPath, rgAssembly);
+            }
+            catch (IOException e)
+            {
+                // If the instrumentation failed here, then there is nothing w can o
+                RGDebug.Log($"Instrumentation of legacy input APIs failed for {assemblyAssetPath}. Simulating legacy inputs may not work, try re-building the game assemblies.\n{e.Message}\n{e.StackTrace}");
+            }
         }
 
-        private static void InstrumentExistingAssemblies()
+        static void ScheduledInstrumentationLoop()
         {
-            Assembly[] assemblies = CompilationPipeline.GetAssemblies(AssembliesType.Player);
-            Assembly rgAssembly = FindRGAssembly();
-            foreach (Assembly assembly in assemblies)
+            bool done;
+            if (EditorApplication.timeSinceStartup >= _scheduledInstrumentationTime)
             {
-                InstrumentAssemblyIfNeeded(assembly.outputPath, rgAssembly);
+                if (InstrumentExistingAssemblies())
+                {
+                    done = true;
+                }
+                else
+                {
+                    // if the instrumentation failed, attempt a couple more times with exponential backoff timeout
+                    if (_numInstrumentationAttempts < MaxAttempts-1)
+                    {
+                        double timeout = 1.0 * Math.Pow(2.0, _numInstrumentationAttempts); // 3 sec, 6 sec, 12 sec
+                        _scheduledInstrumentationTime = EditorApplication.timeSinceStartup + timeout;
+                        ++_numInstrumentationAttempts;
+                        done = false;
+                    }
+                    else
+                    {
+                        done = true;
+                    }
+                }
+            }
+            else
+            {
+                done = false;
+            }
+            if (done)
+            {
+                EditorApplication.update -= ScheduledInstrumentationLoop;
+            }
+        }
+        
+        private static bool InstrumentExistingAssemblies()
+        {
+            try
+            {
+                Assembly[] assemblies = CompilationPipeline.GetAssemblies(AssembliesType.Player);
+                Assembly rgAssembly = FindRGAssembly();
+                foreach (Assembly assembly in assemblies)
+                {
+                    InstrumentAssemblyIfNeeded(assembly.outputPath, rgAssembly);
+                }
+                return true;
+            }
+            catch (IOException e)
+            {
+                // If the instrumentation fails, the ScheduledInstrumentationLoop will schedule a re-attempt a couple more times
+                if (_numInstrumentationAttempts+1 == MaxAttempts)
+                {
+                    RGDebug.LogError($"Instrumenting legacy input APIs failed, maximum number of attempts exhausted. Simulating legacy inputs will not work, try re-building the game assemblies.\n{e.Message}\n{e.StackTrace}");
+                }
+                else
+                {
+                    RGDebug.LogWarning($"Attempt {_numInstrumentationAttempts+1}/{MaxAttempts} at instrumenting legacy input APIs failed, scheduling re-attempt\n{e.Message}\n{e.StackTrace}");
+                }
+                return false;
             }
         }
     }


### PR DESCRIPTION
For various reasons, the initial attempt at instrumenting the legacy input API usage in the assemblies could fail (e.g. file in use by another job). 

This PR introduces graceful handling of these errors. If the initial instrumentation fails, a couple more attempts are scheduled with exponential backoff. Ultimately if all these attempts fail, the user is warned that the SDK's legacy input support may not work and the user should consider rebuilding the game code.

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
