### PR TITLE
[REG-1861] Harden bot replay handling

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotActionJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotActionJsonConverter.cs
@@ -15,26 +15,32 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             JObject jObject = JObject.Load(reader);
-            BotAction action = new();
-            action.type = jObject["type"].ToObject<BotActionType>();
-            IBotActionData data = null;
-            switch (action.type)
+            // ensure this segment HAS an action
+            if (jObject.Count > 0)
             {
-                case BotActionType.InputPlayback:
-                    data = jObject["data"].ToObject<InputPlaybackActionData>(serializer);
-                    break;
-                case BotActionType.RandomMouse_ClickPixel:
-                    data = jObject["data"].ToObject<RandomMousePixelActionData>(serializer);
-                    break;
-                case BotActionType.RandomMouse_ClickObject:
-                    data = jObject["data"].ToObject<RandomMouseObjectActionData>(serializer);
-                    break;
-                default:
-                    throw new JsonSerializationException($"Unsupported BotAction type: '{action.type}'");
+                BotAction action = new();
+                IBotActionData data = null;
+                action.type = jObject["type"].ToObject<BotActionType>();
+                switch (action.type)
+                {
+                    case BotActionType.InputPlayback:
+                        data = jObject["data"].ToObject<InputPlaybackActionData>(serializer);
+                        break;
+                    case BotActionType.RandomMouse_ClickPixel:
+                        data = jObject["data"].ToObject<RandomMousePixelActionData>(serializer);
+                        break;
+                    case BotActionType.RandomMouse_ClickObject:
+                        data = jObject["data"].ToObject<RandomMouseObjectActionData>(serializer);
+                        break;
+                    default:
+                        throw new JsonSerializationException($"Unsupported BotAction type: '{action.type}'");
+                }
+
+                action.data = data;
+                return action;
             }
 
-            action.data = data;
-            return action;
+            return null;
         }
 
         public override bool CanWrite => false;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/KeyFrameEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/KeyFrameEvaluator.cs
@@ -152,6 +152,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                         }
                         else
                         {
+                            _newUnmatchedCriteria.Add("UIPixelHash has not changed");
                             return false;
                         }
                         break;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
@@ -76,7 +76,10 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         public void StopAction(Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
         {
-            botAction.StopAction(Replay_SegmentNumber, currentTransforms, currentEntities);
+            if (botAction != null)
+            {
+                botAction.StopAction(Replay_SegmentNumber, currentTransforms, currentEntities);
+            }
         }
 
         // Replay only

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayBotSegmentsContainer.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayBotSegmentsContainer.cs
@@ -58,6 +58,10 @@ namespace RegressionGames.StateRecorder
         {
             using var zipArchive = ZipFile.Open(zipFilePath, ZipArchiveMode.Read);
 
+            // if the zip contains only one entry that is a directory, dig into that before iterating files (helps handle OS zipped directory formats)
+
+
+
             // sort by numeric value of entries (not string comparison of filenames)
             var entries = zipArchive.Entries.Where(e => e.Name.EndsWith(".json")).OrderBy(e => int.Parse(e.Name.Substring(0, e.Name.IndexOf('.'))));
 


### PR DESCRIPTION
- Hardens a few bot replay file loading/parsing/handling cases

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
