### PR TITLE
[REG-1882] Make virtual mouse cursor not messup CV analysis

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlayCanvasV2.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlayCanvasV2.prefab
@@ -1,5 +1,81 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &124407930152948339
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3319101586032168257}
+  - component: {fileID: 7995980796697667596}
+  - component: {fileID: 6509774744981593005}
+  m_Layer: 5
+  m_Name: VirtualMouseCursor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3319101586032168257
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 124407930152948339}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6927235806806861544}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.5, y: 2}
+  m_SizeDelta: {x: 40, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7995980796697667596
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 124407930152948339}
+  m_CullTransparentMesh: 1
+--- !u!114 &6509774744981593005
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 124407930152948339}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 39257b319544b2f4b99fe93d3f19d94b, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &387301691464193284
 GameObject:
   m_ObjectHideFlags: 0
@@ -2941,82 +3017,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &3882724928923125222
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6616899866124984948}
-  - component: {fileID: 8565215197663429023}
-  - component: {fileID: 5011622320911247157}
-  m_Layer: 5
-  m_Name: ClickHighlight
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &6616899866124984948
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3882724928923125222}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6927235806806861544}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -1.5, y: -15}
-  m_SizeDelta: {x: 150, y: 130}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &8565215197663429023
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3882724928923125222}
-  m_CullTransparentMesh: 1
---- !u!114 &5011622320911247157
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3882724928923125222}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
-  m_RaycastTarget: 0
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 6ed40dec3af864cce92c46e517196ebf, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3951327588528156207
 GameObject:
   m_ObjectHideFlags: 0
@@ -4053,6 +4053,158 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 28}
   m_Pivot: {x: 0.5, y: 1}
+--- !u!1 &4592676549654162190
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5061430410649258493}
+  - component: {fileID: 1030293922241065793}
+  - component: {fileID: 4177226886652366683}
+  m_Layer: 5
+  m_Name: VirtualMouseClickHighlight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5061430410649258493
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4592676549654162190}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6927235806806861544}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1030293922241065793
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4592676549654162190}
+  m_CullTransparentMesh: 1
+--- !u!114 &4177226886652366683
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4592676549654162190}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 6ed40dec3af864cce92c46e517196ebf, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4627350413563657741
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5716806768315515097}
+  - component: {fileID: 9151610176880169612}
+  - component: {fileID: 975420848427337079}
+  m_Layer: 5
+  m_Name: MouseDot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5716806768315515097
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4627350413563657741}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6927235806806861544}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 5, y: 5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9151610176880169612
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4627350413563657741}
+  m_CullTransparentMesh: 1
+--- !u!114 &975420848427337079
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4627350413563657741}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 0.5
 --- !u!1 &4760620846668409867
 GameObject:
   m_ObjectHideFlags: 0
@@ -5538,10 +5690,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6927235806806861544}
-  - component: {fileID: 4568043474053865578}
-  - component: {fileID: 4482785860127067509}
   m_Layer: 5
-  m_Name: MouseCursor
+  m_Name: VirtualMouse
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -5559,7 +5709,9 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 6616899866124984948}
+  - {fileID: 3319101586032168257}
+  - {fileID: 5061430410649258493}
+  - {fileID: 5716806768315515097}
   m_Father: {fileID: 1090041802443136416}
   m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -5568,44 +5720,6 @@ RectTransform:
   m_AnchoredPosition: {x: 279.6634, y: -135.92914}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &4568043474053865578
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7038924818668551959}
-  m_CullTransparentMesh: 1
---- !u!114 &4482785860127067509
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7038924818668551959}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 0
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 39257b319544b2f4b99fe93d3f19d94b, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 1
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &7439472907228313500
 GameObject:
   m_ObjectHideFlags: 0
@@ -6912,4 +7026,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   mouseTransform: {fileID: 6927235806806861544}
-  clickHighlight: {fileID: 5011622320911247157}
+  cursor: {fileID: 6509774744981593005}
+  clickHighlight: {fileID: 4177226886652366683}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionManager.cs
@@ -88,7 +88,7 @@ namespace RegressionGames.ActionManager
             {
                 result = JsonUtility.FromJson<RGActionManagerSettings>(jsonText);
             }
-            
+
             if (result == null || !result.IsValid())
             {
                 result = new RGActionManagerSettings();
@@ -156,7 +156,7 @@ namespace RegressionGames.ActionManager
                 RGUtils.SetupEventSystem();
                 RGUtils.ConfigureInputSettings();
             }
-            
+
             InitInputState();
         }
 
@@ -177,7 +177,7 @@ namespace RegressionGames.ActionManager
                 }
                 _sessionActions = null;
                 _context = null;
-                _settings = LoadSettings(); // restore settings back to the saved configuration 
+                _settings = LoadSettings(); // restore settings back to the saved configuration
             }
         }
 
@@ -203,20 +203,20 @@ namespace RegressionGames.ActionManager
         {
             var tof = UnityEngine.Object.FindObjectOfType<TransformObjectFinder>();
             CurrentTransforms = tof.GetObjectStatusForCurrentFrame().Item2;
-            
+
             var eventSystems = UnityEngine.Object.FindObjectsOfType<EventSystem>();
             CurrentEventSystems.Clear();
             CurrentEventSystems.AddRange(eventSystems);
-            
+
             RGUtils.ForceApplicationFocus();
-            
+
             foreach (RGGameAction action in _sessionActions)
             {
                 Debug.Assert(action.ParameterRange != null);
-                
+
                 // Fetch all objects of the target object type (use Resources API to support ANY type of loaded object)
                 UnityEngine.Object[] objects = Resources.FindObjectsOfTypeAll(action.ObjectType);
-                
+
                 foreach (var obj in objects)
                 {
                     if (obj is Component c && !c.gameObject.activeInHierarchy)
@@ -269,11 +269,8 @@ namespace RegressionGames.ActionManager
         private static void InitInputState()
         {
             // move mouse off screen
-            var mousePos = new Vector2(Screen.width + 20, -20);
-            MouseEventSender.SendRawPositionMouseEvent(-1, mousePos);
+            _mousePosition = MouseEventSender.MoveMouseOffScreen();
 
-            _mousePosition = mousePos;
-            
             #if ENABLE_LEGACY_INPUT_MANAGER
             _mouseScroll = RGLegacyInputWrapper.mouseScrollDelta;
             _leftMouseButton = RGLegacyInputWrapper.GetKey(KeyCode.Mouse0);
@@ -289,7 +286,7 @@ namespace RegressionGames.ActionManager
             _forwardMouseButton = Mouse.current.forwardButton.isPressed;
             _backMouseButton = Mouse.current.backButton.isPressed;
             #endif
-            
+
             CurrentEventSystems = new List<EventSystem>();
         }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseEventSender.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseEventSender.cs
@@ -90,6 +90,13 @@ namespace RegressionGames.StateRecorder
             return mouse;
         }
 
+        public static Vector2 MoveMouseOffScreen(int replaySegment = 0)
+        {
+            var mousePosition = new Vector2(Screen.width + 20, -20);
+            MouseEventSender.SendRawPositionMouseEvent(replaySegment, mousePosition);
+            return mousePosition;
+        }
+
         public static void SendRawPositionMouseEvent(int replaySegment, Vector2 normalizedPosition, bool leftButton = false, bool middleButton = false, bool rightButton = false, bool forwardButton = false, bool backButton = false)
         {
             SendRawPositionMouseEvent(replaySegment, normalizedPosition, leftButton, middleButton, rightButton, forwardButton, backButton, Vector2.zero);

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -109,8 +109,7 @@ namespace RegressionGames.StateRecorder
             Stop();
             _replaySuccessful = null;
 
-            // get the mouse off the screen, when replay fails, we leave the virtual mouse cursor alone so they can see its location at time of failure, but on new file, we want this gone
-            MouseEventSender.SendRawPositionMouseEvent(-1, new Vector2(Screen.width+20, -20));
+            MouseEventSender.MoveMouseOffScreen();
 
             _dataContainer = dataContainer;
         }
@@ -187,6 +186,7 @@ namespace RegressionGames.StateRecorder
             _dataContainer = null;
             KeyboardEventSender.Reset();
             MouseEventSender.Reset();
+            MouseEventSender.MoveMouseOffScreen();
 
             TransformStatus.Reset();
             KeyFrameEvaluator.Evaluator.Reset();
@@ -216,6 +216,7 @@ namespace RegressionGames.StateRecorder
             _dataContainer?.Reset();
             KeyboardEventSender.Reset();
             MouseEventSender.Reset();
+            MouseEventSender.MoveMouseOffScreen();
 
             TransformStatus.Reset();
             KeyFrameEvaluator.Evaluator.Reset();
@@ -244,6 +245,7 @@ namespace RegressionGames.StateRecorder
             _dataContainer?.Reset();
             KeyboardEventSender.Reset();
             MouseEventSender.Reset();
+            MouseEventSender.MoveMouseOffScreen();
 
             TransformStatus.Reset();
             KeyFrameEvaluator.Evaluator.Reset();
@@ -267,7 +269,7 @@ namespace RegressionGames.StateRecorder
                 if (_startPlaying)
                 {
                     // start the mouse off the screen.. this avoids CV or other things failing because the virtual mouse is in the way at the start
-                    MouseEventSender.SendRawPositionMouseEvent(-1, new Vector2(Screen.width+20, -20));
+                    MouseEventSender.MoveMouseOffScreen();
 
                     #if ENABLE_LEGACY_INPUT_MANAGER
                     RGLegacyInputWrapper.StartSimulation(this);
@@ -484,7 +486,7 @@ namespace RegressionGames.StateRecorder
 
                 if (_nextBotSegments.Count == 0)
                 {
-                    MouseEventSender.SendRawPositionMouseEvent(-1, new Vector2(Screen.width+20, -20));
+                    MouseEventSender.MoveMouseOffScreen();
 
                     // we hit the end of the replay
                     if (_loopCount > -1)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/VirtualMouseCursor.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/VirtualMouseCursor.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 using UnityEngine.UI;
 
 namespace RegressionGames.StateRecorder
@@ -6,14 +7,35 @@ namespace RegressionGames.StateRecorder
     public class VirtualMouseCursor : MonoBehaviour
     {
         public RectTransform mouseTransform;
+        public Image cursor;
         public Image clickHighlight;
+
+        public void Start()
+        {
+            // set the click highlight NOT visible
+            var color = clickHighlight.color;
+            color.a = 0f;
+            clickHighlight.color = color;
+
+            // set the cursor NOT visible
+            color = cursor.color;
+            color.a = 0f;
+            cursor.color = color;
+        }
 
         public void SetPosition(Vector2 position, bool clicked = false)
         {
             mouseTransform.position = position;
+
+            // set whether the click highlight is visible
             var color = clickHighlight.color;
             color.a = clicked ? 1f : 0f;
             clickHighlight.color = color;
+
+            // set whether the cursor is visible
+            color = cursor.color;
+            color.a = clicked ? 1f : 0f;
+            cursor.color = color;
         }
     }
 }


### PR DESCRIPTION
- Changes our playback mouse cursor to be only a tiny dot and not the screen blocking williward head
- Hides the cursor on any run finish so that the cursor isn't stuck on the screen
- downsizes and re-centers the 'click highlight' so that we can more accurately see where the click occurred



https://github.com/user-attachments/assets/7b162867-88ca-467c-ad54-044a266a219d


---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
