### PR TITLE
[REG-1896] Hard stop (abort) segment actions from UI/user request

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BehaviourActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BehaviourActionData.cs
@@ -118,14 +118,15 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                 {
                     if (!_myGameObject.GetComponent(_typeToCreate))
                     {
-                        // behaviour was destroyed, stop
-                        StopAction(segmentNumber, currentTransforms, currentEntities);
+                        // behaviour was destroyed, stop .. really this is an abort, but this is sample for how to call stop
+                        ((IBotActionData)this).StopAction(segmentNumber, currentTransforms, currentEntities);
                         // will return false
 
                     }
                     else if (maxRuntimeSeconds.HasValue && _startTime > 0 && time - _startTime > maxRuntimeSeconds.Value)
                     {
-                        StopAction(segmentNumber, currentTransforms, currentEntities);
+                        // really this is an abort, but this is sample for how to call stop
+                        ((IBotActionData)this).StopAction(segmentNumber, currentTransforms, currentEntities);
                         // will return false
                     }
                     else
@@ -139,13 +140,13 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                     // and/or
                     // UnityEngine.Object.FindObjectOfType<EntityObjectFinder>().GetObjectStatusForCurrentFrame(); - for runtimes with ECS support
                 }
-            } 
+            }
 
             error = null;
             return false;
         }
 
-        public void StopAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
+        public void AbortAction(int segmentNumber)
         {
             _isStopped = true;
             if (_myGameObject != null)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotAction.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotAction.cs
@@ -35,6 +35,13 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             return data.ProcessAction(segmentNumber, currentTransforms, currentEntities, out error);
         }
 
+        // called when a user asks for the replay playback of a bot sequence / segments to stop
+        // This should stop the action immediately, even for input playback or other actions with a list of tasks.
+        public void AbortAction(int segmentNumber)
+        {
+            data.AbortAction(segmentNumber);
+        }
+
         // called when a segment ends to stop any action processing
         // For segments with action sequences, they should still finish processing all their actions before stopping.
         public void StopAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
@@ -74,6 +74,21 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             return false;
         }
 
+        /**
+         * <summary>A HARD stop that doesn't wait for the action to finish.  Useful for stopping segments from the UI controls/etc.</summary>
+         */
+        public void AbortAction()
+        {
+            if (botAction != null)
+            {
+                botAction.AbortAction(Replay_SegmentNumber);
+            }
+        }
+
+        /**
+         * <summary>A SOFT stop that signals the action to stop as soon as possible. Most actions will stop nearly immediately, but input replay actions will finish their list first.
+         * This is called once a segment's criteria have been matched and it is up to each action impl to decide how to implement this as some actions may need to finish a set of inputs before stopping.</summary>
+         */
         public void StopAction(Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
         {
             if (botAction != null)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVImageMouseActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVImageMouseActionData.cs
@@ -343,9 +343,15 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             return false;
         }
 
+        public void AbortAction(int segmentNumber)
+        {
+            // hard stop NOW
+            _isStopped = true;
+        }
+
         public void StopAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
         {
-            // for cv image analysis, we finish the action queue even if criteria match before hand (no-op)
+            // for cv image analysis, we finish the action queue even if criteria match before hand... don't set _isStopped;
         }
 
         public void WriteToStringBuilder(StringBuilder stringBuilder)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
@@ -20,10 +20,20 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public bool ProcessAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities, out string error);
 
         /**
+         * Called when a user or ui stops a playback.
+         * Even for segments with action sequences, they should stop as soon as possible.
+         */
+        public void AbortAction(int segmentNumber);
+
+        /**
          * Called when a segment completes to stop any outstanding actions or mark the action as should stop.
          * For segments with action sequences, they should still finish processing all their actions before stopping.
+         * By default this calls AbortAction(segmentNumber)
          */
-        public void StopAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities);
+        public void StopAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
+        {
+            AbortAction(segmentNumber);
+        }
 
         public void WriteToStringBuilder(StringBuilder stringBuilder);
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
@@ -43,12 +43,10 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         public bool ProcessAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities, out string error)
         {
-
             var result = false;
 
             if (!_isStopped)
             {
-
                 var currentTime = Time.unscaledTime;
 
                 var allInputs = inputData.AllInputsSortedByTime();
@@ -56,7 +54,6 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                 foreach (object input in allInputs)
                 {
                     if (input is KeyboardInputActionData replayKeyboardInputEntry)
-
                     {
                         // if we don't have one of the times, mark that event send as already 'done' so we don't send it
                         if (!replayKeyboardInputEntry.Replay_StartTime.HasValue)
@@ -69,7 +66,6 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                             replayKeyboardInputEntry.Replay_StartEndSentFlags[1] = true;
                         }
 
-
                         // cannot send start and end on same input update for the same key.. that is why these are reversed
                         if (replayKeyboardInputEntry.Replay_StartEndSentFlags[0] && !replayKeyboardInputEntry.Replay_StartEndSentFlags[1] && currentTime >= replayKeyboardInputEntry.Replay_EndTime)
                         {
@@ -78,7 +74,6 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                             KeyboardEventSender.SendKeyEvent(segmentNumber, replayKeyboardInputEntry.Key, KeyState.Up);
                             replayKeyboardInputEntry.Replay_StartEndSentFlags[1] = true;
                         }
-
 
                         if (!replayKeyboardInputEntry.Replay_StartEndSentFlags[0] && currentTime >= replayKeyboardInputEntry.Replay_StartTime)
                         {
@@ -90,7 +85,6 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                     }
                     else if (input is MouseInputActionData replayMouseInputEntry)
                     {
-
                         if (!replayMouseInputEntry.Replay_IsDone && currentTime >= replayMouseInputEntry.Replay_StartTime)
                         {
                             // send event

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/MonkeyBotActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/MonkeyBotActionData.cs
@@ -15,32 +15,32 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
     [JsonConverter(typeof(MonkeyBotActionDataJsonConverter))]
     public class MonkeyBotActionData : IBotActionData
     {
-        [NonSerialized] 
+        [NonSerialized]
         public static readonly BotActionType Type = BotActionType.MonkeyBot;
-        
+
         public int apiVersion = SdkApiVersion.VERSION_6;
         public float actionInterval = 0.05f;
         public RGActionManagerSettings actionSettings;
 
         [NonSerialized]
-        private bool isStopped;
+        private bool _isStopped;
 
-        [NonSerialized] 
-        private RGMonkeyBotLogic monkey;
-        
+        [NonSerialized]
+        private RGMonkeyBotLogic _monkey;
+
         public void StartAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
         {
             var controller = UnityEngine.Object.FindObjectOfType<ReplayDataPlaybackController>();
             RGActionManager.StartSession(controller, actionSettings);
-            monkey = new RGMonkeyBotLogic();
-            monkey.ActionInterval = actionInterval;
+            _monkey = new RGMonkeyBotLogic();
+            _monkey.ActionInterval = actionInterval;
         }
 
         public bool ProcessAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities, out string error)
         {
-            if (!isStopped)
+            if (!_isStopped)
             {
-                bool didAnyAction = monkey.Update();
+                bool didAnyAction = _monkey.Update();
                 error = null;
                 return didAnyAction;
             }
@@ -49,10 +49,10 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             return false;
         }
 
-        public void StopAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
+        public void AbortAction(int segmentNumber)
         {
             RGActionManager.StopSession();
-            isStopped = true;
+            _isStopped = true;
         }
 
         public void WriteToStringBuilder(StringBuilder stringBuilder)
@@ -68,13 +68,13 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         public void ReplayReset()
         {
-            isStopped = false;
-            monkey = null;
+            _isStopped = false;
+            _monkey = null;
         }
 
         public bool IsCompleted()
         {
-            return isStopped;
+            return _isStopped;
         }
 
         public int EffectiveApiVersion()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMouseObjectActionData.cs
@@ -57,16 +57,16 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
          */
         public List<string> preconditionNormalizedPaths = new();
 
-        private bool IsStopped;
+        private bool _isStopped;
 
         public bool IsCompleted()
         {
-            return IsStopped;
+            return _isStopped;
         }
 
         public void ReplayReset()
         {
-            IsStopped = false;
+            _isStopped = false;
         }
 
         public void StartAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
@@ -76,7 +76,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         public bool ProcessAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities, out string error)
         {
-            if (!IsStopped)
+            if (!_isStopped)
             {
                 var now = Time.unscaledTime;
                 if (now - timeBetweenClicks > Replay_LastClickTime)
@@ -297,9 +297,9 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             return false;
         }
 
-        public void StopAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
+        public void AbortAction(int segmentNumber)
         {
-            IsStopped = true;
+            _isStopped = true;
         }
 
         private GUIStyle _guiStyle = null;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/RandomMousePixelActionData.cs
@@ -44,16 +44,16 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         private GUIStyle _guiStyle = null;
 
-        private bool IsStopped;
+        private bool _isStopped;
 
         public bool IsCompleted()
         {
-            return IsStopped;
+            return _isStopped;
         }
 
         public void ReplayReset()
         {
-            IsStopped = false;
+            _isStopped = false;
         }
 
         public void StartAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
@@ -63,7 +63,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         public bool ProcessAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities, out string error)
         {
-            if (!IsStopped)
+            if (!_isStopped)
             {
                 var now = Time.unscaledTime;
                 if (now - timeBetweenClicks > Replay_LastClickTime)
@@ -140,9 +140,9 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             return false;
         }
 
-        public void StopAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
+        public void AbortAction(int segmentNumber)
         {
-            IsStopped = true;
+            _isStopped = true;
         }
 
         public void OnGUI(Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayDataPlaybackController.cs
@@ -166,7 +166,7 @@ namespace RegressionGames.StateRecorder
                 foreach (var nextBotSegment in _nextBotSegments)
                 {
                     // stop any action
-                    nextBotSegment.StopAction(new(), new());
+                    nextBotSegment.AbortAction();
                 }
             }
 
@@ -360,13 +360,13 @@ namespace RegressionGames.StateRecorder
             {
                 var nextBotSegment = _nextBotSegments[i];
 
-                var matched = nextBotSegment.Replay_Matched || KeyFrameEvaluator.Evaluator.Matched( 
-                    i ==0, 
-                    nextBotSegment.Replay_SegmentNumber, 
+                var matched = nextBotSegment.Replay_Matched || KeyFrameEvaluator.Evaluator.Matched(
+                    i ==0,
+                    nextBotSegment.Replay_SegmentNumber,
                     nextBotSegment.Replay_ActionCompleted,
                     nextBotSegment.keyFrameCriteria
                 );
-                
+
                 if (matched)
                 {
                     if (!nextBotSegment.Replay_Matched)
@@ -374,7 +374,7 @@ namespace RegressionGames.StateRecorder
                         nextBotSegment.Replay_Matched = true;
                         // log this the first time
                         RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment - Criteria Matched");
-                        // tell the action that our segment completed
+                        // tell the action that our segment completed and it should stop when it finishes its current actions
                         nextBotSegment.StopAction(transformStatuses, entityStatuses);
                         if (i == 0)
                         {


### PR DESCRIPTION
- Adds API to hard stop bot actions when the User/UI requests a stop.  This is different than the 'soft' stop issued when a segment's criteria match that lets the current action finish before stopping

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
