### PR TITLE
[REG-1907] SDK Cleanup to Finalize Blue Flower Tests

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentZipParser.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentZipParser.cs
@@ -87,6 +87,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                     using var sr = new StreamReader(entry.Open());
 
                     var fileText = sr.ReadToEnd();
+                    badSegmentName = entry.FullName;
 
                     try
                     {
@@ -135,28 +136,25 @@ namespace RegressionGames.StateRecorder.BotSegments
                         }
                         catch (Exception ex)
                         {
-                            throw new Exception($"Invalid/missing file data while parsing BotSegment or BotSegmentList from zip file path: {zipFilePath} at entry: {entry.Name}", ex);
+                            throw new Exception($"Invalid/missing file data in BotSegment or BotSegmentList", ex);
                         }
                     }
-
-                    badSegmentName = entry.FullName;
                 }
             }
             catch (Exception e)
             {
-                // Failed to parse the json.  End user doesn't really need this message, this is for developers at RG creating new bot segment types.. we give them a for real exception below
-                throw new Exception($"Exception while parsing bot segments zip: {zipFilePath}", e);
+                throw new Exception($"Exception parsing bot segments zip: {zipFilePath} at segment: {badSegmentName}", e);
             }
 
             if (versionMismatch > 0)
             {
-                throw new Exception($"Error parsing bot segments .zip at segment: {badSegmentName}.  File contains segments which require SDK version {versionMismatch}, but currently installed SDK version is {SdkApiVersion.CURRENT_VERSION}");
+                throw new Exception($"Error parsing bot segments zip: {zipFilePath} at segment: {badSegmentName}.  File contains segments which require SDK version {versionMismatch}, but currently installed SDK version is {SdkApiVersion.CURRENT_VERSION}");
             }
 
             if (results.Count == 0)
             {
                 // entries was empty
-                throw new Exception($"Error parsing bot segments .zip at segment: {badSegmentName}.  Must include at least 1 bot segment json.  Ensure you are loading a valid 'bot_segments.zip' file.");
+                throw new Exception($"Error parsing bot segments zip: {zipFilePath} at segment: {badSegmentName}.  Must include at least 1 bot segment json.  Ensure you are loading a valid 'bot_segments.zip' file.");
             }
 
             return results;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
@@ -280,6 +280,11 @@ namespace RegressionGames.StateRecorder.BotSegments
                     // if starting to play, or on loop 1.. start recording
                     if (_loopCount < 2)
                     {
+                        var gameFacePixelHashObserver = GameFacePixelHashObserver.GetInstance();
+                        if (gameFacePixelHashObserver != null)
+                        {
+                            gameFacePixelHashObserver.SetActive(true);
+                        }
                         _screenRecorder.StartRecording(_dataPlaybackContainer.SessionId);
                     }
                 }
@@ -387,7 +392,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                         {
                             nextBotSegment.Replay_Matched = true;
                             // log this the first time
-                            RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment - Criteria Matched");
+                            RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment - Criteria Matched - {nextBotSegment.name} - {nextBotSegment.description}");
                             // tell the action that our segment completed and it should stop when it finishes its current actions
                             nextBotSegment.StopAction(transformStatuses, entityStatuses);
                             if (i == 0)
@@ -415,7 +420,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                         if (nextBotSegment.Replay_ActionStarted && nextBotSegment.Replay_ActionCompleted)
                         {
                             _lastTimeLoggedKeyFrameConditions = now;
-                            RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment - Completed");
+                            RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment - Completed - {nextBotSegment.name} - {nextBotSegment.description}");
                             //Process the inputs from that bot segment if necessary
                             _nextBotSegments.RemoveAt(i);
                         }
@@ -452,7 +457,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                         {
                             _lastTimeLoggedKeyFrameConditions = now;
                             FindObjectOfType<ReplayToolbarManager>()?.SetKeyFrameWarningText(null);
-                            RGDebug.LogInfo($"({next.Replay_SegmentNumber}) - Bot Segment - Added {(next.HasTransientCriteria ? "" : "Non-")}Transient BotSegment for Evaluation after Transient BotSegment");
+                            RGDebug.LogInfo($"({next.Replay_SegmentNumber}) - Bot Segment - Added {(next.HasTransientCriteria ? "" : "Non-")}Transient BotSegment for Evaluation after Transient BotSegment - {next.name} - {next.description}");
                             _nextBotSegments.Add(next);
                         }
                     }
@@ -465,7 +470,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                     {
                         _lastTimeLoggedKeyFrameConditions = now;
                         FindObjectOfType<ReplayToolbarManager>()?.SetKeyFrameWarningText(null);
-                        RGDebug.LogInfo($"({next.Replay_SegmentNumber}) - Bot Segment - Added {(next.HasTransientCriteria ? "" : "Non-")}Transient BotSegment for Evaluation");
+                        RGDebug.LogInfo($"({next.Replay_SegmentNumber}) - Bot Segment - Added {(next.HasTransientCriteria ? "" : "Non-")}Transient BotSegment for Evaluation - {next.name} - {next.description}");
                         _nextBotSegments.Add(next);
                     }
                 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BehaviourActionDataJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BehaviourActionDataJsonConverter.cs
@@ -20,7 +20,10 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
             // ReSharper disable once UseObjectOrCollectionInitializer - easier to debug lines without this
             BehaviourActionData data = new();
             data.behaviourFullName = jObject.GetValue("behaviourFullName").ToObject<string>(serializer);
-            data.apiVersion = jObject.GetValue("apiVersion").ToObject<int>();
+            if (jObject.ContainsKey("apiVersion"))
+            {
+                data.apiVersion = jObject.GetValue("apiVersion").ToObject<int>();
+            }
             data.maxRuntimeSeconds = jObject.GetValue("maxRuntimeSeconds").ToObject<float>(serializer);
             return data;
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotSegmentJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotSegmentJsonConverter.cs
@@ -24,8 +24,11 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
             botSegment.description = jObject.GetValue("description")?.ToObject<string>(serializer) ?? "";
             // allow sessionId to be null/undefined in the file... so manually created segments don't have to generate one
             botSegment.sessionId = jObject.GetValue("sessionId")?.ToObject<string>(serializer) ?? Guid.NewGuid().ToString("n");
-            botSegment.apiVersion = jObject.GetValue("apiVersion").ToObject<int>(serializer);
-            botSegment.botAction = jObject.GetValue("botAction").ToObject<BotAction>(serializer);
+            if (jObject.ContainsKey("apiVersion"))
+            {
+                botSegment.apiVersion = jObject.GetValue("apiVersion").ToObject<int>(serializer);
+            }
+            botSegment.botAction = jObject.GetValue("botAction")?.ToObject<BotAction>(serializer);
             if (jObject.ContainsKey("keyFrameCriteria"))
             {
                 // backwards compatibility before we renamed keyFrameCriteria to endCriteria

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/CVImageMouseActionDataJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/CVImageMouseActionDataJsonConverter.cs
@@ -20,7 +20,10 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
                 JObject jObject = JObject.Load(reader);
                 // ReSharper disable once UseObjectOrCollectionInitializer - easier to debug when on separate lines
                 CVImageMouseActionData actionModel = new();
-                actionModel.apiVersion = jObject.GetValue("apiVersion").ToObject<int>(serializer);
+                if (jObject.ContainsKey("apiVersion"))
+                {
+                    actionModel.apiVersion = jObject.GetValue("apiVersion").ToObject<int>(serializer);
+                }
                 actionModel.imageData = jObject.GetValue("imageData").ToObject<string>(serializer);
                 actionModel.withinRect = jObject.GetValue("withinRect")?.ToObject<CVWithinRect>(serializer);
                 actionModel.actions = jObject.GetValue("actions").ToObject<List<CVMouseActionDetails>>(serializer);

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/KeyFrameCriteriaJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/KeyFrameCriteriaJsonConverter.cs
@@ -17,7 +17,11 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
             JObject jObject = JObject.Load(reader);
             KeyFrameCriteria criteria = new();
             criteria.transient = jObject["transient"].ToObject<bool>();
-            criteria.apiVersion = jObject["apiVersion"].ToObject<int>();
+            if (jObject.ContainsKey("apiVersion"))
+            {
+                criteria.apiVersion = jObject["apiVersion"].ToObject<int>();
+            }
+
             criteria.type = jObject["type"].ToObject<KeyFrameCriteriaType>();
             IKeyFrameCriteriaData data = null;
             switch (criteria.type)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/MonkeyBotActionDataJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/MonkeyBotActionDataJsonConverter.cs
@@ -12,7 +12,11 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
         {
             JObject jObject = JObject.Load(reader);
             MonkeyBotActionData data = new MonkeyBotActionData();
-            data.apiVersion = jObject["apiVersion"].ToObject<int>();
+            if (jObject.ContainsKey("apiVersion"))
+            {
+                data.apiVersion = jObject["apiVersion"].ToObject<int>();
+            }
+
             data.actionInterval = jObject["actionInterval"].ToObject<float>();
             data.actionSettings = jObject["actionSettings"].ToObject<RGActionManagerSettings>();
             return data;
@@ -22,9 +26,9 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
         {
             return typeof(MonkeyBotActionData).IsAssignableFrom(objectType);
         }
-        
+
         public override bool CanWrite => false;
-        
+
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             throw new NotImplementedException();

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/RandomMouseObjectActionDataJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/RandomMouseObjectActionDataJsonConverter.cs
@@ -19,7 +19,11 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
             JObject jObject = JObject.Load(reader);
             RandomMouseObjectActionData data = new();
             data.screenSize = jObject.GetValue("screenSize").ToObject<Vector2Int>(serializer);
-            data.apiVersion = jObject.GetValue("apiVersion").ToObject<int>();
+            if (jObject.ContainsKey("apiVersion"))
+            {
+                data.apiVersion = jObject.GetValue("apiVersion").ToObject<int>();
+            }
+
             data.allowDrag = jObject.GetValue("allowDrag").ToObject<bool>();
             data.timeBetweenClicks = jObject.GetValue("timeBetweenClicks").ToObject<float>();
             data.excludedAreas = jObject.GetValue("excludedAreas").ToObject<List<RectInt>>();

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/RandomMousePixelActionDataJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/RandomMousePixelActionDataJsonConverter.cs
@@ -19,7 +19,11 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
             JObject jObject = JObject.Load(reader);
             RandomMousePixelActionData data = new();
             data.screenSize = jObject.GetValue("screenSize").ToObject<Vector2Int>(serializer);
-            data.apiVersion = jObject.GetValue("apiVersion").ToObject<int>();
+            if (jObject.ContainsKey("apiVersion"))
+            {
+                data.apiVersion = jObject.GetValue("apiVersion").ToObject<int>();
+            }
+
             data.timeBetweenClicks = jObject.GetValue("timeBetweenClicks").ToObject<float>();
             data.excludedAreas = jObject.GetValue("excludedAreas").ToObject<List<RectInt>>();
             return data;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -46,7 +46,7 @@ namespace RegressionGames.StateRecorder
 
         private static ScreenRecorder _this;
 
-        private bool _isRecording;
+        public bool IsRecording { get; private set; }
 
         private bool _usingIOSMetalGraphics = false;
 
@@ -246,7 +246,7 @@ namespace RegressionGames.StateRecorder
                 Destroy(tex);
             }
 
-            if (_isRecording)
+            if (IsRecording)
             {
                 StartCoroutine(RecordFrame());
             }
@@ -262,7 +262,7 @@ namespace RegressionGames.StateRecorder
         {
             // Do this 1 frame after the request so that the click action of starting the recording itself isn't captured
             yield return null;
-            if (!_isRecording)
+            if (!IsRecording)
             {
                 _lastCvFrameTime = -1;
                 KeyboardInputActionObserver.GetInstance()?.StartRecording();
@@ -273,7 +273,7 @@ namespace RegressionGames.StateRecorder
                 {
                     objectFinder.Cleanup();
                 }
-                _isRecording = true;
+                IsRecording = true;
                 _tickNumber = 0;
                 _currentSessionId = Guid.NewGuid().ToString("n");
                 _referenceSessionId = referenceSessionId;
@@ -358,8 +358,8 @@ namespace RegressionGames.StateRecorder
 
         public void StopRecording()
         {
-            var wasRecording = _isRecording;
-            _isRecording = false;
+            var wasRecording = IsRecording;
+            IsRecording = false;
             if (wasRecording)
             {
                 var gameFacePixelHashObserver = GameFacePixelHashObserver.GetInstance();


### PR DESCRIPTION
- Makes `apiVersion` field optional in Bot Segments
- Allows Zip files to contain both BotSegments and BotSegmentLists interleaved
- Properly sorts zip file entries

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
