### PR TITLE
[REG-1883] Update action manager and legacy input unit tests to be more precise

### DIFF
--- a/src/RGUnityBots/Assets/Scenes/ActionManagerTestScene.unity
+++ b/src/RGUnityBots/Assets/Scenes/ActionManagerTestScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:685dc83762de9fef38783e24eb2594f42c8a1740772d68de00d2290543dd8bdb
-size 196863
+oid sha256:c51273e47ddbd5de6e14b453e292f99a416c40b88cd44d35f4e31ca651c06598
+size 190204

--- a/src/RGUnityBots/Assets/Tests/Runtime/RGActionManagerTests.cs
+++ b/src/RGUnityBots/Assets/Tests/Runtime/RGActionManagerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Linq;
 using System.Text;
@@ -6,6 +7,7 @@ using NUnit.Framework;
 using RegressionGames;
 using RegressionGames.ActionManager;
 using RegressionGames.ActionManager.Actions;
+using RegressionGames.RGLegacyInputUtility;
 using RegressionGames.StateRecorder;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -183,9 +185,35 @@ namespace Tests.Runtime
             InputSystem.ResetDevice(MouseEventSender.GetMouse(), true);
         }
 
+        private bool _inputUpdateCompleted = false;
+
+        [SetUp]
+        public void SetupActionManagerTests()
+        {
+            InputSystem.onAfterUpdate += OnAfterInputSystemUpdate;
+        }
+
+        private void OnAfterInputSystemUpdate()
+        {
+            _inputUpdateCompleted = true;
+        }
+        
+        /// <summary>
+        /// Wait for both legacy and new Input System event processing updates to complete, then
+        /// immediately invoke the given callback.
+        /// </summary>
+        private IEnumerator WaitForInputUpdate()
+        {
+            RGLegacyInputWrapper.Update(); // manually trigger a legacy input processing step
+            _inputUpdateCompleted = false;
+            yield return new WaitUntil(() => _inputUpdateCompleted); // wait for new Input System update to complete
+        }
+        
         [UnityTest]
         public IEnumerator TestActionManager()
         {
+            RGLegacyInputWrapper.UpdateMode = RGLegacyInputUpdateMode.MANUAL;
+            
             if (Keyboard.current == null)
             {
                 InputSystem.AddDevice<Keyboard>();
@@ -195,36 +223,32 @@ namespace Tests.Runtime
             
             GameObject eventSystem = GameObject.Find("EventSystem");
             var eventSys = eventSystem.GetComponent<EventSystem>();
-            
+
             // Test Input System Keyboard
+            ResetInputSystem();
             RGActionManager.StartSession(eventSys);
             GameObject inputSysKeyListener = FindGameObject("InputSysKeyListener");
             inputSysKeyListener.SetActive(true);
             try
             {
                 FindAndPerformAction("Any Key", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Keyboard.current.anyKey.wasPressedThisFrame");
-
+                
                 FindAndPerformAction("Key fireKey", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "keyboard[key].isPressed");
                 
                 FindAndPerformAction("Key Key.Backslash", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Keyboard.current.backslashKey.isPressed");
-                
+
                 FindAndPerformAction("Key Key.LeftAlt", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "keyboard.altKey.wasPressedThisFrame");
                 
                 FindAndPerformAction("Key Key.F2", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Keyboard.current[Key.F2].isPressed");
             }
             finally
@@ -242,19 +266,16 @@ namespace Tests.Runtime
             try
             {
                 FindAndPerformAction("Axis \"Mouse X\"", 1);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetAxisRaw(\"Mouse X\")");
                 
                 FindAndPerformAction("Axis \"Mouse ScrollWheel\"", 1);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetAxis(\"Mouse ScrollWheel\")");
                 
                 FindAndPerformAction("Axis axisName", 1);
                 FindAndPerformAction("Axis axisName2", 1);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetAxis(axis)");
             }
             finally
@@ -271,21 +292,17 @@ namespace Tests.Runtime
             try
             {
                 FindAndPerformAction("Button ButtonName", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetButton(ButtonName)");
                 
                 FindAndPerformAction("Button \"Fire1\"", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetButtonDown(btn)");
                 
                 FindAndPerformAction("Button \"Fire2\"", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 FindAndPerformAction("Button \"Fire2\"", false);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetButtonUp(\"Fire2\")");
             }
             finally
@@ -302,37 +319,30 @@ namespace Tests.Runtime
             try
             {
                 FindAndPerformAction("Any Key", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.anyKey");
                 LogAssert.Expect(LogType.Log, "Input.anyKeyDown");
                 
                 FindAndPerformAction("Key _gameSettings.bindings.CrouchKey", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetKey(crouchKey)");
                 
                 FindAndPerformAction("Key _gameSettings.bindings.fireKey", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetKeyDown(_gameSettings.bindings.fireKey)");
                 
                 FindAndPerformAction("Key _gameSettings.bindings.jumpKey", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 FindAndPerformAction("Key _gameSettings.bindings.jumpKey", false);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetKeyUp(_gameSettings.bindings.jumpKey)");
                 
                 FindAndPerformAction("Key KeyCode.LeftShift", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetKey(aimKey)");
                 
                 FindAndPerformAction("Key MOVE_RIGHT_KEY", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetKey(MOVE_RIGHT_KEY)");
             }
             finally
@@ -351,32 +361,26 @@ namespace Tests.Runtime
             {
                 #if ENABLE_LEGACY_INPUT_MANAGER
                 FindAndPerformAction("Mouse Button 0", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetMouseButton(0)");
                 
                 FindAndPerformAction("Mouse Button mouseBtn", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetMouseButtonDown(mouseBtn)");
                 
                 FindAndPerformAction("Mouse Button otherMouseBtn", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 FindAndPerformAction("Mouse Button otherMouseBtn", false);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetMouseButtonUp(btn)");
                 #endif
                 
                 FindAndPerformAction("Mouse Button 3", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Mouse.current.forwardButton.isPressed");
                 
                 FindAndPerformAction("Mouse Button 4", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "mouse.backButton.wasPressedThisFrame");
             }
             finally
@@ -393,19 +397,16 @@ namespace Tests.Runtime
             try
             {
                 FindAndPerformAction("Mouse Position", new Vector2(0.1f, 0.1f));
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 FindAndPerformAction("Mouse Position", new Vector2(0.8f, 0.7f));
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 #if ENABLE_LEGACY_INPUT_MANAGER
                 LogAssert.Expect(LogType.Log, "mousePos1 != lastMousePos1");
                 #endif
                 LogAssert.Expect(LogType.Log, "mousePos2 != lastMousePos2");
 
                 FindAndPerformAction("Mouse Scroll", new Vector2Int(1, 1));
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 #if ENABLE_LEGACY_INPUT_MANAGER
                 LogAssert.Expect(LogType.Log, "Input.mouseScrollDelta.sqrMagnitude");
                 #endif
@@ -427,28 +428,24 @@ namespace Tests.Runtime
             {
                 string hoverAction = "Mouse Hover Over MouseHandlerObject";
                 string pressAction = "Mouse Press On MouseHandlerObject";
-                
+
                 FindAndPerformAction(hoverAction, true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "OnMouseEnter MouseHandlerListener");
                 LogAssert.Expect(LogType.Log, "OnMouseOver MouseHandlerListener");
                 
                 FindAndPerformAction(hoverAction, false);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "OnMouseExit MouseHandlerListener");
                 
                 FindAndPerformAction(pressAction, true);
-                yield return null;
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "OnMouseDown MouseHandlerListener");
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "OnMouseDrag MouseHandlerListener");
                 
                 FindAndPerformAction(pressAction, false);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "OnMouseUpAsButton MouseHandlerListener");
                 LogAssert.Expect(LogType.Log, "OnMouseUp MouseHandlerListener");
             }
@@ -493,8 +490,7 @@ namespace Tests.Runtime
                     inp.Perform();
                 }
 
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 
                 LogAssert.Expect(LogType.Log, "Hit 2D game object The_Square");
             }
@@ -539,8 +535,7 @@ namespace Tests.Runtime
                     inp.Perform();
                 }
 
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 
                 LogAssert.Expect(LogType.Log, "Hit 3D game object The_Cube");
             }
@@ -569,69 +564,56 @@ namespace Tests.Runtime
             try
             {
                 // UI Button Click
-                yield return null;
-                yield return null;
+                yield return null; // wait for one frame for the UI elements to become active
                 FindAndPerformAction("ActionManagerTests.UIHandler.OnBtnClick", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 FindAndPerformAction("ActionManagerTests.UIHandler.OnBtnClick", false);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Clicked button The_Button");
                 
                 // Toggle Click
                 FindAndPerformAction("Press The_Toggle", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 FindAndPerformAction("Press The_Toggle", false);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "The_Toggle changed to True");
                 FindAndPerformAction("Press The_Toggle", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 FindAndPerformAction("Press The_Toggle", false);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "The_Toggle changed to False");
                 
                 // Dropdown Press
                 FindAndPerformAction("Press Dropdown", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 FindAndPerformAction("Press Dropdown", false);
-                yield return RGTestUtils.WaitUntil(() => IsValidAction("Press Item (Dropdown Dropdown)"));
+                yield return WaitForInputUpdate();
+                yield return RGTestUtils.WaitUntil(() => IsValidAction("Press Item (Dropdown Dropdown)"), 5, "Dropdown item did not appear");
                 FindAndPerformAction("Press Item (Dropdown Dropdown)", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 FindAndPerformAction("Press Item (Dropdown Dropdown)", false);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Dropdown value changed");
-                yield return RGTestUtils.WaitUntil(() => GameObject.Find("Dropdown List") == null);
+                yield return RGTestUtils.WaitUntil(() => GameObject.Find("Dropdown List") == null, 5, "Dropdown item did not disappear");
                 
                 // TextMeshPro Dropdown Press
                 FindAndPerformAction("Press TMP_Dropdown", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 FindAndPerformAction("Press TMP_Dropdown", false);
-                yield return RGTestUtils.WaitUntil(() => IsValidAction("Press Item (Dropdown TMP_Dropdown)"));
+                yield return WaitForInputUpdate();
+                yield return RGTestUtils.WaitUntil(() => IsValidAction("Press Item (Dropdown TMP_Dropdown)"), 5, "TMP_Dropdown item did not appear");
                 FindAndPerformAction("Press Item (Dropdown TMP_Dropdown)", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 FindAndPerformAction("Press Item (Dropdown TMP_Dropdown)", false);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "TMP_Dropdown value changed");
-                yield return RGTestUtils.WaitUntil(() => GameObject.Find("Dropdown List") == null);
+                yield return RGTestUtils.WaitUntil(() => GameObject.Find("Dropdown List") == null, 5, "TMP_Dropdown item did not disappear");
                 
                 // InputField text entry
                 FindAndPerformAction("Press InputField", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 FindAndPerformAction("Press InputField", false);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 (Key, bool)[] keyEntryTest = { (Key.H, true), (Key.E, false), (Key.L, false), (Key.L, false), (Key.O, false) };
                 foreach (var (key, shiftPressed) in keyEntryTest)
                 {
@@ -639,24 +621,19 @@ namespace Tests.Runtime
                     if (shiftPressed)
                         keyIndex += 1;
                     FindAndPerformAction("Text Entry InputField", UIInputFieldTextEntryAction.PARAM_FIRST_KEY + keyIndex);
-                    yield return null;
-                    yield return null;
+                    yield return WaitForInputUpdate();
                     FindAndPerformAction("Text Entry InputField", UIInputFieldTextEntryAction.PARAM_NULL);
-                    yield return null;
-                    yield return null;
+                    yield return WaitForInputUpdate();
                 }
                 FindAndPerformAction("Text Submit InputField", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "InputField submitted with text Hello");
                 
                 // TextMeshPro InputField text entry
                 FindAndPerformAction("Press TMP_InputField", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 FindAndPerformAction("Press TMP_InputField", false);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 (Key, bool)[] keyEntryTest2 = { (Key.W, true), (Key.O, false), (Key.R, false), (Key.L, false), (Key.D, false) };
                 foreach (var (key, shiftPressed) in keyEntryTest2)
                 {
@@ -664,47 +641,36 @@ namespace Tests.Runtime
                     if (shiftPressed)
                         keyIndex += 1;
                     FindAndPerformAction("Text Entry TMP_InputField", UIInputFieldTextEntryAction.PARAM_FIRST_KEY + keyIndex);
-                    yield return null;
-                    yield return null;
+                    yield return WaitForInputUpdate();
                     FindAndPerformAction("Text Entry TMP_InputField", UIInputFieldTextEntryAction.PARAM_NULL);
-                    yield return null;
-                    yield return null;
+                    yield return WaitForInputUpdate();
                 }
                 FindAndPerformAction("Text Submit TMP_InputField", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "TMP_InputField submitted with text World");
                 
                 // Horizontal Slider Movement
                 FindAndPerformAction("Press Slider_Horizontal", 0.25f);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 FindAndPerformAction("Release Slider_Horizontal", 0.25f);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Slider_Horizontal changed to first half");
                 FindAndPerformAction("Press Slider_Horizontal", 0.75f);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 FindAndPerformAction("Release Slider_Horizontal", 0.75f);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Slider_Horizontal changed to second half");
                 
                 // Vertical Slider Movement
                 FindAndPerformAction("Press Slider_Vertical", 0.25f);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 FindAndPerformAction("Release Slider_Vertical", 0.25f);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Slider_Vertical changed to first half");
                 FindAndPerformAction("Press Slider_Vertical", 0.75f);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 FindAndPerformAction("Release Slider_Vertical", 0.75f);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Slider_Vertical changed to second half");
 
                 // Scrollbar tests do not work when running in the CI pipeline, only run these locally
@@ -712,34 +678,30 @@ namespace Tests.Runtime
                 {
                     // Horizontal Scrollbar Movement
                     FindAndPerformAction("Press Scrollbar_Horizontal", 0.25f);
-                    yield return null;
-                    yield return null;
+                    yield return WaitForInputUpdate();
+                    yield return null; // need to wait an extra frame for dragging the scrollbar
                     FindAndPerformAction("Release Scrollbar_Horizontal", 0.25f);
-                    yield return null;
-                    yield return null;
+                    yield return WaitForInputUpdate();
                     LogAssert.Expect(LogType.Log, "Scrollbar_Horizontal changed to first half");
                     FindAndPerformAction("Press Scrollbar_Horizontal", 0.75f);
-                    yield return null;
-                    yield return null;
+                    yield return WaitForInputUpdate();
+                    yield return null; // need to wait an extra frame for dragging the scrollbar
                     FindAndPerformAction("Release Scrollbar_Horizontal", 0.75f);
-                    yield return null;
-                    yield return null;
+                    yield return WaitForInputUpdate();
                     LogAssert.Expect(LogType.Log, "Scrollbar_Horizontal changed to second half");
-                
+                    
                     // Vertical Scrollbar Movement
                     FindAndPerformAction("Press Scrollbar_Vertical", 0.25f);
-                    yield return null;
-                    yield return null;
+                    yield return WaitForInputUpdate();
+                    yield return null; // need to wait an extra frame for dragging the scrollbar
                     FindAndPerformAction("Release Scrollbar_Vertical", 0.25f);
-                    yield return null;
-                    yield return null;
+                    yield return WaitForInputUpdate();
                     LogAssert.Expect(LogType.Log, "Scrollbar_Vertical changed to first half");
                     FindAndPerformAction("Press Scrollbar_Vertical", 0.75f);
-                    yield return null;
-                    yield return null;
+                    yield return WaitForInputUpdate();
+                    yield return null; // need to wait an extra frame for dragging the scrollbar
                     FindAndPerformAction("Release Scrollbar_Vertical", 0.75f);
-                    yield return null;
-                    yield return null;
+                    yield return WaitForInputUpdate();
                     LogAssert.Expect(LogType.Log, "Scrollbar_Vertical changed to second half");
                 }
             }
@@ -760,10 +722,8 @@ namespace Tests.Runtime
             interprocObj.SetActive(true);
             try
             {
-                yield return null;
                 FindAndPerformAction("Key jumpKeyCode", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Player jumped");
             }
             finally
@@ -779,28 +739,24 @@ namespace Tests.Runtime
             inputActionListener.SetActive(true);
             try
             {
-                yield return null;
+                yield return null; // wait one frame for the InputActions to become active
+                
                 FindAndPerformAction("InputAction Move", new Vector2Int(1, 1));
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "moveVal.sqrMagnitude");
 
                 FindAndPerformAction("InputAction Jump", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "jumpAction.IsPressed()");
 
                 FindAndPerformAction("InputAction Fire", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "fireAction pressed this frame");
 
                 FindAndPerformAction("InputAction Aim", new Vector2Int(-1, -1));
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 FindAndPerformAction("InputAction Aim", new Vector2Int(1, 1));
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Aim changed");
             }
             finally
@@ -817,20 +773,18 @@ namespace Tests.Runtime
             csWrapperListener.SetActive(true);
             try
             {
-                yield return null;
+                yield return null; // wait one frame for the InputActions to become active
+                
                 FindAndPerformAction("InputAction Crouch", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Crouch pressed");
                 
                 FindAndPerformAction("InputAction Horizontal", 1);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "horizVal > 0");
                 
                 FindAndPerformAction("InputAction Horizontal", -1);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "horizVal < 0");
             }
             finally
@@ -846,23 +800,20 @@ namespace Tests.Runtime
             playerInputListener.SetActive(true);
             try
             {
-                yield return null;
+                yield return null; // wait one frame for the InputActions to become active
+                
                 FindAndPerformAction("InputAction Move", new Vector2Int(1, 1));
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "OnMove()");
                 
                 FindAndPerformAction("InputAction Jump", true);
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "OnJump()");
                 
                 FindAndPerformAction("InputAction Aim", new Vector2Int(-1, -1));
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 FindAndPerformAction("InputAction Aim", new Vector2Int(1, 1));
-                yield return null;
-                yield return null;
+                yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "OnAim()");
             }
             finally

--- a/src/RGUnityBots/Assets/Tests/Runtime/RGLegacyInputSimulationTests.cs
+++ b/src/RGUnityBots/Assets/Tests/Runtime/RGLegacyInputSimulationTests.cs
@@ -1,17 +1,11 @@
 ﻿#if ENABLE_LEGACY_INPUT_MANAGER
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using NUnit.Framework;
-using NUnit.Framework.Interfaces;
-using NUnit.Framework.Internal;
 using RegressionGames;
 using RegressionGames.RGLegacyInputUtility;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
-using Object = UnityEngine.Object;
 
 namespace Tests.Runtime
 {
@@ -22,6 +16,7 @@ namespace Tests.Runtime
             RGLegacyInputWrapper.StopSimulation();
             GameObject eventSystem = GameObject.Find("EventSystem");
             var eventSys = eventSystem.GetComponent<EventSystem>();
+            RGLegacyInputWrapper.UpdateMode = RGLegacyInputUpdateMode.MANUAL;
             RGLegacyInputWrapper.StartSimulation(eventSys);
         }
         
@@ -48,8 +43,10 @@ namespace Tests.Runtime
                 RGLegacyInputWrapper.SimulateMouseMovement(new Vector3(pos.x, pos.y, 0.0f));
                 RGLegacyInputWrapper.SimulateKeyPress(KeyCode.Mouse0);
                 yield return null;
+                RGLegacyInputWrapper.Update();
                 RGLegacyInputWrapper.SimulateKeyRelease(KeyCode.Mouse0);
                 yield return null;
+                RGLegacyInputWrapper.Update();
                 yield return null;
                 AssertLogMessagesPresent("ClickedHandler()");
             }
@@ -58,11 +55,11 @@ namespace Tests.Runtime
             {
                 ResetState();
                 RGLegacyInputWrapper.SimulateKeyPress(KeyCode.X);
-                yield return null;
+                RGLegacyInputWrapper.Update();
                 yield return null;
                 AssertLogMessagesPresent("GetKey(X)", "GetKeyDown(\"x\")", "anyKey", "anyKeyDown");
                 RGLegacyInputWrapper.SimulateKeyRelease(KeyCode.X);
-                yield return null;
+                RGLegacyInputWrapper.Update();
                 yield return null;
                 AssertLogMessagesPresent("GetKeyUp(X)");
             }
@@ -90,22 +87,22 @@ namespace Tests.Runtime
                 
                     RGLegacyInputWrapper.SimulateMouseMovement(new Vector3(screenPt.x, screenPt.y, 0));
                     yield return null;
-                    yield return null;
                     AssertLogMessagesPresent(
                         $"{objName} OnMouseEnter()",
                         "GetAxisRaw(\"Mouse X\") != 0.0f",
                         "GetAxisRaw(\"Mouse Y\") != 0.0f");
 
                     RGLegacyInputWrapper.SimulateKeyPress(KeyCode.Mouse0);
-                    yield return null;
+                    RGLegacyInputWrapper.Update();
                     yield return null;
                     AssertLogMessagesPresent($"{objName} OnMouseDown()");
 
+                    RGLegacyInputWrapper.Update();
                     yield return null;
                     AssertLogMessagesPresent($"{objName} OnMouseDrag()");
 
                     RGLegacyInputWrapper.SimulateKeyRelease(KeyCode.Mouse0);
-                    yield return null;
+                    RGLegacyInputWrapper.Update();
                     yield return null;
 
                     AssertLogMessagesPresent($"{objName} OnMouseUp()", 
@@ -113,24 +110,24 @@ namespace Tests.Runtime
                         "GetMouseButtonUp(0)");
 
                     RGLegacyInputWrapper.SimulateMouseMovement(Vector3.zero);
-                    yield return null;
+                    RGLegacyInputWrapper.Update();
                     yield return null;
 
                     AssertLogMessagesPresent($"{objName} OnMouseExit()");
                 }
 
                 RGLegacyInputWrapper.SimulateMouseScrollWheel(new Vector2(-2.0f, 10.0f));
-                yield return null;
+                RGLegacyInputWrapper.Update();
                 yield return null;
                 AssertLogMessagesPresent("GetAxisRaw(\"Mouse ScrollWheel\") > 0.0f", "mouseScrollDelta.x < 0.0f");
 
                 RGLegacyInputWrapper.SimulateKeyPress(KeyCode.Mouse1);
-                yield return null;
+                RGLegacyInputWrapper.Update();
                 yield return null;
                 AssertLogMessagesPresent("GetMouseButtonDown(1)");
             
                 RGLegacyInputWrapper.SimulateKeyPress(KeyCode.Mouse2);
-                yield return null;
+                RGLegacyInputWrapper.Update();
                 yield return null;
                 AssertLogMessagesPresent("GetMouseButton(2)");
             }
@@ -140,25 +137,25 @@ namespace Tests.Runtime
                 ResetState();
             
                 RGLegacyInputWrapper.SimulateKeyPress(KeyCode.RightArrow);
-                yield return null;
+                RGLegacyInputWrapper.Update();
                 yield return null;
                 AssertLogMessagesPresent("GetAxis(\"Horizontal\") > 0.0f");
                 RGLegacyInputWrapper.SimulateKeyRelease(KeyCode.RightArrow);
             
                 RGLegacyInputWrapper.SimulateKeyPress(KeyCode.LeftArrow);
-                yield return null;
+                RGLegacyInputWrapper.Update();
                 yield return null;
                 AssertLogMessagesPresent("GetAxis(\"Horizontal\") < 0.0f");
                 RGLegacyInputWrapper.SimulateKeyRelease(KeyCode.LeftArrow);
             
                 RGLegacyInputWrapper.SimulateKeyPress(KeyCode.UpArrow);
-                yield return null;
+                RGLegacyInputWrapper.Update();
                 yield return null;
                 AssertLogMessagesPresent("GetAxisRaw(\"Vertical\") > 0.0f");
                 RGLegacyInputWrapper.SimulateKeyRelease(KeyCode.UpArrow);
             
                 RGLegacyInputWrapper.SimulateKeyPress(KeyCode.DownArrow);
-                yield return null;
+                RGLegacyInputWrapper.Update();
                 yield return null;
                 AssertLogMessagesPresent("GetAxisRaw(\"Vertical\") < 0.0f");
                 RGLegacyInputWrapper.SimulateKeyRelease(KeyCode.DownArrow);
@@ -169,17 +166,17 @@ namespace Tests.Runtime
                 ResetState();
             
                 RGLegacyInputWrapper.SimulateKeyPress(KeyCode.Space);
-                yield return null;
+                RGLegacyInputWrapper.Update();
                 yield return null;
                 AssertLogMessagesPresent("GetButton(\"Jump\")");
             
                 RGLegacyInputWrapper.SimulateKeyRelease(KeyCode.Space);
-                yield return null;
+                RGLegacyInputWrapper.Update();
                 yield return null;
                 AssertLogMessagesPresent("GetButtonUp(\"Jump\")");
             
                 RGLegacyInputWrapper.SimulateKeyPress(KeyCode.LeftControl);
-                yield return null;
+                RGLegacyInputWrapper.Update();
                 yield return null;
                 AssertLogMessagesPresent("GetButtonDown(\"Fire1\")");
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGLegacyInputUtility/RGLegacyInputWrapper.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGLegacyInputUtility/RGLegacyInputWrapper.cs
@@ -8,7 +8,8 @@ using UnityEngine;
 namespace RegressionGames.RGLegacyInputUtility
 {
     /// <summary>
-    /// Update mode used as parameter to StartSimulation()
+    /// Update mode of RGLegacyInputWrapper.
+    /// Default is AUTOMATIC.
     /// </summary>
     public enum RGLegacyInputUpdateMode
     {

--- a/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/RGTestUtils.cs
+++ b/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/RGTestUtils.cs
@@ -50,13 +50,14 @@ namespace RegressionGames
         /// </summary>
         /// <param name="condition">The condition that should become true</param>
         /// <param name="timeout">Maximum time to wait for the condition to become true (in seconds)</param>
-        public static IEnumerator WaitUntil(Func<bool> condition, int timeout = 5)
+        /// <param name="message">Message to display upon failure (optional)</param>
+        public static IEnumerator WaitUntil(Func<bool> condition, int timeout = 5, string message = null)
         {
             var startTime = Time.unscaledTime;
             bool result;
             while (!(result = condition()) && Time.unscaledTime - startTime < timeout)
                 yield return null;
-            Assert.IsTrue(result, $"Condition did not become true within {timeout} seconds");
+            Assert.IsTrue(result, message ?? $"Condition did not become true within {timeout} seconds");
         }
 
         /// <summary>


### PR DESCRIPTION
This PR updates the unit tests for the action manager and legacy input support to be more precise and wait for the minimum amount of frames needed for actions to take place (previously, the tests were imprecise and waited for 2-4 frames with the hope that it was enough for the event processing to take place).

Changes:
1. Add the ability to manually invoke the update loop of the legacy input support, so that the tests can have more precise control over when the update happens.
2. Minimize the number of frames waited for as much as possible, and add comments indicating why extra frames are waited for. For tests about the new Input System, the tests now specifically wait for an update step to complete rather than waiting an arbitrary number of frames.

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
