### PR TITLE
[REG-1848] Address instrumentation conflicts and improve error handling

### DIFF
--- a/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
@@ -266,8 +266,10 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
 
         static void ScheduledInstrumentationLoop()
         {
+            bool editorIsBusy = EditorApplication.isCompiling || EditorApplication.isUpdating;
+            
             bool done;
-            if (EditorApplication.timeSinceStartup >= _scheduledInstrumentationTime)
+            if (!editorIsBusy && EditorApplication.timeSinceStartup >= _scheduledInstrumentationTime)
             {
                 if (InstrumentExistingAssemblies())
                 {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/Actions/MouseHoverObjectAction.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/Actions/MouseHoverObjectAction.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Collections.Generic;
-using System.Text;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
 using UnityEngine.UI;


### PR DESCRIPTION
This is a second pass at addressing issues that can occur with the input instrumentation:
1. Check the `EditorApplication.isCompiling` and `EditorApplication.isUpdating` flags. If either is true, defer the instrumentation until later.
2. Remove the inner exception handler in InstrumentAssemblyIfNeeded (we already have exception handlers in the callers), and broaden the exceptions handled to all Exceptions (this will handle any errors that could come out of Mono.Cecil's own APIs).

I've tested this by re-opening Boss Room and some other Unity projects from scratch (deleting the Library folder). The whole instrumentation process works in my testing.

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
