### PR TITLE
[REG-1884] Don't send 2 of same key in same frame

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
@@ -4,6 +4,7 @@ using System.Text;
 using RegressionGames.StateRecorder.JsonConverters;
 using RegressionGames.StateRecorder.Models;
 using UnityEngine;
+using UnityEngine.InputSystem;
 
 namespace RegressionGames.StateRecorder.BotSegments.Models
 {
@@ -46,10 +47,22 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
             var allInputs = inputData.AllInputsSortedByTime();
 
+            // make sure not to send 2 events for the same key in the same frame Update
+            HashSet<Key> keysSeenThisUpdate = new();
+
+            bool stopKeyboard = false;
+
             foreach (object input in allInputs)
             {
-                if (input is KeyboardInputActionData replayKeyboardInputEntry)
+                if (!stopKeyboard && input is KeyboardInputActionData replayKeyboardInputEntry)
                 {
+                    // if we already sent an event for this key this frame... don't send any other keyboard events this frame or we'll cause issues
+                    if (keysSeenThisUpdate.Contains(replayKeyboardInputEntry.Key))
+                    {
+                        stopKeyboard = true;
+                        continue;
+                    }
+
                     // if we don't have one of the times, mark that event send as already 'done' so we don't send it
                     if (!replayKeyboardInputEntry.Replay_StartTime.HasValue)
                     {
@@ -61,12 +74,13 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                         replayKeyboardInputEntry.Replay_StartEndSentFlags[1] = true;
                     }
 
-                    // cannot send start and end on same input update for the same key.. that is why these are reversed
+                    // cannot send start and end on same input update for the same key.. that is why these are reversed for safety
                     if (replayKeyboardInputEntry.Replay_StartEndSentFlags[0] && !replayKeyboardInputEntry.Replay_StartEndSentFlags[1] && currentTime >= replayKeyboardInputEntry.Replay_EndTime)
                     {
                         // send end event
                         result = true;
                         KeyboardEventSender.SendKeyEvent(segmentNumber, replayKeyboardInputEntry.Key, KeyState.Up);
+                        keysSeenThisUpdate.Add(replayKeyboardInputEntry.Key);
                         replayKeyboardInputEntry.Replay_StartEndSentFlags[1] = true;
                     }
 
@@ -75,12 +89,13 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                         // send start event
                         result = true;
                         KeyboardEventSender.SendKeyEvent(segmentNumber, replayKeyboardInputEntry.Key, KeyState.Down);
+                        keysSeenThisUpdate.Add(replayKeyboardInputEntry.Key);
                         replayKeyboardInputEntry.Replay_StartEndSentFlags[0] = true;
                     }
                 }
-                else if (input is MouseInputActionData replayMouseInputEntry)
-                {
 
+                if (input is MouseInputActionData replayMouseInputEntry)
+                {
                     if (!replayMouseInputEntry.Replay_IsDone && currentTime >= replayMouseInputEntry.Replay_StartTime)
                     {
                         // send event

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardEventSender.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardEventSender.cs
@@ -15,7 +15,7 @@ namespace RegressionGames.StateRecorder
     public static class KeyboardEventSender
     {
         private static bool _isShiftDown;
-        
+
         // Stores the changed state of keys. When the Input System completes an update, this is cleared.
         // If multiple key state changes occur within the same frame, all of these are added to the keyboard event that is sent to the Input System.
         private static Dictionary<Key, KeyState> _keyStates = new Dictionary<Key, KeyState>();
@@ -63,7 +63,7 @@ namespace RegressionGames.StateRecorder
                         inputControl.WriteValueIntoEvent(entry.Value == KeyState.Down ? 1f : 0f, eventPtr);
                     }
                 }
-                
+
                 InputSystem.QueueEvent(eventPtr);
             }
         }
@@ -94,7 +94,7 @@ namespace RegressionGames.StateRecorder
                 RGDebug.LogInfo($"({replaySegment}) Sending Text Event for char: '{value}'");
                 InputSystem.QueueEvent(ref inputEvent);
             }
-            
+
             // If there are active UI input fields, simulate a KeyDown UI event for newly pressed keys
             // This simulation is done directly on the components, because there is no way to directly queue the event to Unity's event manager
             var inputFields = UnityEngine.Object.FindObjectsOfType<InputField>();
@@ -102,7 +102,7 @@ namespace RegressionGames.StateRecorder
             if (inputFields.Length > 0 || tmpInputFields.Length > 0)
             {
                 var keyCode = RGLegacyInputUtils.InputSystemKeyToKeyCode(key);
-                Event evt = CreateUIKeyboardEvent(keyCode, 
+                Event evt = CreateUIKeyboardEvent(keyCode,
                     isShiftDown: _isShiftDown,
                     isCommandDown: IsKeyPressedOrPending(Key.LeftCommand) || IsKeyPressedOrPending(Key.RightCommand),
                     isAltDown: IsKeyPressedOrPending(Key.LeftAlt) || IsKeyPressedOrPending(Key.RightAlt),
@@ -125,32 +125,32 @@ namespace RegressionGames.StateRecorder
         }
 
         /**
-         * Allows updating multiple keys in the same event. 
+         * Allows updating multiple keys in the same event.
          */
         public static void SendKeysInOneEvent(int replaySegment, IDictionary<Key, KeyState> keyStates)
         {
             #if ENABLE_LEGACY_INPUT_MANAGER
             SendKeysInOneEventLegacy(keyStates);
             #endif
-            
-            RGDebug.LogInfo($"({replaySegment}) Sending Multiple Key Event: [" + 
+
+            RGDebug.LogInfo($"({replaySegment}) Sending Multiple Key Event: [" +
                             string.Join(", ", keyStates.Select(a => a.Key + ":" + a.Value).ToArray()) + "]");
-            
+
             foreach (var (key, upOrDown) in keyStates)
             {
                 if (_keyStates.ContainsKey(key))
                 {
                     RGDebug.LogWarning($"KeyboardEventSender - Multiple key events have been sent within one frame for {key}. Only the last state ({upOrDown}) will be kept.");
                 }
-            
+
                 _keyStates[key] = upOrDown;
-                
+
                 if (key == Key.LeftShift || key == Key.RightShift)
                 {
                     _isShiftDown = upOrDown == KeyState.Down;
                 }
             }
-            
+
             QueueKeyboardUpdateEvent();
 
             foreach (var entry in keyStates)
@@ -163,7 +163,7 @@ namespace RegressionGames.StateRecorder
                 }
             }
         }
-        
+
         public static void SendKeyEvent(int replaySegment, Key key, KeyState upOrDown)
         {
             #if ENABLE_LEGACY_INPUT_MANAGER
@@ -179,11 +179,11 @@ namespace RegressionGames.StateRecorder
             {
                 RGDebug.LogWarning($"KeyboardEventSender - Multiple key events have been sent within one frame for {key}. Only the last state ({upOrDown}) will be kept.");
             }
-            
-            RGDebug.LogInfo($"({replaySegment}) Sending Key Event: {key} - {upOrDown}");
-            
+
+            RGDebug.LogInfo($"({replaySegment}) [frame: {Time.frameCount}] - Sending Key Event: {key} - {upOrDown}");
+
             _keyStates[key] = upOrDown;
-            
+
             QueueKeyboardUpdateEvent();
 
             if (upOrDown == KeyState.Down)
@@ -206,7 +206,7 @@ namespace RegressionGames.StateRecorder
                 SendKeyEventLegacy(entry.Key, entry.Value);
             }
         }
-        
+
         private static void SendKeyEventLegacy(Key key, KeyState upOrDown)
         {
             if (RGLegacyInputWrapper.IsPassthrough)
@@ -229,7 +229,7 @@ namespace RegressionGames.StateRecorder
             }
         }
 #endif
-        
+
         /// <summary>
         /// Creates a UnityGUI keyboard event for simulating input events to UI components.
         /// </summary>

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseEventSender.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseEventSender.cs
@@ -223,7 +223,7 @@ namespace RegressionGames.StateRecorder
 
                  if (RGDebug.IsDebugEnabled)
                  {
-                     RGDebug.LogDebug($"({replaySegment}) Sending Mouse Event - {mouseEventString}");
+                     RGDebug.LogDebug($"({replaySegment}) [frame: {Time.frameCount}] - Sending Mouse Event - {mouseEventString}");
                  }
 
                  InputSystem.QueueEvent(eventPtr);


### PR DESCRIPTION
- Stops us from sending 2 events for the same key within the same frame
- Adds the current frame # to event send messages for clarity/debugging
- Test: Close in time, or even intentionally making the end before the start don't write in the same frame

![image](https://github.com/user-attachments/assets/beab9903-e9d0-4e61-9f75-d04583c98c35)

![image](https://github.com/user-attachments/assets/31116daa-6041-42a1-97e2-8a273d511253)


---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
