### PR TITLE
[REG-1874] Support games whose active input handling is set to exclusively use the new Input System

### DIFF
--- a/src/RGUnityBots/Assets/Resources/RGActionAnalysisResult.txt
+++ b/src/RGUnityBots/Assets/Resources/RGActionAnalysisResult.txt
@@ -15,7 +15,7 @@
 },
     {
 "actionTypeName":"RegressionGames.ActionManager.Actions.MousePositionAction, RegressionGames, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-"paths":["ActionManagerTests.MouseRaycast2DObject/MouseRaycast2DObject.cs:8:27:8:46/Input.mousePosition/ActionManagerTests.MouseRaycast2DObject/MouseRaycast2DObject.cs:10:24:10:64/Physics2D.Raycast(worldPt, Vector2.zero)"],
+"paths":["ActionManagerTests.MouseRaycast2DObject/MouseRaycast2DObject.cs:10:27:10:46/Input.mousePosition/ActionManagerTests.MouseRaycast2DObject/MouseRaycast2DObject.cs:15:24:15:64/Physics2D.Raycast(worldPt, Vector2.zero)"],
 "objectTypeName":"ActionManagerTests.MouseRaycast2DObject, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
 "parameterRange":{"type":"RANGE_VECTOR2","minValueX":0,"minValueY":0,"maxValueX":1,"maxValueY":1},
 "positionType":"COLLIDER_2D"
@@ -56,14 +56,14 @@
 },
     {
 "actionTypeName":"RegressionGames.ActionManager.Actions.MousePositionAction, RegressionGames, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-"paths":["ActionManagerTests.MouseMovementListeningObject/MouseMovementListeningObject.cs:11:27:11:46/Input.mousePosition","ActionManagerTests.MouseMovementListeningObject/MouseMovementListeningObject.cs:16:32:16:51/Input.mousePosition","ActionManagerTests.MouseMovementListeningObject/MouseMovementListeningObject.cs:17:32:17:54/Mouse.current.position"],
+"paths":["ActionManagerTests.MouseMovementListeningObject/MouseMovementListeningObject.cs:15:28:15:47/Input.mousePosition","ActionManagerTests.MouseMovementListeningObject/MouseMovementListeningObject.cs:17:28:17:50/Mouse.current.position","ActionManagerTests.MouseMovementListeningObject/MouseMovementListeningObject.cs:23:32:23:51/Input.mousePosition","ActionManagerTests.MouseMovementListeningObject/MouseMovementListeningObject.cs:31:32:31:54/Mouse.current.position"],
 "objectTypeName":"ActionManagerTests.MouseMovementListeningObject, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
 "parameterRange":{"type":"RANGE_VECTOR2","minValueX":0,"minValueY":0,"maxValueX":1,"maxValueY":1},
 "positionType":"NON_UI"
 },
     {
 "actionTypeName":"RegressionGames.ActionManager.Actions.MouseScrollAction, RegressionGames, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-"paths":["ActionManagerTests.MouseMovementListeningObject/MouseMovementListeningObject.cs:29:16:29:38/Input.mouseScrollDelta","ActionManagerTests.MouseMovementListeningObject/MouseMovementListeningObject.cs:34:16:34:36/Mouse.current.scroll"],
+"paths":["ActionManagerTests.MouseMovementListeningObject/MouseMovementListeningObject.cs:39:16:39:38/Input.mouseScrollDelta","ActionManagerTests.MouseMovementListeningObject/MouseMovementListeningObject.cs:45:16:45:36/Mouse.current.scroll"],
 "objectTypeName":"ActionManagerTests.MouseMovementListeningObject, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
 "parameterRange":{"type":"RANGE_VECTOR2_INT","minValueX":-1,"minValueY":-1,"maxValueX":1,"maxValueY":1}
 },
@@ -124,7 +124,7 @@
 },
     {
 "actionTypeName":"RegressionGames.ActionManager.Actions.MousePositionAction, RegressionGames, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-"paths":["ActionManagerTests.MouseRaycast3DObject/MouseRaycast3DObject.cs:10:27:10:46/Input.mousePosition/ActionManagerTests.MouseRaycast3DObject/MouseRaycast3DObject.cs:12:16:12:76/Physics.Raycast(ray, out var hit, Mathf.Infinity, layerMask)"],
+"paths":["ActionManagerTests.MouseRaycast3DObject/MouseRaycast3DObject.cs:12:27:12:46/Input.mousePosition/ActionManagerTests.MouseRaycast3DObject/MouseRaycast3DObject.cs:17:16:17:76/Physics.Raycast(ray, out var hit, Mathf.Infinity, layerMask)"],
 "objectTypeName":"ActionManagerTests.MouseRaycast3DObject, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
 "parameterRange":{"type":"RANGE_VECTOR2","minValueX":0,"minValueY":0,"maxValueX":1,"maxValueY":1},
 "positionType":"COLLIDER_3D",
@@ -134,7 +134,7 @@
 },
     {
 "actionTypeName":"RegressionGames.ActionManager.Actions.LegacyKeyAction, RegressionGames, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-"paths":["ActionManagerTests.InterprocObject/InterprocObject.cs:8:12:8:49/InputUtil.CheckPlayerJump(gameObject)/ActionManagerTests.InputUtil/InputUtil.cs:15:16:15:32/ReadPlayerJump()/ActionManagerTests.InputUtil/InputUtil.cs:10:19:10:44/Input.GetKey(jumpKeyCode)/jumpKeyCode"],
+"paths":["ActionManagerTests.InterprocObject/InterprocObject.cs:8:12:8:49/InputUtil.CheckPlayerJump(gameObject)/ActionManagerTests.InputUtil/InputUtil.cs:24:16:24:32/ReadPlayerJump()/ActionManagerTests.InputUtil/InputUtil.cs:16:19:16:44/Input.GetKey(jumpKeyCode)/jumpKeyCode"],
 "objectTypeName":"ActionManagerTests.InterprocObject, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
 "parameterRange":{"type":"RANGE_BOOL","minValue":0,"maxValue":1},
 "keyCodeFunc":{"funcType":"TYPE_MEMBER_ACCESS","data":"{\"MemberAccesses\":[{\"MemberType\":4,\"DeclaringType\":\"ActionManagerTests.InputUtil, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null\",\"MemberName\":\"jumpKeyCode\"}]}"}
@@ -256,35 +256,35 @@
 },
     {
 "actionTypeName":"RegressionGames.ActionManager.Actions.MouseButtonAction, RegressionGames, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-"paths":["ActionManagerTests.MouseBtnListeningObject/MouseBtnListeningObject.cs:12:16:12:39/Input.GetMouseButton(0)/0"],
+"paths":["ActionManagerTests.MouseBtnListeningObject/MouseBtnListeningObject.cs:13:16:13:39/Input.GetMouseButton(0)/0"],
 "objectTypeName":"ActionManagerTests.MouseBtnListeningObject, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
 "parameterRange":{"type":"RANGE_BOOL","minValue":0,"maxValue":1},
 "mouseButtonFunc":{"funcType":"TYPE_CONSTANT","data":"0"}
 },
     {
 "actionTypeName":"RegressionGames.ActionManager.Actions.MouseButtonAction, RegressionGames, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-"paths":["ActionManagerTests.MouseBtnListeningObject/MouseBtnListeningObject.cs:17:16:17:50/Input.GetMouseButtonDown(mouseBtn)/mouseBtn"],
+"paths":["ActionManagerTests.MouseBtnListeningObject/MouseBtnListeningObject.cs:18:16:18:50/Input.GetMouseButtonDown(mouseBtn)/mouseBtn"],
 "objectTypeName":"ActionManagerTests.MouseBtnListeningObject, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
 "parameterRange":{"type":"RANGE_BOOL","minValue":0,"maxValue":1},
 "mouseButtonFunc":{"funcType":"TYPE_MEMBER_ACCESS","data":"{\"MemberAccesses\":[{\"MemberType\":4,\"DeclaringType\":\"ActionManagerTests.MouseBtnListeningObject, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null\",\"MemberName\":\"mouseBtn\"}]}"}
 },
     {
 "actionTypeName":"RegressionGames.ActionManager.Actions.MouseButtonAction, RegressionGames, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-"paths":["ActionManagerTests.MouseBtnListeningObject/MouseBtnListeningObject.cs:23:16:23:43/Input.GetMouseButtonUp(btn)/otherMouseBtn"],
+"paths":["ActionManagerTests.MouseBtnListeningObject/MouseBtnListeningObject.cs:24:16:24:43/Input.GetMouseButtonUp(btn)/otherMouseBtn"],
 "objectTypeName":"ActionManagerTests.MouseBtnListeningObject, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
 "parameterRange":{"type":"RANGE_BOOL","minValue":0,"maxValue":1},
 "mouseButtonFunc":{"funcType":"TYPE_MEMBER_ACCESS","data":"{\"MemberAccesses\":[{\"MemberType\":4,\"DeclaringType\":\"ActionManagerTests.MouseBtnListeningObject, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null\",\"MemberName\":\"otherMouseBtn\"}]}"}
 },
     {
 "actionTypeName":"RegressionGames.ActionManager.Actions.MouseButtonAction, RegressionGames, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-"paths":["ActionManagerTests.MouseBtnListeningObject/MouseBtnListeningObject.cs:28:16:28:43/Mouse.current.forwardButton"],
+"paths":["ActionManagerTests.MouseBtnListeningObject/MouseBtnListeningObject.cs:30:16:30:43/Mouse.current.forwardButton"],
 "objectTypeName":"ActionManagerTests.MouseBtnListeningObject, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
 "parameterRange":{"type":"RANGE_BOOL","minValue":0,"maxValue":1},
 "mouseButtonFunc":{"funcType":"TYPE_CONSTANT","data":"3"}
 },
     {
 "actionTypeName":"RegressionGames.ActionManager.Actions.MouseButtonAction, RegressionGames, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-"paths":["ActionManagerTests.MouseBtnListeningObject/MouseBtnListeningObject.cs:34:16:34:32/mouse.backButton"],
+"paths":["ActionManagerTests.MouseBtnListeningObject/MouseBtnListeningObject.cs:36:16:36:32/mouse.backButton"],
 "objectTypeName":"ActionManagerTests.MouseBtnListeningObject, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
 "parameterRange":{"type":"RANGE_BOOL","minValue":0,"maxValue":1},
 "mouseButtonFunc":{"funcType":"TYPE_CONSTANT","data":"4"}

--- a/src/RGUnityBots/Assets/Scenes/ActionManagerTestScene.unity
+++ b/src/RGUnityBots/Assets/Scenes/ActionManagerTestScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5d2c03f57cfb1e1d3c39f3f67eccd388f5f2ec0d735f5f270a69587299c4c109
-size 51294
+oid sha256:3094de21d0db6a2537a66445212b028be580b127fd882bab4aae2fbff0260a56
+size 50458

--- a/src/RGUnityBots/Assets/Scripts/ActionManagerTests/InputUtil.cs
+++ b/src/RGUnityBots/Assets/Scripts/ActionManagerTests/InputUtil.cs
@@ -1,14 +1,23 @@
 ﻿using UnityEngine;
+using UnityEngine.InputSystem;
 
 namespace ActionManagerTests
 {
     public static class InputUtil
     {
+        #if ENABLE_LEGACY_INPUT_MANAGER
         public static KeyCode jumpKeyCode = KeyCode.Space;
+        #else
+        public static Key jumpKeyCode = Key.Space;
+        #endif
 
         private static bool ReadPlayerJump()
         {
+            #if ENABLE_LEGACY_INPUT_MANAGER
             return Input.GetKey(jumpKeyCode);
+            #else
+            return Keyboard.current[jumpKeyCode].isPressed;
+            #endif
         }
 
         public static void CheckPlayerJump(GameObject gameObject)

--- a/src/RGUnityBots/Assets/Scripts/ActionManagerTests/MouseBtnListeningObject.cs
+++ b/src/RGUnityBots/Assets/Scripts/ActionManagerTests/MouseBtnListeningObject.cs
@@ -10,6 +10,7 @@ namespace ActionManagerTests
         
         void Update()
         {
+            #if ENABLE_LEGACY_INPUT_MANAGER
             if (Input.GetMouseButton(0))
             {
                 Debug.Log("Input.GetMouseButton(0)");
@@ -25,6 +26,7 @@ namespace ActionManagerTests
             {
                 Debug.Log("Input.GetMouseButtonUp(btn)");
             }
+            #endif
 
             if (Mouse.current.forwardButton.isPressed)
             {

--- a/src/RGUnityBots/Assets/Scripts/ActionManagerTests/MouseMovementListeningObject.cs
+++ b/src/RGUnityBots/Assets/Scripts/ActionManagerTests/MouseMovementListeningObject.cs
@@ -5,32 +5,43 @@ namespace ActionManagerTests
 {
     public class MouseMovementListeningObject : MonoBehaviour
     {
-        private Vector3 lastMousePos;
+        #if ENABLE_LEGACY_INPUT_MANAGER
+        private Vector3 lastMousePos1;
+        #endif
+        private Vector3 lastMousePos2;
 
         void Start()
         {
-            lastMousePos = Input.mousePosition;
+            #if ENABLE_LEGACY_INPUT_MANAGER
+            lastMousePos1 = Input.mousePosition;
+            #endif
+            lastMousePos2 = Mouse.current.position.value;
         }
         
         void Update()
         {
+            #if ENABLE_LEGACY_INPUT_MANAGER
             Vector3 mousePos1 = Input.mousePosition;
+            if (mousePos1 != lastMousePos1)
+            {
+                Debug.Log("mousePos1 != lastMousePos1");
+            }
+            lastMousePos1 = mousePos1;
+            #endif
+            
             Vector3 mousePos2 = Mouse.current.position.value;
-            if (mousePos1 != lastMousePos)
+            if (mousePos2 != lastMousePos2)
             {
-                Debug.Log("mousePos1 != lastMousePos");
+                Debug.Log("mousePos2 != lastMousePos2");
             }
-            if (mousePos2 != lastMousePos)
-            {
-                Debug.Log("mousePos2 != lastMousePos");
-            }
+            lastMousePos2 = mousePos2;
 
-            lastMousePos = mousePos1;
-
+            #if ENABLE_LEGACY_INPUT_MANAGER
             if (Input.mouseScrollDelta.sqrMagnitude > 0.1f)
             {
                 Debug.Log("Input.mouseScrollDelta.sqrMagnitude");
             }
+            #endif
 
             if (Mouse.current.scroll.value.sqrMagnitude > 0.1f)
             {

--- a/src/RGUnityBots/Assets/Scripts/ActionManagerTests/MouseRaycast2DObject.cs
+++ b/src/RGUnityBots/Assets/Scripts/ActionManagerTests/MouseRaycast2DObject.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using UnityEngine.InputSystem;
 
 namespace ActionManagerTests
 {
@@ -6,7 +7,11 @@ namespace ActionManagerTests
     {
         void Update()
         {
+            #if ENABLE_LEGACY_INPUT_MANAGER
             var mousePos = Input.mousePosition;
+            #else
+            var mousePos = Mouse.current.position.value;
+            #endif
             var worldPt = Camera.main.ScreenToWorldPoint(mousePos);
             var hit2D = Physics2D.Raycast(worldPt, Vector2.zero);
             if (hit2D.collider != null)

--- a/src/RGUnityBots/Assets/Scripts/ActionManagerTests/MouseRaycast3DObject.cs
+++ b/src/RGUnityBots/Assets/Scripts/ActionManagerTests/MouseRaycast3DObject.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using UnityEngine.InputSystem;
 
 namespace ActionManagerTests
 {
@@ -8,7 +9,11 @@ namespace ActionManagerTests
         
         void Update()
         {
+            #if ENABLE_LEGACY_INPUT_MANAGER
             var mousePos = Input.mousePosition;
+            #else
+            var mousePos = Mouse.current.position.value;
+            #endif
             var ray = Camera.main.ScreenPointToRay(mousePos);
             if (Physics.Raycast(ray, out var hit, Mathf.Infinity, layerMask))
             {

--- a/src/RGUnityBots/Assets/Tests/Runtime/RGActionManagerTests.cs
+++ b/src/RGUnityBots/Assets/Tests/Runtime/RGActionManagerTests.cs
@@ -226,6 +226,7 @@ namespace Tests.Runtime
                 RGActionManager.StopSession();
             }
             
+            #if ENABLE_LEGACY_INPUT_MANAGER
             // Test Legacy Input Manager Axis
             ResetInputSystem();
             RGActionManager.StartSession(eventSys);
@@ -332,6 +333,7 @@ namespace Tests.Runtime
                 legacyKeyListener.SetActive(false);
                 RGActionManager.StopSession();
             }
+            #endif
             
             // Test Mouse Button
             ResetInputSystem();
@@ -340,6 +342,7 @@ namespace Tests.Runtime
             mouseBtnListener.SetActive(true);
             try
             {
+                #if ENABLE_LEGACY_INPUT_MANAGER
                 FindAndPerformAction("Mouse Button 0", true);
                 yield return null;
                 yield return null;
@@ -357,6 +360,7 @@ namespace Tests.Runtime
                 yield return null;
                 yield return null;
                 LogAssert.Expect(LogType.Log, "Input.GetMouseButtonUp(btn)");
+                #endif
                 
                 FindAndPerformAction("Mouse Button 3", true);
                 yield return null;
@@ -387,13 +391,17 @@ namespace Tests.Runtime
                 FindAndPerformAction("Mouse Position", new Vector2(0.8f, 0.7f));
                 yield return null;
                 yield return null;
-                LogAssert.Expect(LogType.Log, "mousePos1 != lastMousePos");
-                LogAssert.Expect(LogType.Log, "mousePos2 != lastMousePos");
+                #if ENABLE_LEGACY_INPUT_MANAGER
+                LogAssert.Expect(LogType.Log, "mousePos1 != lastMousePos1");
+                #endif
+                LogAssert.Expect(LogType.Log, "mousePos2 != lastMousePos2");
 
                 FindAndPerformAction("Mouse Scroll", new Vector2Int(1, 1));
                 yield return null;
                 yield return null;
+                #if ENABLE_LEGACY_INPUT_MANAGER
                 LogAssert.Expect(LogType.Log, "Input.mouseScrollDelta.sqrMagnitude");
+                #endif
                 LogAssert.Expect(LogType.Log, "Mouse.current.scroll.value.sqrMagnitude");
             }
             finally
@@ -402,6 +410,7 @@ namespace Tests.Runtime
                 RGActionManager.StopSession();
             }
             
+            #if ENABLE_LEGACY_INPUT_MANAGER
             // Test Mouse Handlers
             ResetInputSystem();
             RGActionManager.StartSession(eventSys);
@@ -441,6 +450,7 @@ namespace Tests.Runtime
                 mouseHandlerListener.SetActive(false);
                 RGActionManager.StopSession();
             }
+            #endif
             
             // Test Mouse Raycast 2D
             ResetInputSystem();

--- a/src/gg.regression.unity.bots/Editor/Scripts/RGEditorUtils.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGEditorUtils.cs
@@ -1,4 +1,7 @@
 using System;
+using System.IO;
+using RegressionGames.StateRecorder;
+using UnityEditor.Compilation;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
@@ -62,5 +65,25 @@ namespace RegressionGames.Editor
             }
 #endif
         }
+        
+        
+        #if UNITY_EDITOR
+        /// <summary>
+        /// Finds the Runtime assembly for the Regression Games SDK.
+        /// </summary>
+        public static Assembly FindRGAssembly()
+        {
+            var rgAsmName = Path.GetFileName(typeof(ReplayDataPlaybackController).Assembly.Location);
+            Assembly[] assemblies = CompilationPipeline.GetAssemblies(AssembliesType.Player);
+            foreach (Assembly assembly in assemblies)
+            {
+                if (Path.GetFileName(assembly.outputPath) == rgAsmName)
+                {
+                    return assembly;
+                }
+            }
+            return null;
+        }
+        #endif
     }
 }

--- a/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputInstrumentation.cs
@@ -1,4 +1,5 @@
-﻿#if UNITY_EDITOR
+﻿#if ENABLE_LEGACY_INPUT_MANAGER
+#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -237,25 +238,11 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
             }
         }
         
-        public static Assembly FindRGAssembly()
-        {
-            var rgAsmName = Path.GetFileName(typeof(RGLegacyInputWrapper).Assembly.Location);
-            Assembly[] assemblies = CompilationPipeline.GetAssemblies(AssembliesType.Player);
-            foreach (Assembly assembly in assemblies)
-            {
-                if (Path.GetFileName(assembly.outputPath) == rgAsmName)
-                {
-                    return assembly;
-                }
-            }
-            return null;
-        }
-
         private static void OnAssemblyCompiled(string assemblyAssetPath, CompilerMessage[] messages)
         {
             try
             {
-                Assembly rgAssembly = FindRGAssembly();
+                Assembly rgAssembly = RGEditorUtils.FindRGAssembly();
                 InstrumentAssemblyIfNeeded(assemblyAssetPath, rgAssembly);
             }
             catch (Exception e)
@@ -308,7 +295,7 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
             try
             {
                 Assembly[] assemblies = CompilationPipeline.GetAssemblies(AssembliesType.Player);
-                Assembly rgAssembly = FindRGAssembly();
+                Assembly rgAssembly = RGEditorUtils.FindRGAssembly();
                 foreach (Assembly assembly in assemblies)
                 {
                     InstrumentAssemblyIfNeeded(assembly.outputPath, rgAssembly);
@@ -331,4 +318,5 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
         }
     }
 }
+#endif
 #endif

--- a/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputSettingsPreprocessBuild.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGLegacyInputUtility/RGLegacyInputSettingsPreprocessBuild.cs
@@ -1,4 +1,5 @@
-﻿#if UNITY_EDITOR
+﻿#if ENABLE_LEGACY_INPUT_MANAGER
+#if UNITY_EDITOR
 using System.IO;
 using System.Linq;
 using RegressionGames.RGLegacyInputUtility;
@@ -37,4 +38,5 @@ namespace RegressionGames.Editor.RGLegacyInputUtility
     }
 }
 
+#endif
 #endif

--- a/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionManager.cs
@@ -145,16 +145,19 @@ namespace RegressionGames.ActionManager
             }
             _context = context;
             _sessionActions = new List<RGGameAction>(_actionProvider.Actions.Where(IsActionEnabled));
-            InitInputState();
 
             if (DoesContextNeedSetUp())
             {
+                #if ENABLE_LEGACY_INPUT_MANAGER
                 RGLegacyInputWrapper.StartSimulation(_context);
+                #endif
                 KeyboardEventSender.Initialize();
                 SceneManager.sceneLoaded += OnSceneLoad;
                 RGUtils.SetupEventSystem();
                 RGUtils.ConfigureInputSettings();
             }
+            
+            InitInputState();
         }
 
         /// <summary>
@@ -167,7 +170,9 @@ namespace RegressionGames.ActionManager
                 if (DoesContextNeedSetUp())
                 {
                     SceneManager.sceneLoaded -= OnSceneLoad;
+                    #if ENABLE_LEGACY_INPUT_MANAGER
                     RGLegacyInputWrapper.StopSimulation();
+                    #endif
                     RGUtils.RestoreInputSettings();
                 }
                 _sessionActions = null;
@@ -268,12 +273,23 @@ namespace RegressionGames.ActionManager
             MouseEventSender.SendRawPositionMouseEvent(-1, mousePos);
 
             _mousePosition = mousePos;
+            
+            #if ENABLE_LEGACY_INPUT_MANAGER
             _mouseScroll = RGLegacyInputWrapper.mouseScrollDelta;
             _leftMouseButton = RGLegacyInputWrapper.GetKey(KeyCode.Mouse0);
             _middleMouseButton = RGLegacyInputWrapper.GetKey(KeyCode.Mouse2);
             _rightMouseButton = RGLegacyInputWrapper.GetKey(KeyCode.Mouse1);
             _forwardMouseButton = RGLegacyInputWrapper.GetKey(KeyCode.Mouse3);
             _backMouseButton = RGLegacyInputWrapper.GetKey(KeyCode.Mouse4);
+            #else
+            _mouseScroll = Mouse.current.delta.value;
+            _leftMouseButton = Mouse.current.leftButton.isPressed;
+            _middleMouseButton = Mouse.current.middleButton.isPressed;
+            _rightMouseButton = Mouse.current.rightButton.isPressed;
+            _forwardMouseButton = Mouse.current.forwardButton.isPressed;
+            _backMouseButton = Mouse.current.backButton.isPressed;
+            #endif
+            
             CurrentEventSystems = new List<EventSystem>();
         }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGLegacyInputUtility/RGBaseInput.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGLegacyInputUtility/RGBaseInput.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿#if ENABLE_LEGACY_INPUT_MANAGER
+using UnityEngine;
 using UnityEngine.EventSystems;
 
 namespace RegressionGames.RGLegacyInputUtility
@@ -41,3 +42,4 @@ namespace RegressionGames.RGLegacyInputUtility
         }
     }
 }
+#endif

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGLegacyInputUtility/RGLegacyEditorOnlyUtils.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGLegacyInputUtility/RGLegacyEditorOnlyUtils.cs
@@ -1,4 +1,5 @@
-﻿#if UNITY_EDITOR
+﻿#if ENABLE_LEGACY_INPUT_MANAGER
+#if UNITY_EDITOR
 using System.Linq;
 using System.IO;
 using UnityEngine;
@@ -24,4 +25,5 @@ namespace RegressionGames.RGLegacyInputUtility
         }
     }
 }
+#endif
 #endif

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGLegacyInputUtility/RGLegacyInputManagerSettings.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGLegacyInputUtility/RGLegacyInputManagerSettings.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if ENABLE_LEGACY_INPUT_MANAGER
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -123,3 +124,4 @@ namespace RegressionGames.RGLegacyInputUtility
         }
     }
 }
+#endif

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGLegacyInputUtility/RGStandaloneInputModule.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGLegacyInputUtility/RGStandaloneInputModule.cs
@@ -1,4 +1,4 @@
-﻿
+﻿#if ENABLE_LEGACY_INPUT_MANAGER
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -109,3 +109,4 @@ namespace RegressionGames.RGLegacyInputUtility
         }
     }
 }
+#endif

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGUtils.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGUtils.cs
@@ -84,7 +84,11 @@ namespace RegressionGames
             {
                 BaseInputModule inputModule = eventSystem.gameObject
                     .GetComponents<BaseInputModule>()
+                    #if ENABLE_LEGACY_INPUT_MANAGER
                     .FirstOrDefault(module => module is not RGStandaloneInputModule);
+                    #else
+                    .FirstOrDefault();
+                    #endif
                 
                 // If there is no module, add the appropriate input module so that the replay can simulate UI inputs.
                 // If both the new and old input systems are active, prefer the new input system's UI module.


### PR DESCRIPTION
This PR addresses an issue where if Build Settings -> Player Settings -> Active Input Handling is set to “Input System Package (New)”, rather than “Both”, the SDK currently errors out due to a variety of dependency on both the old/new input systems throughout the SDK. This adds ENABLE_LEGACY_INPUT_MANAGER checks in all the remaining places where they should be to disable the legacy input usage when the game is exclusively using the new Input System.

As before, it is out of scope to fully remove dependency on the new Input System in the SDK for games that only use the legacy input system. This PR is just to ensure that the configurations of "Both" and "Input System Package (New)" are both working.

This was tested in two ways:
1. The unit tests in the RGUnityBots project were run with active input handling set to New Input System only.
2. Boss Room was re-configured to be set to use the new Input System only, and the record/replay and monkey bot were checked to work as expected.

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
