### PR TITLE
[REG-1848] Improvements to address file in use errors during instrumentation

### DIFF
--- a/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
@@ -28,7 +28,7 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
         [InitializeOnLoadMethod]
         static void OnStartup()
         {
-            CompilationPipeline.compilationStarted += UpdateAssemblyResolver;
+            CompilationPipeline.compilationStarted += ResetAssemblyResolver;
             CompilationPipeline.assemblyCompilationFinished += OnAssemblyCompiled;
             
             _numInstrumentationAttempts = 0;
@@ -71,8 +71,9 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
 
         private static DefaultAssemblyResolver _assemblyResolver = null;
 
-        private static void UpdateAssemblyResolver(object o)
+        private static void ResetAssemblyResolver(object o)
         {
+            _assemblyResolver?.Dispose();
             _assemblyResolver = CreateAssemblyResolver();
         }
 
@@ -195,7 +196,7 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
 
             if (_assemblyResolver == null)
             {
-                UpdateAssemblyResolver(null);
+                ResetAssemblyResolver(null);
             }
 
             using (ModuleDefinition module = ReadAssembly(assemblyPath))
@@ -306,6 +307,7 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
         {
             try
             {
+                ResetAssemblyResolver(null);
                 Assembly[] assemblies = CompilationPipeline.GetAssemblies(AssembliesType.Player);
                 Assembly rgAssembly = FindRGAssembly();
                 foreach (Assembly assembly in assemblies)

--- a/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
@@ -69,7 +69,7 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
             return ns.Contains("RegressionGames");
         }
 
-        private static DefaultAssemblyResolver _assemblyResolver = null;
+        private static RGAssemblyResolver _assemblyResolver = null;
 
         private static void ResetAssemblyResolver(object o)
         {
@@ -77,7 +77,7 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
             _assemblyResolver = CreateAssemblyResolver();
         }
 
-        private static DefaultAssemblyResolver CreateAssemblyResolver()
+        private static RGAssemblyResolver CreateAssemblyResolver()
         {
             ISet<string> compiledSearchDirs = new HashSet<string>();
             Assembly[] assemblies = CompilationPipeline.GetAssemblies(AssembliesType.Player);
@@ -93,7 +93,7 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
                 precompiledSearchDirs.Add(Path.GetDirectoryName(path));
             }
 
-            DefaultAssemblyResolver resolver = new DefaultAssemblyResolver();
+            RGAssemblyResolver resolver = new RGAssemblyResolver();
             foreach (string searchDir in compiledSearchDirs)
             {
                 resolver.AddSearchDirectory(searchDir);
@@ -307,7 +307,6 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
         {
             try
             {
-                ResetAssemblyResolver(null);
                 Assembly[] assemblies = CompilationPipeline.GetAssemblies(AssembliesType.Player);
                 Assembly rgAssembly = FindRGAssembly();
                 foreach (Assembly assembly in assemblies)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGLegacyInputUtility/RGAssemblyResolver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGLegacyInputUtility/RGAssemblyResolver.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using Mono.Cecil;
+using UnityEngine;
+
+namespace RegressionGames.RGLegacyInputUtility
+{
+    public class RGAssemblyResolver : DefaultAssemblyResolver
+    {
+        public override AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
+        {
+            // force in-memory storage of resolved assemblies
+            if (!parameters.InMemory)
+            {
+                parameters = new ReaderParameters()
+                {
+                    ReadingMode = parameters.ReadingMode,
+                    InMemory = true,
+                    AssemblyResolver = parameters.AssemblyResolver,
+                    MetadataResolver = parameters.MetadataResolver,
+                    MetadataImporterProvider = parameters.MetadataImporterProvider,
+                    ReflectionImporterProvider = parameters.ReflectionImporterProvider,
+                    SymbolStream = parameters.SymbolStream,
+                    SymbolReaderProvider = parameters.SymbolReaderProvider,
+                    ReadSymbols = parameters.ReadSymbols,
+                    ThrowIfSymbolsAreNotMatching = parameters.ThrowIfSymbolsAreNotMatching,
+                    ReadWrite = parameters.ReadWrite,
+                    ApplyWindowsRuntimeProjections = parameters.ApplyWindowsRuntimeProjections
+                };
+            }
+            return base.Resolve(name, parameters);
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGLegacyInputUtility/RGAssemblyResolver.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGLegacyInputUtility/RGAssemblyResolver.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: daa1f006f5c3426db904291f17dd0e71
+timeCreated: 1721672862


### PR DESCRIPTION
This PR is to fix file in use errors that are still triggered by the instrumentation process in some games:
1. Add an assembly resolver RGAssemblyResolver, which stores all resolved assemblies in memory rather than holding onto a FileStream.
2. Dispose the assembly resolver when re-creating it.

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
