### PR TITLE
[REG-1859] Monkey bot segment

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/Actions/MouseHoverObjectAction.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/Actions/MouseHoverObjectAction.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Collections.Generic;
-using System.Text;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
-using UnityEngine.UI;
 using Object = UnityEngine.Object;
 using RegressionGames.StateRecorder.Models;
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionManager.cs
@@ -62,11 +62,11 @@ namespace RegressionGames.ActionManager
         public static void InitializeInEditor()
         {
             ReloadActions();
-            LoadSettings();
+            _settings = LoadSettings();
         }
         #endif
 
-        private static void LoadSettings()
+        private static RGActionManagerSettings LoadSettings()
         {
             string jsonText = null;
             #if UNITY_EDITOR
@@ -83,17 +83,21 @@ namespace RegressionGames.ActionManager
                 jsonText = jsonFile?.text;
             }
             #endif
+            
+            RGActionManagerSettings result;
             if (jsonText != null)
             {
-                _settings = JsonUtility.FromJson<RGActionManagerSettings>(jsonText);
+                result = JsonUtility.FromJson<RGActionManagerSettings>(jsonText);
             }
             else
             {
-                _settings = new RGActionManagerSettings();
+                result = new RGActionManagerSettings();
                 #if UNITY_EDITOR
                 SaveSettings();
                 #endif
             }
+
+            return result;
         }
 
         #if UNITY_EDITOR
@@ -110,32 +114,64 @@ namespace RegressionGames.ActionManager
         }
         #endif
 
-        public static void StartSession(MonoBehaviour context)
+        /// <summary>
+        /// Returns whether the given context needs the game environment to be configured
+        /// (starting input wrapper, hooking scenes, etc.)
+        /// </summary>
+        private static bool DoesContextNeedSetUp()
+        {
+            return _context is not ReplayDataPlaybackController;
+        }
+
+        /// <summary>
+        /// Start an action manager session. This should be called prior to any calls to GetValidActions().
+        /// </summary>
+        /// <param name="context">The MonoBehaviour context under which actions will be simulated.</param>
+        /// <param name="actionSettings">Session-specific action settings (optional - if null will use saved configuration)</param>
+        public static void StartSession(MonoBehaviour context, RGActionManagerSettings actionSettings = null)
         {
             if (_context != null)
             {
                 throw new Exception($"Session is already active with context {_context}");
             }
             ReloadActions();
-            LoadSettings();
+            if (actionSettings != null)
+            {
+                _settings = actionSettings;
+            }
+            else
+            {
+                _settings = LoadSettings();
+            }
             _context = context;
             _sessionActions = new List<RGGameAction>(_actionProvider.Actions.Where(IsActionEnabled));
-            RGLegacyInputWrapper.StartSimulation(_context);
-            SceneManager.sceneLoaded += OnSceneLoad;
-            RGUtils.SetupEventSystem();
-            RGUtils.ConfigureInputSettings();
             InitInputState();
+
+            if (DoesContextNeedSetUp())
+            {
+                RGLegacyInputWrapper.StartSimulation(_context);
+                SceneManager.sceneLoaded += OnSceneLoad;
+                RGUtils.SetupEventSystem();
+                RGUtils.ConfigureInputSettings();
+            }
         }
 
+        /// <summary>
+        /// Stop an action manager session.
+        /// </summary>
         public static void StopSession()
         {
             if (_context != null)
             {
-                SceneManager.sceneLoaded -= OnSceneLoad;
-                RGLegacyInputWrapper.StopSimulation();
-                RGUtils.RestoreInputSettings();
+                if (DoesContextNeedSetUp())
+                {
+                    SceneManager.sceneLoaded -= OnSceneLoad;
+                    RGLegacyInputWrapper.StopSimulation();
+                    RGUtils.RestoreInputSettings();
+                }
                 _sessionActions = null;
                 _context = null;
+                _settings = LoadSettings(); // restore settings back to the saved configuration 
             }
         }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionManagerSettings.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionManagerSettings.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
+using RegressionGames.StateRecorder.JsonConverters;
 using UnityEngine;
 
 namespace RegressionGames.ActionManager
@@ -31,6 +33,23 @@ namespace RegressionGames.ActionManager
         public void MarkDirty()
         {
             _disabledActionPathSet = null;
+        }
+
+        public void WriteToStringBuilder(StringBuilder stringBuilder)
+        {
+            stringBuilder.Append("{\n");
+            stringBuilder.Append("\"DisabledActionPaths\":[\n");
+            int disabledActionPathCount = DisabledActionPaths.Count;
+            for (int i = 0; i < disabledActionPathCount; ++i)
+            {
+                StringJsonConverter.WriteToStringBuilder(stringBuilder, DisabledActionPaths[i]);
+                if (i + 1 < disabledActionPathCount)
+                {
+                    stringBuilder.Append(",\n");
+                }
+            }
+            stringBuilder.Append("\n]");
+            stringBuilder.Append("\n}");
         }
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/GenericBots/RGMonkeyBot.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/GenericBots/RGMonkeyBot.cs
@@ -1,36 +1,12 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using RegressionGames.ActionManager;
-using RegressionGames.ActionManager.Actions;
+﻿using RegressionGames.ActionManager;
 using UnityEngine;
 
 namespace RegressionGames.GenericBots
 {
-    internal class MonkeyBotActionEntry
-    {
-        public IRGGameActionInstance ActionInstance;
-        public object Parameter;
-        public bool Performed;
-        public IList<RGActionInput> Inputs;
-    }
-    
     public class RGMonkeyBot : MonoBehaviour, IRGBot
     {
         public float actionInterval = 0.05f; // unscaled time
-        
-        private float _lastActionTime;
-
-        private IList<MonkeyBotActionEntry> _actionsBuf;
-        private IList<MonkeyBotActionEntry> _remainingActionsBuf;
-
-        private ISet<int> _mouseBtnsBuf;
-
-        private void ResetState()
-        {
-            _actionsBuf.Clear();
-            _remainingActionsBuf.Clear();
-            _mouseBtnsBuf.Clear();
-        }
+        private RGMonkeyBotLogic monkey;
     
         void Start()
         {
@@ -41,152 +17,15 @@ namespace RegressionGames.GenericBots
                 return;
             }
             RGActionManager.StartSession(this);
-            
-            _lastActionTime = Time.unscaledTime;
-            _actionsBuf = new List<MonkeyBotActionEntry>();
-            _remainingActionsBuf = new List<MonkeyBotActionEntry>();
-            _mouseBtnsBuf = new HashSet<int>();
-            
+
+            monkey = new RGMonkeyBotLogic();
             DontDestroyOnLoad(this);
         }
     
         void Update()
         {
-            if (GameObject.Find("Selection Panel") != null)
-            {
-                // Pause sending events while the overlay panel is open
-                return;
-            }
-
-            float currentTimeUnscaled = Time.unscaledTime;
-            if (currentTimeUnscaled - _lastActionTime < actionInterval)
-            {
-                // if not deciding on a new action, then repeat inputs sent on the last frame
-                foreach (var act in _actionsBuf.Where(act => act.Performed))
-                {
-                    foreach (var inp in act.Inputs)
-                    {
-                        inp.Perform();
-                    }
-                }
-                return;
-            }
-            _lastActionTime = currentTimeUnscaled;
-            
-            bool didHeuristic = false;
-            
-            // Heuristic: If the last action was a mouse down on a Unity UI button, always release the mouse button on this frame over
-            // the same mouse coordinate to trigger the click event
-            foreach (var performedAction in _actionsBuf.Where(act => act.Performed))
-            {
-                if (performedAction.ActionInstance is UIButtonPressInstance && (bool)performedAction.Parameter)
-                {
-                    var action = performedAction.ActionInstance.BaseAction;
-                    var targetObject = performedAction.ActionInstance.TargetObject;
-                    if (targetObject != null && action.IsValidForObject(targetObject))
-                    {
-                        foreach (var inp in action.GetInstance(targetObject).GetInputs(false))
-                        {
-                            inp.Perform();
-                        }
-                        didHeuristic = true;
-                    }
-                }
-            }
-            if (didHeuristic)
-            {
-                ResetState();
-                return;
-            }
-            
-            // Heuristic: If the last set of inputs was a mouse position movement + a set of mouse button presses, 
-            // then have some random chance of releasing those buttons over the same mouse position to complete a potential click event.
-            // Otherwise, in general it is very unlikely that a mouse button press and release would occur over the same position.
-            {
-                bool haveMousePos = false;
-                _mouseBtnsBuf.Clear();
-                foreach (var inp in _actionsBuf.Where(act => act.Performed).SelectMany(act => act.Inputs))
-                {
-                    if (inp is MousePositionInput)
-                    {
-                        haveMousePos = true;
-                    } else if (inp is MouseButtonInput mbInput)
-                    {
-                        if (mbInput.IsPressed)
-                        {
-                            _mouseBtnsBuf.Add(mbInput.MouseButton);
-                        }
-                    } else if (inp is LegacyKeyInput keyInput)
-                    {
-                        if (keyInput.KeyCode >= KeyCode.Mouse0 && keyInput.KeyCode <= KeyCode.Mouse6)
-                        {
-                            _mouseBtnsBuf.Add(keyInput.KeyCode - KeyCode.Mouse0);
-                        }
-                    }
-                }
-
-                if (haveMousePos && _mouseBtnsBuf.Count > 0)
-                {
-                    if (Random.Range(0, 2) == 1) // 50% chance of attempting a click event
-                    {
-                        foreach (var btn in _mouseBtnsBuf)
-                        {
-                            new MouseButtonInput(btn, false).Perform();
-                        }
-                        didHeuristic = true;
-                    }
-                }
-            }
-            if (didHeuristic)
-            {
-                ResetState();
-                return;
-            }
-            
-            ResetState();
-
-            // Compute the set of valid actions
-            foreach (var actionInstance in RGActionManager.GetValidActions())
-            {
-                var entry = new MonkeyBotActionEntry()
-                {
-                    ActionInstance = actionInstance,
-                    Parameter = actionInstance.BaseAction.ParameterRange.RandomSample(),
-                    Performed = false
-                };
-                entry.Inputs = new List<RGActionInput>(actionInstance.GetInputs(entry.Parameter));
-                if (entry.Inputs.Count > 0)
-                {
-                    _actionsBuf.Add(entry);
-                }
-            }
-
-            // Randomly perform actions from the list 
-            // This repeatedly selects actions whose inputs do not overlap
-            // with the inputs that have already been performed.
-            do
-            {
-                _remainingActionsBuf.Clear();
-                foreach (var action in _actionsBuf.Where(act => !act.Performed))
-                {
-                    if (!_actionsBuf.Any(performedAction =>
-                            performedAction.Performed && performedAction.Inputs.Overlap(action.Inputs)))
-                    {
-                        _remainingActionsBuf.Add(action);
-                    }
-                }
-
-                if (_remainingActionsBuf.Count > 0)
-                {
-                    var action = _remainingActionsBuf[Random.Range(0, _remainingActionsBuf.Count)];
-                    foreach (var inp in action.Inputs)
-                    {
-                        inp.Perform();
-                    }
-
-                    action.Performed = true;
-                }
-            } while (_remainingActionsBuf.Count > 0);
+            monkey.ActionInterval = actionInterval;
+            monkey.Update();
         }
 
         void OnDestroy()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/GenericBots/RGMonkeyBotLogic.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/GenericBots/RGMonkeyBotLogic.cs
@@ -1,0 +1,197 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using RegressionGames.ActionManager;
+using RegressionGames.ActionManager.Actions;
+using UnityEngine;
+
+namespace RegressionGames.GenericBots
+{
+    internal class MonkeyBotActionEntry
+    {
+        public IRGGameActionInstance ActionInstance;
+        public object Parameter;
+        public bool Performed;
+        public IList<RGActionInput> Inputs;
+    }
+    
+    public class RGMonkeyBotLogic
+    {
+        public float ActionInterval { get; set; } = 0.05f;
+
+        private float _lastActionTime;
+        private IList<MonkeyBotActionEntry> _actionsBuf;
+        private IList<MonkeyBotActionEntry> _remainingActionsBuf;
+        private ISet<int> _mouseBtnsBuf;
+
+        public RGMonkeyBotLogic()
+        {
+            Reset();
+        }
+
+        public void Reset()
+        {
+            _lastActionTime = Time.unscaledTime;
+            _actionsBuf = new List<MonkeyBotActionEntry>();
+            _remainingActionsBuf = new List<MonkeyBotActionEntry>();
+            _mouseBtnsBuf = new HashSet<int>();
+        }
+        
+        private void ResetState()
+        {
+            _actionsBuf.Clear();
+            _remainingActionsBuf.Clear();
+            _mouseBtnsBuf.Clear();
+        }
+
+        /// <summary>
+        /// Perform an update step of the monkey bot.
+        /// </summary>
+        /// <returns>Whether any action was performed (inputs simulated).</returns>
+        public bool Update()
+        {
+            bool didAnyAction = false;
+            
+            if (GameObject.Find("Selection Panel") != null)
+            {
+                // Pause sending events while the overlay panel is open
+                return didAnyAction;
+            }
+
+            float currentTimeUnscaled = Time.unscaledTime;
+            if (currentTimeUnscaled - _lastActionTime < ActionInterval)
+            {
+                // if not deciding on a new action, then repeat inputs sent on the last frame
+                foreach (var act in _actionsBuf.Where(act => act.Performed))
+                {
+                    foreach (var inp in act.Inputs)
+                    {
+                        inp.Perform();
+                        didAnyAction = true;
+                    }
+                }
+                return didAnyAction;
+            }
+            _lastActionTime = currentTimeUnscaled;
+            
+            bool didHeuristic = false;
+            
+            // Heuristic: If the last action was a mouse down on a Unity UI button, always release the mouse button on this frame over
+            // the same mouse coordinate to trigger the click event
+            foreach (var performedAction in _actionsBuf.Where(act => act.Performed))
+            {
+                if (performedAction.ActionInstance is UIButtonPressInstance && (bool)performedAction.Parameter)
+                {
+                    var action = performedAction.ActionInstance.BaseAction;
+                    var targetObject = performedAction.ActionInstance.TargetObject;
+                    if (targetObject != null && action.IsValidForObject(targetObject))
+                    {
+                        foreach (var inp in action.GetInstance(targetObject).GetInputs(false))
+                        {
+                            inp.Perform();
+                            didAnyAction = true;
+                        }
+                        didHeuristic = true;
+                    }
+                }
+            }
+            if (didHeuristic)
+            {
+                ResetState();
+                return didAnyAction;
+            }
+            
+            // Heuristic: If the last set of inputs was a mouse position movement + a set of mouse button presses, 
+            // then have some random chance of releasing those buttons over the same mouse position to complete a potential click event.
+            // Otherwise, in general it is very unlikely that a mouse button press and release would occur over the same position.
+            {
+                bool haveMousePos = false;
+                _mouseBtnsBuf.Clear();
+                foreach (var inp in _actionsBuf.Where(act => act.Performed).SelectMany(act => act.Inputs))
+                {
+                    if (inp is MousePositionInput)
+                    {
+                        haveMousePos = true;
+                    } else if (inp is MouseButtonInput mbInput)
+                    {
+                        if (mbInput.IsPressed)
+                        {
+                            _mouseBtnsBuf.Add(mbInput.MouseButton);
+                        }
+                    } else if (inp is LegacyKeyInput keyInput)
+                    {
+                        if (keyInput.KeyCode >= KeyCode.Mouse0 && keyInput.KeyCode <= KeyCode.Mouse6)
+                        {
+                            _mouseBtnsBuf.Add(keyInput.KeyCode - KeyCode.Mouse0);
+                        }
+                    }
+                }
+
+                if (haveMousePos && _mouseBtnsBuf.Count > 0)
+                {
+                    if (Random.Range(0, 2) == 1) // 50% chance of attempting a click event
+                    {
+                        foreach (var btn in _mouseBtnsBuf)
+                        {
+                            new MouseButtonInput(btn, false).Perform();
+                            didAnyAction = true;
+                        }
+                        didHeuristic = true;
+                    }
+                }
+            }
+            if (didHeuristic)
+            {
+                ResetState();
+                return didAnyAction;
+            }
+            
+            ResetState();
+
+            // Compute the set of valid actions
+            foreach (var actionInstance in RGActionManager.GetValidActions())
+            {
+                var entry = new MonkeyBotActionEntry()
+                {
+                    ActionInstance = actionInstance,
+                    Parameter = actionInstance.BaseAction.ParameterRange.RandomSample(),
+                    Performed = false
+                };
+                entry.Inputs = new List<RGActionInput>(actionInstance.GetInputs(entry.Parameter));
+                if (entry.Inputs.Count > 0)
+                {
+                    _actionsBuf.Add(entry);
+                }
+            }
+
+            // Randomly perform actions from the list 
+            // This repeatedly selects actions whose inputs do not overlap
+            // with the inputs that have already been performed.
+            do
+            {
+                _remainingActionsBuf.Clear();
+                foreach (var action in _actionsBuf.Where(act => !act.Performed))
+                {
+                    if (!_actionsBuf.Any(performedAction =>
+                            performedAction.Performed && performedAction.Inputs.Overlap(action.Inputs)))
+                    {
+                        _remainingActionsBuf.Add(action);
+                    }
+                }
+
+                if (_remainingActionsBuf.Count > 0)
+                {
+                    var action = _remainingActionsBuf[Random.Range(0, _remainingActionsBuf.Count)];
+                    foreach (var inp in action.Inputs)
+                    {
+                        inp.Perform();
+                        didAnyAction = true;
+                    }
+
+                    action.Performed = true;
+                }
+            } while (_remainingActionsBuf.Count > 0);
+
+            return didAnyAction;
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/GenericBots/RGMonkeyBotLogic.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/GenericBots/RGMonkeyBotLogic.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 021b7a76240f41fc9bb2d92595cf37e7
+timeCreated: 1721156692

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BehaviourActionDataJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BehaviourActionDataJsonConverter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using RegressionGames.StateRecorder.BotSegments.Models;
+using UnityEngine;
+
+namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
+{
+    public sealed class BehaviourActionDataJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(BehaviourActionData).IsAssignableFrom(objectType);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JObject jObject = JObject.Load(reader);
+            // ReSharper disable once UseObjectOrCollectionInitializer - easier to debug lines without this
+            BehaviourActionData data = new();
+            data.BehaviourFullName = jObject.GetValue("behaviourFullName").ToObject<string>(serializer);
+            data.apiVersion = jObject.GetValue("apiVersion").ToObject<int>();
+            return data;
+        }
+
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BehaviourActionDataJsonConverter.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BehaviourActionDataJsonConverter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1572a117a1c34207806c5200b696fc9b
+timeCreated: 1721070536

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotActionJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotActionJsonConverter.cs
@@ -29,6 +29,9 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
                 case BotActionType.RandomMouse_ClickObject:
                     data = jObject["data"].ToObject<RandomMouseObjectActionData>(serializer);
                     break;
+                case BotActionType.MonkeyBot:
+                    data = jObject["data"].ToObject<MonkeyBotActionData>(serializer);
+                    break;
                 default:
                     throw new JsonSerializationException($"Unsupported BotAction type: '{action.type}'");
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/MonkeyBotActionDataJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/MonkeyBotActionDataJsonConverter.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using RegressionGames.ActionManager;
+using RegressionGames.StateRecorder.BotSegments.Models;
+
+namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
+{
+    public class MonkeyBotActionDataJsonConverter : JsonConverter
+    {
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JObject jObject = JObject.Load(reader);
+            MonkeyBotActionData data = new MonkeyBotActionData();
+            data.apiVersion = jObject["apiVersion"].ToObject<int>();
+            data.actionInterval = jObject["actionInterval"].ToObject<float>();
+            data.actionSettings = jObject["actionSettings"].ToObject<RGActionManagerSettings>();
+            return data;
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(MonkeyBotActionData).IsAssignableFrom(objectType);
+        }
+        
+        public override bool CanWrite => false;
+        
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/MonkeyBotActionDataJsonConverter.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/MonkeyBotActionDataJsonConverter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2a4e88bdc1c4418580331963b1e2918f
+timeCreated: 1721156168

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BehaviourActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BehaviourActionData.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using Newtonsoft.Json;
+using RegressionGames.StateRecorder.BotSegments.JsonConverters;
+using RegressionGames.StateRecorder.JsonConverters;
+using RegressionGames.StateRecorder.Models;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace RegressionGames.StateRecorder.BotSegments.Models
+{
+    /**
+     * <summary>Data for clicking on a random pixel in the frame</summary>
+     */
+    [Serializable]
+    [JsonConverter(typeof(BehaviourActionDataJsonConverter))]
+    public class BehaviourActionData : IBotActionData
+    {
+        // api version for this object, update if object format changes
+        public int apiVersion = SdkApiVersion.VERSION_5;
+
+        [NonSerialized]
+        public static readonly BotActionType Type = BotActionType.Behaviour;
+
+        public string BehaviourFullName;
+
+        private bool IsStopped;
+
+        private GameObject myGameObject;
+
+        public bool IsCompleted()
+        {
+            return IsStopped;
+        }
+
+        public void ReplayReset()
+        {
+        }
+
+        public void StartAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
+        {
+            Type t = null;
+            // load our script type without knowing the assembly name, just the full type
+            foreach (Assembly a in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                foreach (var type in a.GetTypes())
+                {
+                    if (type.FullName != null && type.FullName.Equals(BehaviourFullName))
+                    {
+                        t = type;
+                        break;
+                    }
+                }
+            }
+            if (t == null)
+            {
+                RGDebug.LogError($"Regression Games could not load Bot Segment Behaviour Action for Type - {BehaviourFullName}. Type was not found in any assembly in the current runtime.");
+            }
+            else
+            {
+                // load behaviour and set as a child of the playback controller
+                var pbController = UnityEngine.Object.FindObjectOfType<ReplayDataPlaybackController>();
+                myGameObject = new GameObject($"BehaviourAction_{BehaviourFullName}")
+                {
+                    transform =
+                    {
+                        parent = pbController.transform
+                    }
+                };
+
+                // Attach our behaviour
+                myGameObject.AddComponent(t);
+            }
+        }
+
+        public bool ProcessAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities, out string error)
+        {
+            // Behaviour is expected to perform its actions in its own 'Update' or 'LateUpdate' calls
+            // It can get the current state information from the runtime directly... or can access our information by using
+            // UnityEngine.Object.FindObjectOfType<TransformObjectFinder>().GetObjectStatusForCurrentFrame();
+            // and/or
+            // UnityEngine.Object.FindObjectOfType<EntityObjectFinder>().GetObjectStatusForCurrentFrame(); - for runtimes with ECS support
+            error = null;
+            if (!IsStopped)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public void StopAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
+        {
+            IsStopped = true;
+            if (myGameObject != null)
+            {
+                UnityEngine.Object.Destroy(myGameObject);
+            }
+            myGameObject = null;
+        }
+
+        public void OnGUI(Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
+        {
+            // OnGUI can be implemented on the behaviour itself
+        }
+
+        public void WriteToStringBuilder(StringBuilder stringBuilder)
+        {
+            stringBuilder.Append("{\"apiVersion\":");
+            IntJsonConverter.WriteToStringBuilder(stringBuilder, apiVersion);
+            stringBuilder.Append(",\"behaviourFullName\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, BehaviourFullName);
+            stringBuilder.Append("}");
+        }
+
+        public int EffectiveApiVersion()
+        {
+            return apiVersion;
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BehaviourActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BehaviourActionData.cs
@@ -37,6 +37,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         public void ReplayReset()
         {
+            IsStopped = false;
         }
 
         public void StartAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BehaviourActionData.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BehaviourActionData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 91522d22765e4444941168eb984daf75
+timeCreated: 1721070303

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotAction.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotAction.cs
@@ -35,6 +35,13 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             return data.ProcessAction(segmentNumber, currentTransforms, currentEntities, out error);
         }
 
+        // called when a segment ends to stop any action processing
+        // For segments with action sequences, they should still finish processing all their actions before stopping.
+        public void StopAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
+        {
+            data.StopAction(segmentNumber, currentTransforms, currentEntities);
+        }
+
         public void ReplayReset()
         {
             data.ReplayReset();

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotActionType.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotActionType.cs
@@ -6,11 +6,11 @@
         InputPlayback,
         RandomMouse_ClickPixel,
         RandomMouse_ClickObject,
+        Behaviour,
 
         //FUTURE
         //Timer,
         //FrameCount,
-        //Behaviour,
         //AgentBuilder,
         //OrchestratedInput,
         //RandomKeyboard_Key,

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotActionType.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotActionType.cs
@@ -7,6 +7,7 @@
         RandomMouse_ClickPixel,
         RandomMouse_ClickObject,
         Behaviour,
+        MonkeyBot,
 
         //FUTURE
         //Timer,

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
@@ -74,6 +74,11 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             return false;
         }
 
+        public void StopAction(Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
+        {
+            botAction.StopAction(Replay_SegmentNumber, currentTransforms, currentEntities);
+        }
+
         // Replay only
         public void ReplayReset()
         {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
@@ -19,6 +19,12 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
          */
         public bool ProcessAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities, out string error);
 
+        /**
+         * Called when a segment completes to stop any outstanding actions or mark the action as should stop.
+         * For segments with action sequences, they should still finish processing all their actions before stopping.
+         */
+        public void StopAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities);
+
         public void WriteToStringBuilder(StringBuilder stringBuilder);
 
         public void ReplayReset();

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
@@ -29,10 +29,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         public void ReplayReset();
 
-        /**
-         * Returns null if the action runs until the keyframecriteria match
-         */
-        public bool? IsCompleted();
+        public bool IsCompleted();
 
         public int EffectiveApiVersion();
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
@@ -94,7 +94,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             // for input playback, we finish the action queue even if criteria match before hand (no-op)
         }
 
-        public bool? IsCompleted()
+        public bool IsCompleted()
         {
             foreach (var keyboardInputActionData in inputData.keyboard)
             {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
@@ -89,6 +89,11 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             return result;
         }
 
+        public void StopAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
+        {
+            // for input playback, we finish the action queue even if criteria match before hand (no-op)
+        }
+
         public bool? IsCompleted()
         {
             foreach (var keyboardInputActionData in inputData.keyboard)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/MonkeyBotActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/MonkeyBotActionData.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+using RegressionGames.ActionManager;
+using RegressionGames.GenericBots;
+using RegressionGames.StateRecorder.BotSegments.JsonConverters;
+using RegressionGames.StateRecorder.JsonConverters;
+using RegressionGames.StateRecorder.Models;
+using UnityEngine;
+
+namespace RegressionGames.StateRecorder.BotSegments.Models
+{
+    [Serializable]
+    [JsonConverter(typeof(MonkeyBotActionDataJsonConverter))]
+    public class MonkeyBotActionData : IBotActionData
+    {
+        [NonSerialized] 
+        public static readonly BotActionType Type = BotActionType.MonkeyBot;
+        
+        public int apiVersion = SdkApiVersion.VERSION_5;
+        public float actionInterval = 0.05f;
+        public RGActionManagerSettings actionSettings;
+
+        [NonSerialized]
+        private bool isStopped;
+
+        [NonSerialized] 
+        private RGMonkeyBotLogic monkey;
+        
+        public void StartAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
+        {
+            Debug.Log("StartAction called");
+            var controller = UnityEngine.Object.FindObjectOfType<ReplayDataPlaybackController>();
+            RGActionManager.StartSession(controller, actionSettings);
+            monkey = new RGMonkeyBotLogic();
+            monkey.ActionInterval = actionInterval;
+        }
+
+        public bool ProcessAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities, out string error)
+        {
+            if (!isStopped)
+            {
+                bool didAnyAction = monkey.Update();
+                error = null;
+                return didAnyAction;
+            }
+
+            error = null;
+            return false;
+        }
+
+        public void StopAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
+        {
+            Debug.Log("StopAction called");
+            RGActionManager.StopSession();
+            isStopped = true;
+        }
+
+        public void WriteToStringBuilder(StringBuilder stringBuilder)
+        {
+            stringBuilder.Append("{\"apiVersion\":");
+            IntJsonConverter.WriteToStringBuilder(stringBuilder, apiVersion);
+            stringBuilder.Append(",\"actionInterval\":");
+            FloatJsonConverter.WriteToStringBuilder(stringBuilder, actionInterval);
+            stringBuilder.Append(",\"actionSettings\":");
+            actionSettings.WriteToStringBuilder(stringBuilder);
+            stringBuilder.Append("}");
+        }
+
+        public void ReplayReset()
+        {
+            isStopped = false;
+            monkey = null;
+        }
+
+        public bool IsCompleted()
+        {
+            return isStopped;
+        }
+
+        public int EffectiveApiVersion()
+        {
+            return apiVersion;
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/MonkeyBotActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/MonkeyBotActionData.cs
@@ -30,7 +30,6 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         
         public void StartAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
         {
-            Debug.Log("StartAction called");
             var controller = UnityEngine.Object.FindObjectOfType<ReplayDataPlaybackController>();
             RGActionManager.StartSession(controller, actionSettings);
             monkey = new RGMonkeyBotLogic();
@@ -52,7 +51,6 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         public void StopAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
         {
-            Debug.Log("StopAction called");
             RGActionManager.StopSession();
             isStopped = true;
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/MonkeyBotActionData.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/MonkeyBotActionData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 110971a35404412ebef38c49ac15b85c
+timeCreated: 1721155323

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
@@ -75,217 +75,220 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         public bool ProcessAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities, out string error)
         {
-            var now = Time.unscaledTime;
-            if (now - timeBetweenClicks > Replay_LastClickTime)
+            if (!IsStopped)
             {
-                var screenHeight = Screen.height;
-                var screenWidth = Screen.width;
-
-                List<ObjectStatus> possibleTransformsToClick;
-                // pick randomly either UI or gameObject
-                var uiOrEntityObject = Random.Range(0, 2) > 0;
-                var preconditionsMet = preconditionNormalizedPaths.Count == 0;
-                if (!preconditionsMet)
+                var now = Time.unscaledTime;
+                if (now - timeBetweenClicks > Replay_LastClickTime)
                 {
-                    preconditionsMet = currentTransforms.Any(a => a.Value.screenSpaceBounds != null && StateRecorderUtils.OptimizedContainsStringInList(preconditionNormalizedPaths, a.Value.NormalizedPath));
-                }
+                    var screenHeight = Screen.height;
+                    var screenWidth = Screen.width;
 
-                if (!preconditionsMet)
-                {
-                    preconditionsMet = currentEntities.Any(a => a.Value.screenSpaceBounds != null && StateRecorderUtils.OptimizedContainsStringInList(preconditionNormalizedPaths, a.Value.NormalizedPath));
-                }
-
-                if (!preconditionsMet)
-                {
-                    //TODO: Someday make this only log the ones that weren't matched instead of all the preconditions
-                    StringBuilder theError = new StringBuilder(500);
-                    theError.Append("RandomMouseClicker - Missing one or more precondition normalized paths\r\n");
-                    var preconditionNormalizedPathsCount = preconditionNormalizedPaths.Count;
-                    for (var i = 0; i < preconditionNormalizedPathsCount; i++)
+                    List<ObjectStatus> possibleTransformsToClick;
+                    // pick randomly either UI or gameObject
+                    var uiOrEntityObject = Random.Range(0, 2) > 0;
+                    var preconditionsMet = preconditionNormalizedPaths.Count == 0;
+                    if (!preconditionsMet)
                     {
-                        var pc = preconditionNormalizedPaths[i];
-                        theError.Append(pc);
-                        if (i + 1 < preconditionNormalizedPathsCount)
-                        {
-                            theError.Append("\r\n");
-                        }
+                        preconditionsMet = currentTransforms.Any(a => a.Value.screenSpaceBounds != null && StateRecorderUtils.OptimizedContainsStringInList(preconditionNormalizedPaths, a.Value.NormalizedPath));
                     }
 
-                    error = theError.ToString();
-                    return false;
-                }
-
-                if (currentEntities.Count == 0 || uiOrEntityObject && currentTransforms.Count > 0)
-                {
-                    possibleTransformsToClick = currentTransforms.Values.Where(a => a.screenSpaceBounds != null).ToList();
-                }
-                else
-                {
-                    possibleTransformsToClick = currentEntities.Values.Where(a => a.screenSpaceBounds != null).ToList();
-                }
-
-                var possibleTransformsCount = possibleTransformsToClick.Count;
-                if (possibleTransformsCount > 0)
-                {
-                    var RESTART_LIMIT = 20;
-                    var restartCount = 0;
-                    // try up to 20 times per frame to find a valid click object, but after that, give up till the next frame as none may be available
-                    // helps prevent long searches, or cases where the user excludes the whole screen
-                    do
+                    if (!preconditionsMet)
                     {
-                        var transformOption = possibleTransformsToClick[Random.Range(0, possibleTransformsCount)];
-                        if (StateRecorderUtils.OptimizedStringStartsWithStringInList(excludedNormalizedPaths, transformOption.NormalizedPath))
+                        preconditionsMet = currentEntities.Any(a => a.Value.screenSpaceBounds != null && StateRecorderUtils.OptimizedContainsStringInList(preconditionNormalizedPaths, a.Value.NormalizedPath));
+                    }
+
+                    if (!preconditionsMet)
+                    {
+                        //TODO: Someday make this only log the ones that weren't matched instead of all the preconditions
+                        StringBuilder theError = new StringBuilder(500);
+                        theError.Append("RandomMouseClicker - Missing one or more precondition normalized paths\r\n");
+                        var preconditionNormalizedPathsCount = preconditionNormalizedPaths.Count;
+                        for (var i = 0; i < preconditionNormalizedPathsCount; i++)
                         {
-                            // not allowed object .. pick another
-                            continue; // while
+                            var pc = preconditionNormalizedPaths[i];
+                            theError.Append(pc);
+                            if (i + 1 < preconditionNormalizedPathsCount)
+                            {
+                                theError.Append("\r\n");
+                            }
                         }
 
-                        var ssb = transformOption.screenSpaceBounds.Value;
-                        var ssbCenter = ssb.center;
-                        var x = (int)ssbCenter.x;
-                        var y = (int)ssbCenter.y;
+                        error = theError.ToString();
+                        return false;
+                    }
 
-                        bool valid;
-                        var count = excludedAreas.Count;
-                        var reScan = false;
+                    if (currentEntities.Count == 0 || uiOrEntityObject && currentTransforms.Count > 0)
+                    {
+                        possibleTransformsToClick = currentTransforms.Values.Where(a => a.screenSpaceBounds != null).ToList();
+                    }
+                    else
+                    {
+                        possibleTransformsToClick = currentEntities.Values.Where(a => a.screenSpaceBounds != null).ToList();
+                    }
+
+                    var possibleTransformsCount = possibleTransformsToClick.Count;
+                    if (possibleTransformsCount > 0)
+                    {
+                        var RESTART_LIMIT = 20;
+                        var restartCount = 0;
+                        // try up to 20 times per frame to find a valid click object, but after that, give up till the next frame as none may be available
+                        // helps prevent long searches, or cases where the user excludes the whole screen
                         do
                         {
-                            valid = true;
-                            for (var i = 0; i < count; i++)
+                            var transformOption = possibleTransformsToClick[Random.Range(0, possibleTransformsCount)];
+                            if (StateRecorderUtils.OptimizedStringStartsWithStringInList(excludedNormalizedPaths, transformOption.NormalizedPath))
                             {
-                                var excludedArea = excludedAreas[i];
-                                var xMin = excludedArea.xMin;
-                                var xMax = excludedArea.xMax;
-                                var yMin = excludedArea.yMin;
-                                var yMax = excludedArea.yMax;
-
-                                // normalize the location to the current resolution
-                                if (screenWidth != screenSize.x)
-                                {
-                                    var ratio = screenWidth / (float)screenSize.x;
-                                    xMin = (int)(xMin * ratio);
-                                    xMax = (int)(xMax * ratio);
-                                }
-
-                                if (screenHeight != screenSize.y)
-                                {
-                                    var ratio = screenHeight / (float)screenSize.y;
-                                    yMin = (int)(yMin * ratio);
-                                    yMax = (int)(yMax * ratio);
-                                }
-
-                                if (x >= xMin && x <= xMax)
-                                {
-                                    valid = false;
-                                    if (reScan)
-                                    {
-                                        // violation on reScan, abandon this object
-                                        reScan = false;
-                                        break; // for
-                                    }
-
-                                    // see if we can pick an X that is valid within our object
-                                    if (ssb.min.x < xMin)
-                                    {
-                                        // pick a new X within the box as close to the center as possible to try to still hit collider
-                                        x = xMin - 1;
-                                        // need to rescan again to make sure we didn't violate other areas if multiple overlap my object
-                                        reScan = true;
-                                    }
-                                    else if (ssb.max.x > xMax)
-                                    {
-                                        // pick a new X within the box as close to the center as possible to try to still hit collider
-                                        x = xMax + 1;
-                                        // need to rescan again to make sure we didn't violate other areas if multiple overlap my object
-                                        reScan = true;
-                                    }
-                                    else
-                                    {
-                                        break; // for
-                                    }
-                                }
-
-                                if (y >= yMin && y <= yMax)
-                                {
-                                    valid = false;
-                                    if (reScan)
-                                    {
-                                        // violation on reScan, abandon this object
-                                        reScan = false;
-                                        break; // for
-                                    }
-
-                                    // see if we can pick a Y that is valid within our object
-                                    if (ssb.min.y < yMin)
-                                    {
-                                        // pick a new Y within sthe box as close to the center as possible to try to still hit collider
-                                        y = yMin - 1;
-                                        // need to rescan again to make sure we didn't violate other areas if multiple overlap my object
-                                        reScan = true;
-                                    }
-                                    else if (ssb.max.y > yMax)
-                                    {
-                                        // pick a new Y within the box as close to the center as possible to try to still hit collider
-                                        y = yMax + 1;
-                                        // need to rescan again to make sure we didn't violate other areas if multiple overlap my object
-                                        reScan = true;
-                                    }
-                                    else
-                                    {
-                                        break; // for
-                                    }
-                                }
+                                // not allowed object .. pick another
+                                continue; // while
                             }
 
-                            // if valid on the rescan.. stop the outer loop
-                            if (valid && reScan)
-                            {
-                                reScan = false;
-                            }
-                        } while (reScan);
+                            var ssb = transformOption.screenSpaceBounds.Value;
+                            var ssbCenter = ssb.center;
+                            var x = (int)ssbCenter.x;
+                            var y = (int)ssbCenter.y;
 
-                        if (valid)
-                        {
-                            var drag = allowDrag && Random.Range(0, 2) == 0;
-                            var lb = Random.Range(0, 2) == 0;
-                            var mb = Random.Range(0, 2) == 0;
-                            var rb = Random.Range(0, 2) == 0;
-                            var fb = Random.Range(0, 2) == 0;
-                            var bb = Random.Range(0, 2) == 0;
-                            RGDebug.LogInfo($"({segmentNumber}) - Bot Segment - RandomMouseObjectClicker - {{x:{x}, y:{y}, lb:{(lb?1:0)}, mb:{(mb?1:0)}, rb:{(rb?1:0)}, fb:{(fb?1:0)}, bb:{(bb?1:0)}}} on object with NormalizedPath: {transformOption.NormalizedPath}");
-                            MouseEventSender.SendRawPositionMouseEvent(
-                                segmentNumber,
-                                new Vector2(x, y),
-                                lb,
-                                mb,
-                                rb,
-                                fb,
-                                bb,
-                                Vector2.zero // don't support random scrolling yet...
-                            );
-
-                            if (!drag)
+                            bool valid;
+                            var count = excludedAreas.Count;
+                            var reScan = false;
+                            do
                             {
-                                RGDebug.LogInfo($"({segmentNumber}) - Bot Segment - RandomMouseObjectClicker - unclick - {{x:{x}, y:{y}}}");
-                                // send the un-click event
+                                valid = true;
+                                for (var i = 0; i < count; i++)
+                                {
+                                    var excludedArea = excludedAreas[i];
+                                    var xMin = excludedArea.xMin;
+                                    var xMax = excludedArea.xMax;
+                                    var yMin = excludedArea.yMin;
+                                    var yMax = excludedArea.yMax;
+
+                                    // normalize the location to the current resolution
+                                    if (screenWidth != screenSize.x)
+                                    {
+                                        var ratio = screenWidth / (float)screenSize.x;
+                                        xMin = (int)(xMin * ratio);
+                                        xMax = (int)(xMax * ratio);
+                                    }
+
+                                    if (screenHeight != screenSize.y)
+                                    {
+                                        var ratio = screenHeight / (float)screenSize.y;
+                                        yMin = (int)(yMin * ratio);
+                                        yMax = (int)(yMax * ratio);
+                                    }
+
+                                    if (x >= xMin && x <= xMax)
+                                    {
+                                        valid = false;
+                                        if (reScan)
+                                        {
+                                            // violation on reScan, abandon this object
+                                            reScan = false;
+                                            break; // for
+                                        }
+
+                                        // see if we can pick an X that is valid within our object
+                                        if (ssb.min.x < xMin)
+                                        {
+                                            // pick a new X within the box as close to the center as possible to try to still hit collider
+                                            x = xMin - 1;
+                                            // need to rescan again to make sure we didn't violate other areas if multiple overlap my object
+                                            reScan = true;
+                                        }
+                                        else if (ssb.max.x > xMax)
+                                        {
+                                            // pick a new X within the box as close to the center as possible to try to still hit collider
+                                            x = xMax + 1;
+                                            // need to rescan again to make sure we didn't violate other areas if multiple overlap my object
+                                            reScan = true;
+                                        }
+                                        else
+                                        {
+                                            break; // for
+                                        }
+                                    }
+
+                                    if (y >= yMin && y <= yMax)
+                                    {
+                                        valid = false;
+                                        if (reScan)
+                                        {
+                                            // violation on reScan, abandon this object
+                                            reScan = false;
+                                            break; // for
+                                        }
+
+                                        // see if we can pick a Y that is valid within our object
+                                        if (ssb.min.y < yMin)
+                                        {
+                                            // pick a new Y within sthe box as close to the center as possible to try to still hit collider
+                                            y = yMin - 1;
+                                            // need to rescan again to make sure we didn't violate other areas if multiple overlap my object
+                                            reScan = true;
+                                        }
+                                        else if (ssb.max.y > yMax)
+                                        {
+                                            // pick a new Y within the box as close to the center as possible to try to still hit collider
+                                            y = yMax + 1;
+                                            // need to rescan again to make sure we didn't violate other areas if multiple overlap my object
+                                            reScan = true;
+                                        }
+                                        else
+                                        {
+                                            break; // for
+                                        }
+                                    }
+                                }
+
+                                // if valid on the rescan.. stop the outer loop
+                                if (valid && reScan)
+                                {
+                                    reScan = false;
+                                }
+                            } while (reScan);
+
+                            if (valid)
+                            {
+                                var drag = allowDrag && Random.Range(0, 2) == 0;
+                                var lb = Random.Range(0, 2) == 0;
+                                var mb = Random.Range(0, 2) == 0;
+                                var rb = Random.Range(0, 2) == 0;
+                                var fb = Random.Range(0, 2) == 0;
+                                var bb = Random.Range(0, 2) == 0;
+                                RGDebug.LogInfo($"({segmentNumber}) - Bot Segment - RandomMouseObjectClicker - {{x:{x}, y:{y}, lb:{(lb ? 1 : 0)}, mb:{(mb ? 1 : 0)}, rb:{(rb ? 1 : 0)}, fb:{(fb ? 1 : 0)}, bb:{(bb ? 1 : 0)}}} on object with NormalizedPath: {transformOption.NormalizedPath}");
                                 MouseEventSender.SendRawPositionMouseEvent(
                                     segmentNumber,
                                     new Vector2(x, y),
-                                    false,
-                                    false,
-                                    false,
-                                    false,
-                                    false,
+                                    lb,
+                                    mb,
+                                    rb,
+                                    fb,
+                                    bb,
                                     Vector2.zero // don't support random scrolling yet...
                                 );
+
+                                if (!drag)
+                                {
+                                    RGDebug.LogInfo($"({segmentNumber}) - Bot Segment - RandomMouseObjectClicker - unclick - {{x:{x}, y:{y}}}");
+                                    // send the un-click event
+                                    MouseEventSender.SendRawPositionMouseEvent(
+                                        segmentNumber,
+                                        new Vector2(x, y),
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        Vector2.zero // don't support random scrolling yet...
+                                    );
+                                }
+
+                                Replay_LastClickTime = now;
+                                error = null;
+                                return true;
                             }
 
-                            Replay_LastClickTime = now;
-                            error = null;
-                            return true;
-                        }
-
-                    } while (++restartCount < RESTART_LIMIT);
+                        } while (++restartCount < RESTART_LIMIT);
+                    }
                 }
             }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
@@ -59,7 +59,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         private bool IsStopped;
 
-        public bool? IsCompleted()
+        public bool IsCompleted()
         {
             return IsStopped;
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
@@ -66,6 +66,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         public void ReplayReset()
         {
+            IsStopped = false;
         }
 
         public void StartAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
@@ -57,9 +57,11 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
          */
         public List<string> preconditionNormalizedPaths = new();
 
+        private bool IsStopped;
+
         public bool? IsCompleted()
         {
-            return null;
+            return IsStopped;
         }
 
         public void ReplayReset()
@@ -289,6 +291,11 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
             error = null;
             return false;
+        }
+
+        public void StopAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
+        {
+            IsStopped = true;
         }
 
         private GUIStyle _guiStyle = null;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
@@ -53,6 +53,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         public void ReplayReset()
         {
+            IsStopped = false;
         }
 
         public void StartAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
@@ -41,9 +41,14 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
          */
         public List<RectInt> excludedAreas = new();
 
+
+        private GUIStyle _guiStyle = null;
+
+        private bool IsStopped;
+
         public bool? IsCompleted()
         {
-            return null;
+            return IsStopped;
         }
 
         public void ReplayReset()
@@ -130,7 +135,10 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             return false;
         }
 
-        private GUIStyle _guiStyle = null;
+        public void StopAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
+        {
+            IsStopped = true;
+        }
 
         public void OnGUI(Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
         {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
@@ -62,73 +62,77 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         public bool ProcessAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities, out string error)
         {
-            var now = Time.unscaledTime;
-            if (now - timeBetweenClicks > Replay_LastClickTime)
+            if (!IsStopped)
             {
-                var screenWidth = Screen.width;
-                var screenHeight = Screen.height;
-
-                var x = Random.Range(0, screenWidth);
-                var y = Random.Range(0, screenHeight);
-
-                var RESTART_LIMIT = 20;
-
-                var count = excludedAreas.Count;
-                var restartCount = 0;
-                // try up to 20 times per frame to find a valid click spot, but after that, give up till the next frame as none may be available
-                // helps prevent long searches, or cases where the user excludes the whole screen
-                for (var i = 0; i < count && restartCount < RESTART_LIMIT; i++)
+                var now = Time.unscaledTime;
+                if (now - timeBetweenClicks > Replay_LastClickTime)
                 {
-                    var excludedArea = excludedAreas[i];
-                    var xMin = excludedArea.xMin;
-                    var xMax = excludedArea.xMax;
-                    var yMin = excludedArea.yMin;
-                    var yMax = excludedArea.yMax;
+                    var screenWidth = Screen.width;
+                    var screenHeight = Screen.height;
 
-                    // normalize the location to the current resolution
-                    if (screenWidth != screenSize.x)
+                    var x = Random.Range(0, screenWidth);
+                    var y = Random.Range(0, screenHeight);
+
+                    var RESTART_LIMIT = 20;
+
+                    var count = excludedAreas.Count;
+                    var restartCount = 0;
+                    // try up to 20 times per frame to find a valid click spot, but after that, give up till the next frame as none may be available
+                    // helps prevent long searches, or cases where the user excludes the whole screen
+                    for (var i = 0; i < count && restartCount < RESTART_LIMIT; i++)
                     {
-                        var ratio = screenWidth / screenSize.x;
-                        xMin *= ratio;
-                        xMax *= ratio;
+                        var excludedArea = excludedAreas[i];
+                        var xMin = excludedArea.xMin;
+                        var xMax = excludedArea.xMax;
+                        var yMin = excludedArea.yMin;
+                        var yMax = excludedArea.yMax;
+
+                        // normalize the location to the current resolution
+                        if (screenWidth != screenSize.x)
+                        {
+                            var ratio = screenWidth / screenSize.x;
+                            xMin *= ratio;
+                            xMax *= ratio;
+                        }
+
+                        if (screenHeight != screenSize.y)
+                        {
+                            var ratio = screenHeight / screenSize.y;
+                            yMin *= ratio;
+                            yMax *= ratio;
+                        }
+
+                        if (x >= xMin && x <= xMax)
+                        {
+                            x = Random.Range(0, screenWidth);
+                            // restart the loop
+                            i = -1;
+                            restartCount++;
+                        }
+
+                        if (y >= yMin && y <= yMax)
+                        {
+                            y = Random.Range(0, screenHeight);
+                            // restart the loop
+                            i = -1;
+                            restartCount++;
+                        }
                     }
 
-                    if (screenHeight != screenSize.y)
+                    if (restartCount < RESTART_LIMIT)
                     {
-                        var ratio = screenHeight / screenSize.y;
-                        yMin *= ratio;
-                        yMax *= ratio;
-                    }
-
-                    if (x >= xMin && x <= xMax)
-                    {
-                        x = Random.Range(0, screenWidth);
-                        // restart the loop
-                        i = -1;
-                        restartCount++;
-                    }
-
-                    if (y >= yMin && y <= yMax)
-                    {
-                        y = Random.Range(0, screenHeight);
-                        // restart the loop
-                        i = -1;
-                        restartCount++;
+                        error = null;
+                        MouseEventSender.SendMouseEvent(segmentNumber, new MouseInputActionData()
+                        {
+                            position = new Vector2Int(x, y),
+                            leftButton = Random.Range(0, 2) == 0,
+                            middleButton = Random.Range(0, 2) == 0,
+                            rightButton = Random.Range(0, 2) == 0,
+                        }, null, null, currentTransforms, currentEntities);
+                        return true;
                     }
                 }
 
-                if (restartCount < RESTART_LIMIT)
-                {
-                    error = null;
-                    MouseEventSender.SendMouseEvent(segmentNumber, new MouseInputActionData()
-                    {
-                        position = new Vector2Int(x, y),
-                        leftButton = Random.Range(0, 2) == 0,
-                        middleButton = Random.Range(0, 2) == 0,
-                        rightButton = Random.Range(0, 2) == 0,
-                    }, null, null, currentTransforms, currentEntities);
-                    return true;
-                }
             }
 
             error = null;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
@@ -46,7 +46,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         private bool IsStopped;
 
-        public bool? IsCompleted()
+        public bool IsCompleted()
         {
             return IsStopped;
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -355,6 +355,8 @@ namespace RegressionGames.StateRecorder
                         nextBotSegment.Replay_Matched = true;
                         // log this the first time
                         RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment - Criteria Matched");
+                        // tell the action that our segment completed
+                        nextBotSegment.StopAction(transformStatuses, entityStatuses);
                         if (i == 0)
                         {
                             _lastTimeLoggedKeyFrameConditions = now;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/SdkApiVersion.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/SdkApiVersion.cs
@@ -7,8 +7,9 @@
         public const int VERSION_2 = 2; // added mouse pixel and object random clicking actions to bot segments
         public const int VERSION_3 = 3; // added ui pixel hash key frame criteria to bot segments
         public const int VERSION_4 = 4; // changed state format to enable entity support including 'type' and 'components' fields; added versioning to 'state' recording not just 'bot_segments'
+        public const int VERSION_5 = 5; // added support for monobehaviour bot segment actions
 
         // Update this when new features are used in the SDK
-        public const int CURRENT_VERSION = VERSION_4;
+        public const int CURRENT_VERSION = VERSION_5;
     }
 }


### PR DESCRIPTION
This PR introduces a monkey bot segment that can be used with the bot segments system.

The segment has type name "MonkeyBot" and takes two parameters: action interval (rate at which to perform random actions) and action settings (this is the same settings object as used by the action manager and can be used to select the actions to exclude from the monkey bot).

I've tested this with Boss Room to create a sequence that first performs an input replay through the menus and then indefinitely runs a monkey test in-game. Here is an example bot segment file with the monkey bot segment:
[10.json](https://github.com/user-attachments/files/16256200/10.json)

Note: This is dependent on [[REG-1862] Stoppable Bot Segment Actions + Monobehaviour Actions](https://github.com/Regression-Games/RGUnityBots/pull/224) and will be converted into a full PR when that is done.

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
