### PR TITLE
[REG-1862] Partial Path Matching support + Sample Monobehaviour segment

### DIFF
--- a/src/gg.regression.unity.bots.ecs/Runtime/Scripts/StateRecorder/ECS/EntityObjectFinder.cs
+++ b/src/gg.regression.unity.bots.ecs/Runtime/Scripts/StateRecorder/ECS/EntityObjectFinder.cs
@@ -271,7 +271,7 @@ namespace RegressionGames.StateRecorder.ECS
                 var entities = new List<Entity>();
                 foreach (var entitySelector in _entitySelectors)
                 {
-                    entities.AddRange(entitySelector.SelectEntities(entityManager));
+                    entities.AddRange(entitySelector.SelectEntities(entityManager).Where(a => entityManager.Exists(a)));
                 }
                 return entities;
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionManager.cs
@@ -297,15 +297,7 @@ namespace RegressionGames.ActionManager
         {
             if (key != Key.None)
             {
-                KeyControl control = Keyboard.current[key];
-                KeyboardInputActionData data = new KeyboardInputActionData()
-                {
-                    action = control.name,
-                    binding = control.path,
-                    startTime = Time.unscaledTime,
-                    endTime = isPressed ? null : Time.unscaledTime
-                };
-                KeyboardEventSender.SendKeyEvent(0, data, isPressed ? KeyState.Down : KeyState.Up);
+                KeyboardEventSender.SendKeyEvent(0, key, isPressed ? KeyState.Down : KeyState.Up);
             }
         }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BehaviourActionDataJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BehaviourActionDataJsonConverter.cs
@@ -19,7 +19,7 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
             JObject jObject = JObject.Load(reader);
             // ReSharper disable once UseObjectOrCollectionInitializer - easier to debug lines without this
             BehaviourActionData data = new();
-            data.BehaviourFullName = jObject.GetValue("behaviourFullName").ToObject<string>(serializer);
+            data.behaviourFullName = jObject.GetValue("behaviourFullName").ToObject<string>(serializer);
             data.apiVersion = jObject.GetValue("apiVersion").ToObject<int>();
             return data;
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BehaviourActionDataJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BehaviourActionDataJsonConverter.cs
@@ -21,6 +21,7 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
             BehaviourActionData data = new();
             data.behaviourFullName = jObject.GetValue("behaviourFullName").ToObject<string>(serializer);
             data.apiVersion = jObject.GetValue("apiVersion").ToObject<int>();
+            data.maxRuntimeSeconds = jObject.GetValue("maxRuntimeSeconds").ToObject<float>(serializer);
             return data;
         }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotActionJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotActionJsonConverter.cs
@@ -32,13 +32,15 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
                     case BotActionType.RandomMouse_ClickObject:
                         data = jObject["data"].ToObject<RandomMouseObjectActionData>(serializer);
                         break;
+                    case BotActionType.Behaviour:
+                        data = jObject["data"].ToObject<BehaviourActionData>(serializer);
+                        break;
                     case BotActionType.MonkeyBot:
                         data = jObject["data"].ToObject<MonkeyBotActionData>(serializer);
                         break;
                     default:
                         throw new JsonSerializationException($"Unsupported BotAction type: '{action.type}'");
                 }
-
                 action.data = data;
                 return action;
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/KeyFrameCriteriaJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/KeyFrameCriteriaJsonConverter.cs
@@ -17,11 +17,13 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
             JObject jObject = JObject.Load(reader);
             KeyFrameCriteria criteria = new();
             criteria.transient = jObject["transient"].ToObject<bool>();
+            criteria.apiVersion = jObject["apiVersion"].ToObject<int>();
             criteria.type = jObject["type"].ToObject<KeyFrameCriteriaType>();
             IKeyFrameCriteriaData data = null;
             switch (criteria.type)
             {
                 case KeyFrameCriteriaType.NormalizedPath:
+                case KeyFrameCriteriaType.PartialNormalizedPath:
                     data = jObject["data"].ToObject<PathKeyFrameCriteriaData>(serializer);
                     break;
                 case KeyFrameCriteriaType.UIPixelHash:

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/KeyFrameEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/KeyFrameEvaluator.cs
@@ -96,26 +96,39 @@ namespace RegressionGames.StateRecorder.BotSegments
             return matched;
         }
 
+        private static readonly List<Dictionary<long, PathBasedDeltaCount>> _deltaCounts = new ();
+        private static int _lastFrameEvaluated = -1;
+
+
         /**
          * <summary>Only to be called internally by KeyFrameEvaluator. firstSegment represents if this is the first segment in the current pass's list of segments to evaluate</summary>
          */
         internal bool MatchedHelper(bool firstSegment, int segmentNumber, BooleanCriteria andOr, List<KeyFrameCriteria> criteriaList)
         {
             var objectFinders = Object.FindObjectsByType<ObjectFinder>(FindObjectsSortMode.None);
-            var transformsStatus = new Dictionary<long, ObjectStatus>();
-            var entitiesStatus = new Dictionary<long, ObjectStatus>();
-            foreach (var objectFinder in objectFinders)
+            var currentFrameCount = Time.frameCount;
+            if (_lastFrameEvaluated != currentFrameCount)
             {
-                if (objectFinder is TransformObjectFinder)
+                _lastFrameEvaluated = currentFrameCount;
+                _deltaCounts.Clear();
+                foreach (var objectFinder in objectFinders)
                 {
-                    transformsStatus = objectFinder.GetObjectStatusForCurrentFrame().Item2;
-                }
-                else
-                {
-                    entitiesStatus = objectFinder.GetObjectStatusForCurrentFrame().Item2;
+                    if (objectFinder is TransformObjectFinder)
+                    {
+                        var transformsStatus = objectFinder.GetObjectStatusForCurrentFrame().Item2;
+                        var hashes = objectFinder.ComputeNormalizedPathBasedDeltaCounts(_priorKeyFrameTransformStatus, transformsStatus, out _);
+                        _deltaCounts.Add(hashes);
+                    }
+                    else
+                    {
+                        var entitiesStatus = objectFinder.GetObjectStatusForCurrentFrame().Item2;
+                        var hashes = objectFinder.ComputeNormalizedPathBasedDeltaCounts(_priorKeyFrameEntityStatus, entitiesStatus, out _);
+                        _deltaCounts.Add(hashes);
+                    }
                 }
             }
 
+            var partialNormalizedPathsToMatch = new List<KeyFrameCriteria>();
             var normalizedPathsToMatch = new List<KeyFrameCriteria>();
             var orsToMatch = new List<KeyFrameCriteria>();
             var andsToMatch = new List<KeyFrameCriteria>();
@@ -144,6 +157,9 @@ namespace RegressionGames.StateRecorder.BotSegments
                     case KeyFrameCriteriaType.NormalizedPath:
                         normalizedPathsToMatch.Add(entry);
                         break;
+                    case KeyFrameCriteriaType.PartialNormalizedPath:
+                        partialNormalizedPathsToMatch.Add(entry);
+                        break;
                     case KeyFrameCriteriaType.UIPixelHash:
                         // only check the pixel hash change on the first segment being evaluated so we don't pre-emptively pass on future segments that should return false until they are first in the list
                         if (firstSegment && (entry.Replay_TransientMatched || GameFacePixelHashObserver.GetInstance().HasPixelHashChanged()))
@@ -160,9 +176,37 @@ namespace RegressionGames.StateRecorder.BotSegments
             }
 
             // process each list.. start with the ones for this tier
+
+            // we do this before the partial as this one is far more efficient computationally..
             if (normalizedPathsToMatch.Count > 0)
             {
-                var pathResults = NormalizedPathCriteriaEvaluator.Matched(segmentNumber, normalizedPathsToMatch, _priorKeyFrameTransformStatus, _priorKeyFrameEntityStatus, transformsStatus, entitiesStatus);
+                var pathResults = NormalizedPathCriteriaEvaluator.Matched(segmentNumber, normalizedPathsToMatch, _deltaCounts);
+                var pathResultsCount = pathResults.Count;
+                for (var j = 0; j < pathResultsCount; j++)
+                {
+                    var pathEntry = pathResults[j];
+                    if (pathEntry == null)
+                    {
+                        if (andOr == BooleanCriteria.Or)
+                        {
+                            return true;
+                        }
+                    }
+                    else
+                    {
+                        if (andOr == BooleanCriteria.And)
+                        {
+                            _newUnmatchedCriteria.Add(pathEntry);
+                            return false;
+                        }
+                    }
+                }
+            }
+
+            // process each list.. start with the ones for this tier
+            if (partialNormalizedPathsToMatch.Count > 0)
+            {
+                var pathResults = PartialNormalizedPathCriteriaEvaluator.Matched(segmentNumber, partialNormalizedPathsToMatch, _deltaCounts);
                 var pathResultsCount = pathResults.Count;
                 for (var j = 0; j < pathResultsCount; j++)
                 {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
@@ -60,7 +60,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                 {
                     // send start event
                     result = true;
-                    KeyboardEventSender.SendKeyEvent(segmentNumber, replayKeyboardInputEntry, KeyState.Down);
+                    KeyboardEventSender.SendKeyEvent(segmentNumber, replayKeyboardInputEntry.Key, KeyState.Down);
                     replayKeyboardInputEntry.Replay_StartEndSentFlags[0] = true;
                 }
 
@@ -68,7 +68,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                 {
                     // send end event
                     result = true;
-                    KeyboardEventSender.SendKeyEvent(segmentNumber, replayKeyboardInputEntry, KeyState.Up);
+                    KeyboardEventSender.SendKeyEvent(segmentNumber, replayKeyboardInputEntry.Key, KeyState.Up);
                     replayKeyboardInputEntry.Replay_StartEndSentFlags[1] = true;
                 }
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/KeyFrameCriteria.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/KeyFrameCriteria.cs
@@ -11,7 +11,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
     public class KeyFrameCriteria
     {
         // api version of this top level schema, update if we add/change fields
-        public int apiVersion = SdkApiVersion.VERSION_1;
+        public int apiVersion = SdkApiVersion.VERSION_7;
 
         public KeyFrameCriteriaType type;
         public bool transient;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/KeyFrameCriteriaType.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/KeyFrameCriteriaType.cs
@@ -6,6 +6,7 @@
         And,
         UIPixelHash,
         NormalizedPath,
+        PartialNormalizedPath,
 
         //FUTURE
         //Path,

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/PartialNormalizedPathCriteriaEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/PartialNormalizedPathCriteriaEvaluator.cs
@@ -1,16 +1,15 @@
 ﻿using System.Collections.Generic;
 using RegressionGames.StateRecorder.BotSegments.Models;
 using RegressionGames.StateRecorder.Models;
+using UnityEngine;
 
 namespace RegressionGames.StateRecorder.BotSegments
 {
-    public static class NormalizedPathCriteriaEvaluator
+    public static class PartialNormalizedPathCriteriaEvaluator
     {
-
         // Track counts from the last keyframe completion and use that as the 'prior' data
         public static List<string> Matched(int segmentNumber, List<KeyFrameCriteria> criteriaList, List<Dictionary<long, PathBasedDeltaCount>> deltaCounts)
         {
-
             var resultList = new List<string>();
             foreach (var criteria in criteriaList)
             {
@@ -18,15 +17,22 @@ namespace RegressionGames.StateRecorder.BotSegments
                 if (!(criteria.transient && criteria.Replay_TransientMatched))
                 {
                     var criteriaPathData = criteria.data as PathKeyFrameCriteriaData;
-                    var normalizedPath = criteriaPathData.path;
-                    var pathHash = normalizedPath.GetHashCode();
+                    var partialNormalizedPath = criteriaPathData.path;
                     // see if it is in the transforms path
                     var deltasListCount = deltaCounts.Count;
                     PathBasedDeltaCount objectCounts = null;
                     for (var i = 0; objectCounts == null && i < deltasListCount; i++)
                     {
                         var deltas = deltaCounts[i];
-                        deltas.TryGetValue(pathHash, out objectCounts);
+                        // Partial matching performs awful, we may need to think whether the criteria list will be smaller or the paths will be smaller to organize these loops in the least poorly performing way
+                        foreach (var pathBasedDeltaCount in deltas)
+                        {
+                            if (pathBasedDeltaCount.Value.path.Contains(partialNormalizedPath))
+                            {
+                                objectCounts = pathBasedDeltaCount.Value;
+                                break;
+                            }
+                        }
                     }
                     if (objectCounts != null)
                     {
@@ -36,25 +42,25 @@ namespace RegressionGames.StateRecorder.BotSegments
                             case CountRule.Zero:
                                 if (objectCounts.count != 0)
                                 {
-                                    matched = $"NormalizedPath (UI) - {normalizedPath} - CountRule.Zero - actual: {objectCounts.count}";
+                                    matched = $"PartialNormalizedPath (UI) - {partialNormalizedPath} - CountRule.Zero - actual: {objectCounts.count}";
                                 }
                                 break;
                             case CountRule.NonZero:
                                 if (objectCounts.count <= 0)
                                 {
-                                    matched = $"NormalizedPath (UI) - {normalizedPath} - CountRule.NonZero - actual: {objectCounts.count}";
+                                    matched = $"PartialNormalizedPath (UI) - {partialNormalizedPath} - CountRule.NonZero - actual: {objectCounts.count}";
                                 }
                                 break;
                             case CountRule.GreaterThanEqual:
                                 if (objectCounts.count < criteriaPathData.count)
                                 {
-                                    matched = $"NormalizedPath (UI) - {normalizedPath} - CountRule.GreaterThanEqual - actual: {objectCounts.count} , expected: {criteriaPathData.count}";
+                                    matched = $"PartialNormalizedPath (UI) - {partialNormalizedPath} - CountRule.GreaterThanEqual - actual: {objectCounts.count} , expected: {criteriaPathData.count}";
                                 }
                                 break;
                             case CountRule.LessThanEqual:
                                 if (objectCounts.count > criteriaPathData.count)
                                 {
-                                    matched = $"NormalizedPath (UI) - {normalizedPath} - CountRule.LessThanEqual - actual: {objectCounts.count} , expected: {criteriaPathData.count}";
+                                    matched = $"PartialNormalizedPath (UI) - {partialNormalizedPath} - CountRule.LessThanEqual - actual: {objectCounts.count} , expected: {criteriaPathData.count}";
                                 }
                                 break;
                         }
@@ -62,18 +68,18 @@ namespace RegressionGames.StateRecorder.BotSegments
                         // then evaluate added / removed data
                         if (matched == null && objectCounts.addedCount < criteriaPathData.addedCount)
                         {
-                            matched = $"NormalizedPath (UI) - {normalizedPath} - addedCount - actual: {objectCounts.addedCount} , expected: {criteriaPathData.addedCount}";
+                            matched = $"PartialNormalizedPath (UI) - {partialNormalizedPath} - addedCount - actual: {objectCounts.addedCount} , expected: {criteriaPathData.addedCount}";
                         }
 
                         if (matched == null && objectCounts.removedCount < criteriaPathData.removedCount)
                         {
-                            matched = $"NormalizedPath (UI) - {normalizedPath} - removedCount - actual: {objectCounts.removedCount} , expected: {criteriaPathData.removedCount}";
+                            matched = $"PartialNormalizedPath (UI) - {partialNormalizedPath} - removedCount - actual: {objectCounts.removedCount} , expected: {criteriaPathData.removedCount}";
                         }
                     }
                     else
                     {
                         // else - criteria not met - false
-                        matched = $"NormalizedPath (WorldSpace) - {normalizedPath} - missing object";
+                        matched = $"PartialNormalizedPath (WorldSpace) - {partialNormalizedPath} - missing object";
                     }
 
                 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/PartialNormalizedPathCriteriaEvaluator.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/PartialNormalizedPathCriteriaEvaluator.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 27e9342647c74380bb47af515881e246
+timeCreated: 1721323581

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Samples.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Samples.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a155e409f5f643bfb89201206e300722
+timeCreated: 1721319556

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Samples/SimpleRandomMovementBehaviour.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Samples/SimpleRandomMovementBehaviour.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using RegressionGames.StateRecorder.Models;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -15,12 +16,12 @@ namespace RegressionGames.StateRecorder.BotSegments.Samples
         private const float ActionTimeSprint = 3f;
         private const float ActionTimeNone = 1f;
 
-        private const float MoveTimeMax = 9f;
-        private const float MoveTimeMin = 3f;
+        private const float MoveTimeMax = 15f;
+        private const float MoveTimeMin = 5f;
 
         private float _moveTimeLimit = MoveTimeMin;
 
-        private const float StuckTime = MoveTimeMin;
+        private const float StuckTime = 2f;
 
         private float _actionTime;
 
@@ -41,6 +42,8 @@ namespace RegressionGames.StateRecorder.BotSegments.Samples
         {
             var time = Time.unscaledTime;
 
+            List<(Key, KeyState)> keyStates = new();
+
             // check every StuckTime interval to see if we've gotten stuck or died
             if (time - _lastPositionTime > StuckTime)
             {
@@ -54,19 +57,19 @@ namespace RegressionGames.StateRecorder.BotSegments.Samples
                         RGDebug.LogInfo("RandomMovement - Dead - Respawning");
                         if (_currentDirectionMain.HasValue)
                         {
-                            KeyboardEventSender.SendKeyEvent(0, _currentDirectionMain.Value, KeyState.Up);
+                            keyStates.Add((_currentDirectionMain.Value, KeyState.Up));
                         }
 
                         if (_currentDirectionSecondary.HasValue)
                         {
-                            KeyboardEventSender.SendKeyEvent(0, _currentDirectionSecondary.Value, KeyState.Up);
+                            keyStates.Add((_currentDirectionSecondary.Value, KeyState.Up));
                         }
 
                         var keysToSend = new[] { Key.Enter, Key.Slash, Key.R, Key.E, Key.L, Key.I, Key.F, Key.E, Key.Enter, Key.Escape };
                         foreach (var key in keysToSend)
                         {
-                            KeyboardEventSender.SendKeyEvent(0, key, KeyState.Down);
-                            KeyboardEventSender.SendKeyEvent(0, key, KeyState.Up);
+                            keyStates.Add((key, KeyState.Down));
+                            keyStates.Add((key, KeyState.Up));
                         }
 
                         _currentDirectionMain = null;
@@ -104,11 +107,11 @@ namespace RegressionGames.StateRecorder.BotSegments.Samples
 
                 if (_currentDirectionMain.HasValue)
                 {
-                    KeyboardEventSender.SendKeyEvent(0, _currentDirectionMain.Value, KeyState.Up);
+                    keyStates.Add((_currentDirectionMain.Value, KeyState.Up));
                 }
                 if (_currentDirectionSecondary.HasValue)
                 {
-                    KeyboardEventSender.SendKeyEvent(0, _currentDirectionSecondary.Value, KeyState.Up);
+                    keyStates.Add((_currentDirectionSecondary.Value, KeyState.Up));
                 }
 
                 var previousMainDirection = _currentDirectionMain;
@@ -191,12 +194,12 @@ namespace RegressionGames.StateRecorder.BotSegments.Samples
                 }
 
                 RGDebug.LogInfo("RandomMovement - Primary Movement Key - " + _currentDirectionMain.Value.ToString());
-                KeyboardEventSender.SendKeyEvent(0, _currentDirectionMain.Value, KeyState.Down);
+                keyStates.Add((_currentDirectionMain.Value, KeyState.Down));
 
                 if (_currentDirectionSecondary.HasValue)
                 {
                     RGDebug.LogInfo("RandomMovement - Secondary Movement Key - " + _currentDirectionSecondary.Value.ToString());
-                    KeyboardEventSender.SendKeyEvent(0, _currentDirectionSecondary.Value, KeyState.Down);
+                    keyStates.Add((_currentDirectionSecondary.Value, KeyState.Down));
                 }
                 else
                 {
@@ -210,7 +213,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Samples
                 var action = Random.Range(0, 7);
                 if (_lastActionKey.HasValue)
                 {
-                    KeyboardEventSender.SendKeyEvent(0, _lastActionKey.Value, KeyState.Up);
+                    keyStates.Add((_lastActionKey.Value, KeyState.Up));
                 }
 
                 var resumeMoving = false;
@@ -257,12 +260,12 @@ namespace RegressionGames.StateRecorder.BotSegments.Samples
                         if (_currentDirectionMain.HasValue)
                         {
                             resumeMoving = true;
-                            KeyboardEventSender.SendKeyEvent(0, _currentDirectionMain.Value, KeyState.Up);
+                            keyStates.Add((_currentDirectionMain.Value, KeyState.Up));
                         }
                         if (_currentDirectionSecondary.HasValue)
                         {
                             resumeMoving = true;
-                            KeyboardEventSender.SendKeyEvent(0, _currentDirectionSecondary.Value, KeyState.Up);
+                            keyStates.Add((_currentDirectionSecondary.Value, KeyState.Up));
                         }
                         break;
                 }
@@ -270,41 +273,53 @@ namespace RegressionGames.StateRecorder.BotSegments.Samples
                 if (_lastActionKey.HasValue)
                 {
                     RGDebug.LogInfo("RandomMovement - Action Key - " + _lastActionKey.Value.ToString());
-                    KeyboardEventSender.SendKeyEvent(0, _lastActionKey.Value, KeyState.Down);
+                    keyStates.Add((_lastActionKey.Value, KeyState.Down));
                 }
 
                 if (resumeMoving)
                 {
                     if (_currentDirectionMain.HasValue)
                     {
-                        KeyboardEventSender.SendKeyEvent(0, _currentDirectionMain.Value, KeyState.Down);
+                        keyStates.Add((_currentDirectionMain.Value, KeyState.Down));
                     }
                     if ( _currentDirectionSecondary.HasValue)
                     {
-                        KeyboardEventSender.SendKeyEvent(0, _currentDirectionSecondary.Value, KeyState.Down);
+                        keyStates.Add((_currentDirectionSecondary.Value, KeyState.Down));
                     }
                 }
 
                 lastActionTime = time;
             }
 
+            if (keyStates.Count > 0)
+            {
+                KeyboardEventSender.SendKeysInOneEvent(0, keyStates);
+            }
+
         }
 
         private void OnDestroy()
         {
+            List<(Key, KeyState)> keyStates = new();
+
             if (_currentDirectionMain.HasValue)
             {
-                KeyboardEventSender.SendKeyEvent(0, _currentDirectionMain.Value, KeyState.Up);
+                keyStates.Add((_currentDirectionMain.Value, KeyState.Up));
             }
 
             if (_currentDirectionSecondary.HasValue)
             {
-                KeyboardEventSender.SendKeyEvent(0, _currentDirectionSecondary.Value, KeyState.Up);
+                keyStates.Add((_currentDirectionSecondary.Value, KeyState.Up));
             }
 
             if (_lastActionKey.HasValue)
             {
-                KeyboardEventSender.SendKeyEvent(0, _lastActionKey.Value, KeyState.Up);
+                keyStates.Add((_lastActionKey.Value, KeyState.Up));
+            }
+
+            if (keyStates.Count > 0)
+            {
+                KeyboardEventSender.SendKeysInOneEvent(0, keyStates);
             }
         }
     }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Samples/SimpleRandomMovementBehaviour.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Samples/SimpleRandomMovementBehaviour.cs
@@ -1,0 +1,311 @@
+using RegressionGames.StateRecorder.Models;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using Object = UnityEngine.Object;
+using Random = UnityEngine.Random;
+
+namespace RegressionGames.StateRecorder.BotSegments.Samples
+{
+    public class SimpleRandomMovementBehaviour : MonoBehaviour
+    {
+        private const float ActionTimeRoll = 0f;
+        private const float ActionTimeCrouch = 0f;
+        private const float ActionTimeJump = 0.3f;
+        private const float ActionTimeFly = 5f;
+        private const float ActionTimeSprint = 3f;
+        private const float ActionTimeNone = 1f;
+
+        private const float MoveTimeMax = 9f;
+        private const float MoveTimeMin = 3f;
+
+        private float _moveTimeLimit = MoveTimeMin;
+
+        private const float StuckTime = MoveTimeMin;
+
+        private float _actionTime;
+
+        private Key? _lastActionKey;
+
+        public float lastMoveTime = float.MinValue;
+
+        public float lastActionTime = float.MinValue;
+
+        private Key? _currentDirectionMain;
+        private Key? _currentDirectionSecondary;
+
+        private Vector3 _lastPlayerPosition = Vector3.zero;
+
+        private float _lastPositionTime = float.MinValue;
+
+        private void Update()
+        {
+            var time = Time.unscaledTime;
+
+            // check every StuckTime interval to see if we've gotten stuck or died
+            if (time - _lastPositionTime > StuckTime)
+            {
+                _lastPositionTime = time;
+                var transforms = Object.FindObjectsByType<Transform>(FindObjectsSortMode.None);
+                foreach (var transform1 in transforms)
+                {
+                    // check if we're 'dead' (normally from fall damage)
+                    if (transform1.gameObject.name.Contains("DeadBodyMarker"))
+                    {
+                        RGDebug.LogInfo("RandomMovement - Dead - Respawning");
+                        if (_currentDirectionMain.HasValue)
+                        {
+                            KeyboardEventSender.SendKeyEvent(0, _currentDirectionMain.Value, KeyState.Up);
+                        }
+
+                        if (_currentDirectionSecondary.HasValue)
+                        {
+                            KeyboardEventSender.SendKeyEvent(0, _currentDirectionSecondary.Value, KeyState.Up);
+                        }
+
+                        var keysToSend = new[] { Key.Enter, Key.Slash, Key.R, Key.E, Key.L, Key.I, Key.F, Key.E, Key.Enter, Key.Escape };
+                        foreach (var key in keysToSend)
+                        {
+                            KeyboardEventSender.SendKeyEvent(0, key, KeyState.Down);
+                            KeyboardEventSender.SendKeyEvent(0, key, KeyState.Up);
+                        }
+
+                        _currentDirectionMain = null;
+                        _currentDirectionSecondary = null;
+                        lastMoveTime = float.MinValue;
+                        return;
+                    }
+
+                    // check if we're stuck
+                    if (transform1.gameObject.name.Contains("LocalPlayer"))
+                    {
+                        var pos = transform1.position;
+                        if (Vector3.Distance(pos, _lastPlayerPosition) < 1f)
+                        {
+                            RGDebug.LogInfo("RandomMovement - Stuck !!!!!!!!!!!!!!!!");
+                            // stuck.. need new movements
+                            lastMoveTime = float.MinValue;
+                        }
+                        _lastPlayerPosition = pos;
+                        break;
+                    }
+                }
+            }
+
+            // pick a primary direction and move that way with keyboard for some seconds
+            // every some other seconds, pick a new secondary direction or null
+            // every second pick an action of roll, crouch, sprint, jump, fly, or none
+
+            // primary movement
+            if (time-lastMoveTime > _moveTimeLimit)
+            {
+                lastMoveTime = time;
+
+                _moveTimeLimit = Random.Range(MoveTimeMin, MoveTimeMax);
+
+                if (_currentDirectionMain.HasValue)
+                {
+                    KeyboardEventSender.SendKeyEvent(0, _currentDirectionMain.Value, KeyState.Up);
+                }
+                if (_currentDirectionSecondary.HasValue)
+                {
+                    KeyboardEventSender.SendKeyEvent(0, _currentDirectionSecondary.Value, KeyState.Up);
+                }
+
+                var previousMainDirection = _currentDirectionMain;
+                var previousSecondaryDirection = _currentDirectionSecondary;
+
+                while (previousMainDirection == _currentDirectionMain || previousSecondaryDirection == _currentDirectionMain)
+                {
+                    var direction = Random.Range(0, 4);
+                    switch (direction)
+                    {
+                        //W
+                        default:
+                        case 0:
+                            _currentDirectionMain = Key.W;
+                            break;
+                        //S
+                        case 1:
+                            _currentDirectionMain = Key.S;
+                            break;
+                        //A
+                        case 2:
+                            _currentDirectionMain = Key.A;
+                            break;
+                        //D
+                        case 3:
+                            _currentDirectionMain = Key.D;
+                            break;
+                    }
+                }
+
+
+                while (previousMainDirection == _currentDirectionSecondary || previousSecondaryDirection == _currentDirectionSecondary)
+                {
+                    // more chance of no secondary movement
+                    var secondaryDirection = Random.Range(0, 6);
+                    switch (secondaryDirection)
+                    {
+                        //W
+                        case 0:
+                            if (_currentDirectionMain != Key.S)
+                            {
+                                _currentDirectionSecondary = Key.W;
+                            }
+
+                            break;
+                        //S
+                        case 1:
+                            if (_currentDirectionMain != Key.W)
+                            {
+                                _currentDirectionSecondary = Key.S;
+                            }
+
+                            break;
+                        //A
+                        case 2:
+                            if (_currentDirectionMain != Key.D)
+                            {
+                                _currentDirectionSecondary = Key.A;
+                            }
+
+                            break;
+                        //D
+                        case 3:
+                            if (_currentDirectionMain != Key.A)
+                            {
+                                _currentDirectionSecondary = Key.D;
+                            }
+
+                            break;
+                        //none
+                        default:
+                            _currentDirectionSecondary = null;
+                            break;
+                    }
+
+                    if (_currentDirectionSecondary == _currentDirectionMain)
+                    {
+                        _currentDirectionSecondary = null;
+                    }
+                }
+
+                RGDebug.LogInfo("RandomMovement - Primary Movement Key - " + _currentDirectionMain.Value.ToString());
+                KeyboardEventSender.SendKeyEvent(0, _currentDirectionMain.Value, KeyState.Down);
+
+                if (_currentDirectionSecondary.HasValue)
+                {
+                    RGDebug.LogInfo("RandomMovement - Secondary Movement Key - " + _currentDirectionSecondary.Value.ToString());
+                    KeyboardEventSender.SendKeyEvent(0, _currentDirectionSecondary.Value, KeyState.Down);
+                }
+                else
+                {
+                    RGDebug.LogInfo("RandomMovement - Secondary Movement Key - NONE");
+                }
+            }
+
+            // action
+            if (time - lastActionTime > _actionTime)
+            {
+                var action = Random.Range(0, 7);
+                if (_lastActionKey.HasValue)
+                {
+                    KeyboardEventSender.SendKeyEvent(0, _lastActionKey.Value, KeyState.Up);
+                }
+
+                var resumeMoving = false;
+                switch (action)
+                {
+                    //roll
+                    case 0:
+                        RGDebug.LogInfo("RandomMovement - Action - Roll");
+                        _lastActionKey = Key.LeftCtrl;
+                        _actionTime = ActionTimeRoll;
+                        break;
+                    //sprint
+                    case 1:
+                        RGDebug.LogInfo("RandomMovement - Action - Sprint");
+                        _lastActionKey = Key.LeftShift;
+                        _actionTime = ActionTimeSprint;
+                        break;
+                    //jump (has 2x the probability of any other action)
+                    case 2:
+                    case 6:
+                        RGDebug.LogInfo("RandomMovement - Action - Jump");
+                        _lastActionKey = Key.Space;
+                        _actionTime = ActionTimeJump;
+                        break;
+                    //fly
+                    case 3:
+                        RGDebug.LogInfo("RandomMovement - Action - Fly");
+                        _lastActionKey = Key.Space;
+                        _actionTime = ActionTimeFly;
+                        break;
+                    // no action
+                    case 4:
+                    default:
+                        RGDebug.LogInfo("RandomMovement - Action - NONE");
+                        _lastActionKey = null;
+                        _actionTime = ActionTimeNone;
+                        break;
+                    // crouch
+                    case 5:
+                        RGDebug.LogInfo("RandomMovement - Action - Crouch");
+                        _lastActionKey = Key.LeftCtrl;
+                        _actionTime = ActionTimeCrouch;
+                        // stop moving long enough to crouch
+                        if (_currentDirectionMain.HasValue)
+                        {
+                            resumeMoving = true;
+                            KeyboardEventSender.SendKeyEvent(0, _currentDirectionMain.Value, KeyState.Up);
+                        }
+                        if (_currentDirectionSecondary.HasValue)
+                        {
+                            resumeMoving = true;
+                            KeyboardEventSender.SendKeyEvent(0, _currentDirectionSecondary.Value, KeyState.Up);
+                        }
+                        break;
+                }
+
+                if (_lastActionKey.HasValue)
+                {
+                    RGDebug.LogInfo("RandomMovement - Action Key - " + _lastActionKey.Value.ToString());
+                    KeyboardEventSender.SendKeyEvent(0, _lastActionKey.Value, KeyState.Down);
+                }
+
+                if (resumeMoving)
+                {
+                    if (_currentDirectionMain.HasValue)
+                    {
+                        KeyboardEventSender.SendKeyEvent(0, _currentDirectionMain.Value, KeyState.Down);
+                    }
+                    if ( _currentDirectionSecondary.HasValue)
+                    {
+                        KeyboardEventSender.SendKeyEvent(0, _currentDirectionSecondary.Value, KeyState.Down);
+                    }
+                }
+
+                lastActionTime = time;
+            }
+
+        }
+
+        private void OnDestroy()
+        {
+            if (_currentDirectionMain.HasValue)
+            {
+                KeyboardEventSender.SendKeyEvent(0, _currentDirectionMain.Value, KeyState.Up);
+            }
+
+            if (_currentDirectionSecondary.HasValue)
+            {
+                KeyboardEventSender.SendKeyEvent(0, _currentDirectionSecondary.Value, KeyState.Up);
+            }
+
+            if (_lastActionKey.HasValue)
+            {
+                KeyboardEventSender.SendKeyEvent(0, _lastActionKey.Value, KeyState.Up);
+            }
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Samples/SimpleRandomMovementBehaviour.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Samples/SimpleRandomMovementBehaviour.cs
@@ -16,8 +16,8 @@ namespace RegressionGames.StateRecorder.BotSegments.Samples
         private const float ActionTimeSprint = 3f;
         private const float ActionTimeNone = 1f;
 
-        private const float MoveTimeMax = 15f;
-        private const float MoveTimeMin = 5f;
+        private const float MoveTimeMax = 20f;
+        private const float MoveTimeMin = 4f;
 
         private float _moveTimeLimit = MoveTimeMin;
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Samples/SimpleRandomMovementBehaviour.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Samples/SimpleRandomMovementBehaviour.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 41b7f79053b54dde8138af3819c8edba
+timeCreated: 1721308948

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardEventSender.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardEventSender.cs
@@ -16,9 +16,8 @@ namespace RegressionGames.StateRecorder
             _isShiftDown = false;
         }
 
-        public static void SendKeyEvent(int replaySegment, KeyboardInputActionData keyboardData, KeyState upOrDown)
+        public static void SendKeyEvent(int replaySegment, Key key, KeyState upOrDown)
         {
-            var key = keyboardData.Key;
             #if ENABLE_LEGACY_INPUT_MANAGER
             SendKeyEventLegacy(key, upOrDown);
             #endif
@@ -42,7 +41,7 @@ namespace RegressionGames.StateRecorder
 
                 if (inputControl != null)
                 {
-                    RGDebug.LogInfo($"({replaySegment}) Sending Key Event: [{keyboardData.Replay_StartTime}] [{keyboardData.Replay_EndTime}] - {key} - {upOrDown}");
+                    RGDebug.LogInfo($"({replaySegment}) Sending Key Event: {key} - {upOrDown}");
 
                     // queue input event
                     inputControl.WriteValueIntoEvent(upOrDown == KeyState.Down ? 1f : 0f, eventPtr);

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardEventSender.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardEventSender.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using RegressionGames.RGLegacyInputUtility;
 using RegressionGames.StateRecorder.Models;
 using UnityEngine.InputSystem;
@@ -14,6 +16,92 @@ namespace RegressionGames.StateRecorder
         public static void Reset()
         {
             _isShiftDown = false;
+        }
+
+        /**
+         * Allows updating multiple keys in the same event.  This will break up into multiple events if the same key is passed more than once
+         * or if the shift key is pressed
+         */
+        public static void SendKeysInOneEvent(int replaySegment, List<(Key, KeyState)> keyStates)
+        {
+            var time = InputState.currentTime;
+            var keyboard = Keyboard.current;
+
+            var keys = new HashSet<Key>();
+            InputEventPtr? deltaStateEvent = null;
+
+            List<(Key, KeyState)> logList = new();
+
+            foreach (var valueTuple in keyStates)
+            {
+                var key = valueTuple.Item1;
+                var upOrDown = valueTuple.Item2;
+
+                if (deltaStateEvent.HasValue)
+                {
+                    if (key == Key.LeftShift || key == Key.RightShift)
+                    {
+                        // start a new event
+                        _isShiftDown = upOrDown == KeyState.Down;
+                        RGDebug.LogInfo($"({replaySegment}) Sending Multiple Key Event: [" + string.Join(", ", logList.Select(a => a.Item1 + ":" + a.Item2).ToArray()) + "]");
+                        logList.Clear();
+                        InputSystem.QueueEvent(deltaStateEvent.Value);
+                        deltaStateEvent = null;
+                    }
+                    else
+                    {
+                        if (keys.Contains(key))
+                        {
+                            RGDebug.LogInfo($"({replaySegment}) Sending Multiple Key Event: [" + string.Join(", ", logList.Select(a => a.Item1 + ":" + a.Item2).ToArray()) + "]");
+                            logList.Clear();
+                            InputSystem.QueueEvent(deltaStateEvent.Value);
+                            deltaStateEvent = null;
+                            keys.Clear();
+                        }
+                    }
+                }
+                if (!deltaStateEvent.HasValue)
+                {
+                    DeltaStateEvent.From(keyboard, out var newEvent);
+                    deltaStateEvent = newEvent;
+                }
+
+                logList.Add(valueTuple);
+                keys.Add(key);
+                var inputControl = keyboard.allControls
+                    .FirstOrDefault(a => a is KeyControl kc && kc.keyCode == key) ?? keyboard.anyKey;
+                if (inputControl != null)
+                {
+                    inputControl.WriteValueIntoEvent(upOrDown == KeyState.Down ? 1f : 0f, deltaStateEvent.Value);
+
+                    if (upOrDown == KeyState.Down)
+                    {
+                        // send a text event so that 'onChange' text events fire
+                        // convert key to text
+                        if (KeyboardInputActionObserver.KeyboardKeyToValueMap.TryGetValue(((KeyControl)inputControl).keyCode, out var possibleValues))
+                        {
+                            var value = _isShiftDown ? possibleValues.Item2 : possibleValues.Item1;
+                            if (value == 0x00)
+                            {
+                                RGDebug.LogError($"Found null value for keyboard input {key}");
+                                return;
+                            }
+
+                            var inputEvent = TextEvent.Create(Keyboard.current.deviceId, value, time);
+                            RGDebug.LogInfo($"({replaySegment}) Sending Text Event for char: '{value}'");
+                            InputSystem.QueueEvent(ref inputEvent);
+                        }
+                    }
+                }
+
+            }
+
+            if (deltaStateEvent.HasValue)
+            {
+                RGDebug.LogInfo($"({replaySegment}) Sending Multiple Key Event: [" + string.Join(", ", logList.Select(a => a.Item1 + ":" + a.Item2).ToArray()) + "]");
+                InputSystem.QueueEvent(deltaStateEvent.Value);
+                logList.Clear();
+            }
         }
 
         public static void SendKeyEvent(int replaySegment, Key key, KeyState upOrDown)
@@ -64,6 +152,7 @@ namespace RegressionGames.StateRecorder
                         }
 
                         var inputEvent = TextEvent.Create(Keyboard.current.deviceId, value, time);
+                        RGDebug.LogInfo($"({replaySegment}) Sending Text Event for char: '{value}'");
                         InputSystem.QueueEvent(ref inputEvent);
                     }
                 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -161,6 +161,15 @@ namespace RegressionGames.StateRecorder
 
         public void Stop()
         {
+            if (_nextBotSegments.Count > 0)
+            {
+                foreach (var nextBotSegment in _nextBotSegments)
+                {
+                    // stop any action
+                    nextBotSegment.StopAction(new(), new());
+                }
+            }
+
             _nextBotSegments.Clear();
             _startPlaying = false;
             _isPlaying = false;
@@ -185,7 +194,6 @@ namespace RegressionGames.StateRecorder
             {
                 objectFinder.Cleanup();
             }
-
 
         }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/SdkApiVersion.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/SdkApiVersion.cs
@@ -10,7 +10,9 @@
         public const int VERSION_5 = 5; // added support for monobehaviour bot segment actions
         public const int VERSION_6 = 6; // add support for monkey bot
 
+        public const int VERSION_7 = 7; // added partial normalized path matching
+
         // Update this when new features are used in the SDK
-        public const int CURRENT_VERSION = VERSION_5;
+        public const int CURRENT_VERSION = VERSION_7;
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/SdkApiVersion.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/SdkApiVersion.cs
@@ -9,7 +9,6 @@
         public const int VERSION_4 = 4; // changed state format to enable entity support including 'type' and 'components' fields; added versioning to 'state' recording not just 'bot_segments'
         public const int VERSION_5 = 5; // added support for monobehaviour bot segment actions
         public const int VERSION_6 = 6; // add support for monkey bot
-
         public const int VERSION_7 = 7; // added partial normalized path matching
 
         // Update this when new features are used in the SDK


### PR DESCRIPTION
- Creates a sample exploring monobehaviour bot segment for one of our sample games
- Adds the ability to do partialNormalizedPath criteria
- Fixes a few bugs in the SDK around bot segments
- Sample bot segments are linked https://linear.app/regression-games/issue/REG-1862/playable-worlds-initial-bot-segments-for-blue-flower-test-steps-4
- Updates monobehaviour bot segment support to allow a maxRuntimeSeconds field

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
