### PR TITLE
[REG-1846] SDK Bug Fixes for Blue Flower Testing

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
@@ -359,11 +359,11 @@ namespace RegressionGames.StateRecorder.BotSegments
             {
                 var nextBotSegment = _nextBotSegments[i];
 
-                var matched = nextBotSegment.Replay_Matched || KeyFrameEvaluator.Evaluator.Matched(
+                var matched = nextBotSegment.Replay_Matched || nextBotSegment.endCriteria == null || nextBotSegment.endCriteria.Count == 0 || KeyFrameEvaluator.Evaluator.Matched(
                     i ==0,
                     nextBotSegment.Replay_SegmentNumber,
                     nextBotSegment.Replay_ActionCompleted,
-                    nextBotSegment.keyFrameCriteria
+                    nextBotSegment.endCriteria
                 );
 
                 if (matched)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotSegmentJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotSegmentJsonConverter.cs
@@ -26,7 +26,21 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
             botSegment.sessionId = jObject.GetValue("sessionId")?.ToObject<string>(serializer) ?? Guid.NewGuid().ToString("n");
             botSegment.apiVersion = jObject.GetValue("apiVersion").ToObject<int>(serializer);
             botSegment.botAction = jObject.GetValue("botAction").ToObject<BotAction>(serializer);
-            botSegment.keyFrameCriteria = new List<KeyFrameCriteria>(jObject.GetValue("keyFrameCriteria").ToObject<KeyFrameCriteria[]>(serializer));
+            if (jObject.ContainsKey("keyFrameCriteria"))
+            {
+                // backwards compatibility before we renamed keyFrameCriteria to endCriteria
+                botSegment.endCriteria = new List<KeyFrameCriteria>(jObject.GetValue("keyFrameCriteria").ToObject<KeyFrameCriteria[]>(serializer));
+            }
+            else if (jObject.ContainsKey("endCriteria"))
+            {
+                botSegment.endCriteria = new List<KeyFrameCriteria>(jObject.GetValue("endCriteria").ToObject<KeyFrameCriteria[]>(serializer));
+            }
+            else
+            {
+                // default value of endCriteria to empty list if not present
+                botSegment.endCriteria = new List<KeyFrameCriteria>();
+            }
+
             return botSegment;
         }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/NormalizedPathCriteriaEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/NormalizedPathCriteriaEvaluator.cs
@@ -73,8 +73,11 @@ namespace RegressionGames.StateRecorder.BotSegments
                     }
                     else
                     {
-                        // else - criteria not met - false
-                        matched = $"NormalizedPath (WorldSpace) - {normalizedPath} - missing object";
+                        // unless this was supposed to be zero or less than zero ... criteria not met
+                        if (! (criteriaPathData.countRule == CountRule.Zero || (criteriaPathData.countRule == CountRule.LessThanEqual && criteriaPathData.count <= 0)))
+                        {
+                            matched = $"NormalizedPath (WorldSpace) - {normalizedPath} - missing object";
+                        }
                     }
 
                 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/PartialNormalizedPathCriteriaEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/PartialNormalizedPathCriteriaEvaluator.cs
@@ -79,8 +79,11 @@ namespace RegressionGames.StateRecorder.BotSegments
                     }
                     else
                     {
-                        // else - criteria not met - false
-                        matched = $"PartialNormalizedPath (WorldSpace) - {partialNormalizedPath} - missing object";
+                        // unless this was supposed to be zero or less than zero ... criteria not met
+                        if (! (criteriaPathData.countRule == CountRule.Zero || (criteriaPathData.countRule == CountRule.LessThanEqual && criteriaPathData.count <= 0)))
+                        {
+                            matched = $"PartialNormalizedPath (WorldSpace) - {partialNormalizedPath} - missing object";
+                        }
                     }
 
                 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/KeyboardInputActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/KeyboardInputActionData.cs
@@ -15,7 +15,7 @@ namespace RegressionGames.StateRecorder.Models
     public class KeyboardInputActionData
     {
         // version of this schema, update this if fields change
-        public int apiVersion = SdkApiVersion.VERSION_12;
+        public int apiVersion = SdkApiVersion.VERSION_15;
 
         //These 2 fields look a bit weird, but there is a reason.  We always track the start time for these actions during record, but only write it out
         // to json aon the first tick it occurs.  Then on replay, we need to be able to read in those null values correctly
@@ -37,8 +37,6 @@ namespace RegressionGames.StateRecorder.Models
 
         public bool HasBeenSent;
 
-        public bool isPressed => duration > 0 && endTime == null;
-
         // re-usable and large enough to fit ball sizes
         private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(5_000));
 
@@ -49,12 +47,10 @@ namespace RegressionGames.StateRecorder.Models
             stringBuilder.Append(",\"startTime\":");
             // only send the startTime once.. we can have start and end in the same tick, or different ticks, we can even have ticks in between with neither start or end time while the button is held
             DoubleJsonConverter.WriteToStringBuilderNullable(stringBuilder, JsonStartTime);
-            stringBuilder.Append(",\"binding\":");
-            StringJsonConverter.WriteToStringBuilder(stringBuilder, binding);
             stringBuilder.Append(",\"endTime\":");
             DoubleJsonConverter.WriteToStringBuilderNullable(stringBuilder, endTime);
-            stringBuilder.Append(",\"isPressed\":");
-            BooleanJsonConverter.WriteToStringBuilder(stringBuilder, isPressed);
+            stringBuilder.Append(",\"binding\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, binding);
             stringBuilder.Append("}");
         }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -322,13 +322,13 @@ namespace RegressionGames.StateRecorder
             {
                 gameFacePixelHashObserver.SetActive(true);
             }
-            
+
             RGSettings rgSettings = RGSettings.GetOrCreateSettings();
             if (rgSettings.GetFeatureCodeCoverage())
             {
                 RGCodeCoverage.StartRecording();
             }
-            
+
             StartCoroutine(StartRecordingCoroutine(referenceSessionId));
 
         }
@@ -401,7 +401,7 @@ namespace RegressionGames.StateRecorder
             _tokenSource?.Cancel();
             _tokenSource?.Dispose();
             _tokenSource = null;
-            
+
             RGSettings rgSettings = RGSettings.GetOrCreateSettings();
             if (rgSettings.GetFeatureCodeCoverage())
             {
@@ -548,7 +548,7 @@ namespace RegressionGames.StateRecorder
                         var botSegment = new BotSegment()
                         {
                             sessionId = _currentSessionId,
-                            keyFrameCriteria = keyFrameCriteria,
+                            endCriteria = keyFrameCriteria,
                             botAction = new BotAction()
                             {
                                 type = BotActionType.InputPlayback,
@@ -570,9 +570,9 @@ namespace RegressionGames.StateRecorder
 
                         _lastCvFrameTime = now;
                         _frameCountSinceLastTick = 0;
-                        
+
                         RecordingCodeCoverageState codeCoverageState = null;
-                        
+
                         RGSettings rgSettings = RGSettings.GetOrCreateSettings();
                         bool codeCovEnabled = rgSettings.GetFeatureCodeCoverage();
                         if (codeCovEnabled)
@@ -599,7 +599,7 @@ namespace RegressionGames.StateRecorder
                             performance = performanceMetrics,
                             pixelHash = pixelHash,
                             state = currentStates.Values,
-                            codeCoverage = codeCoverageState, 
+                            codeCoverage = codeCoverageState,
                             inputs = inputData
                         };
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/SdkApiVersion.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/SdkApiVersion.cs
@@ -58,9 +58,17 @@
          * <summary>add code coverage recording support</summary>
          */
         public const int VERSION_13 = 13;
-        
+
+        /**
+         * <summary>
+         * rename 'keyFrameCriteria' to 'endCriteria' in json and allow empty/null criteria for segments
+         * remove 'isPressed' from keyboardInputActionData
+         * </summary>
+         */
+        public const int VERSION_15 = 15;
+
 
         // Update this when new features are used in the SDK
-        public const int CURRENT_VERSION = VERSION_13;
+        public const int CURRENT_VERSION = VERSION_15;
     }
 }


### PR DESCRIPTION
- Fixes various SDK bugs / improvement areas found in blue flower testing
  - Handles uncaught bot segment errors better by ending the bot segment
  - Fixes a case where bot action errors weren't clearing their on screen error once they succeeded
  - Removes unused `isPressed` field from KeyboardInputActionData
    - Also re-orders the botsegment recording field order for easier editing
  - Renames `keyFrameCriteria` to `endCriteria` (backwards compatible) for bot segments due to repeated mis-understanding of when those criteria are evaluated... Hopefully the new name helps self explain that this is the end condition for the segment. 
  - Adds support for null/empty criteria bot segments

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
