### PR TITLE
[REG-1913] Open vocab text query object detection bot segment criteria. 

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
@@ -94,7 +94,9 @@ namespace RegressionGames.StateRecorder.BotSegments
             {
                 // Check if we have results or a request in progress.
                 requestInProgress = _requestTracker.ContainsKey(segmentNumber);
-
+                
+                // TODO(REG-1928): Think more about hardening this data reading.
+                
                 // Get the results for the segment.
                 _queryResultTracker.TryGetValue(segmentNumber, out objectDetectionResults);
                 // Get the prior results for the segment.

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
@@ -328,7 +328,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                             },
                             textQuery: textQuery,
                             queryImage: null,
-                            withinRect: null,
+                            withinRect: withinRect,
                             index: 1
                         ),
                         // Cancel ongoing request in a thread safe manner.

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
@@ -1,17 +1,18 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using RegressionGames.StateRecorder.BotSegments.Models;
 using RegressionGames.StateRecorder.BotSegments.Models.CVService;
+using RegressionGames.StateRecorder.JsonConverters;
 using UnityEngine;
 
 namespace RegressionGames.StateRecorder.BotSegments
 {
 
-
     /**
-     * <summary>Evaluates CV Text criteria using CVServiceManager to send/receive HTTP requests to a python server for doing the actual CV evaluations.
-     * Python 'detects' text in a provided image and then this class evaluates those results against the specified bot segment criteria.</summary>
+     * <summary>Evaluates CV Image criteria using CVServiceManager to send/receive HTTP requests to a python server for doing the actual CV evaluations.
+     * Python 'detects' a source image template in a provided screenshot and then this class evaluates those results against the specified bot segment criteria.</summary>
      */
     public static class CVObjectDetectionEvaluator
     {
@@ -19,11 +20,11 @@ namespace RegressionGames.StateRecorder.BotSegments
         // We manage locks by locking just on the _requestTracker for access to both dictionaries
 
         // if an entry is missing, no request for that segment in progress
-        private static readonly Dictionary<int, Action> _requestTracker = new();
+        private static readonly Dictionary<int, ConcurrentDictionary<int, Action>> _requestTracker = new();
 
         // if an entry is NULL, request is in progress for that segment
         // if an entry has a value, then it is completed for that segment.. it should be cleared out on the next matched call if the result didn't match so it can run again
-        private static readonly Dictionary<int, List<CVObjectDetectionResult>> _resultTracker = new();
+        private static readonly Dictionary<int, ConcurrentDictionary<int, List<CVObjectDetectionResult>>> _queryResultTracker = new();
 
         private static readonly Dictionary<int, List<string>> _priorResultsTracker = new();
 
@@ -34,11 +35,15 @@ namespace RegressionGames.StateRecorder.BotSegments
                 foreach (var keyValuePair in _requestTracker.Where((pair => pair.Value != null)))
                 {
                     RGDebug.LogDebug($"CVObjectDetectionEvaluator - Reset - botSegment: {keyValuePair.Key} - abortingWebRequest");
-                    keyValuePair.Value.Invoke();
+                    var pair = keyValuePair.Value;
+                    foreach (var pairValue in pair.Values)
+                    {
+                        pairValue.Invoke();
+                    }
                 }
 
                 _requestTracker.Clear();
-                _resultTracker.Clear();
+                _queryResultTracker.Clear();
                 _priorResultsTracker.Clear();
             }
         }
@@ -51,13 +56,16 @@ namespace RegressionGames.StateRecorder.BotSegments
             lock (_requestTracker)
             {
                 RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Cleanup - botSegment: {segmentNumber} - insideLock");
-                if (_requestTracker.Remove(segmentNumber, out var request))
+                if (_requestTracker.Remove(segmentNumber, out var requests))
                 {
                     try
                     {
-                        RGDebug.LogDebug($"CVObjectDetectionEvaluator - Cleanup - botSegment: {segmentNumber} - abortingWebRequest");
+                        RGDebug.LogDebug($"CVObjectDetectionEvaluator - Cleanup - botSegment: {segmentNumber} - abortingWebRequests");
                         //try to abort the request
-                        request.Invoke();
+                        foreach (var action in requests.Values)
+                        {
+                            action.Invoke();
+                        }
                     }
                     catch (Exception)
                     {
@@ -66,7 +74,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                 }
 
                 // remove the tracked result
-                _resultTracker.Remove(segmentNumber, out _);
+                _queryResultTracker.Remove(segmentNumber, out _);
                 _priorResultsTracker.Remove(segmentNumber, out _);
                 RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Cleanup - botSegment: {segmentNumber} - END");
             }
@@ -78,135 +86,241 @@ namespace RegressionGames.StateRecorder.BotSegments
             RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - BEGIN");
             var resultList = new List<string>();
 
-            List<CVObjectDetectionResult> cvObjectDetectionResults = null;
+            ConcurrentDictionary<int,List<CVObjectDetectionResult>> objectDetectionResults = null;
             List<string> priorResults = null;
+            var requestInProgress = false;
             lock (_requestTracker)
             {
-                _resultTracker.TryGetValue(segmentNumber, out cvObjectDetectionResults);
+                requestInProgress = _requestTracker.ContainsKey(segmentNumber);
+                _queryResultTracker.TryGetValue(segmentNumber, out objectDetectionResults);
                 _priorResultsTracker.TryGetValue(segmentNumber, out priorResults);
-                var resultsString = cvObjectDetectionResults == null ? "null":$"\n[{string.Join(",\n", cvObjectDetectionResults)}]";
-                if (cvObjectDetectionResults != null)
+                var resultsString = objectDetectionResults == null ? "null":$"\n[{string.Join(",\n", objectDetectionResults.Select(pair => $"{pair.Key}:[{(pair.Value==null?"null":string.Join(",\n", pair.Value))}]"))}]";
+                if (objectDetectionResults != null)
                 {
-                    RGDebug.LogDebug($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - CVObjectDetectionResults: {resultsString}");
+                    RGDebug.LogDebug($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - cvImageResults: {resultsString}");
                 }
             }
-            
-            if (priorResults is not { Count: 0 } || cvObjectDetectionResults == null)
+
+            var criteriaListCount = criteriaList.Count;
+            // only query when no request in progress and when we have cleared out the prior results
+            if (!requestInProgress && objectDetectionResults == null)
             {
-                // Handle possibly starting the web request for evaluation
-                var requestInProgress = _requestTracker.TryGetValue(segmentNumber, out _);
-                if (!requestInProgress)
+                var imageData = ScreenshotCapture.GetCurrentScreenshot(segmentNumber, out var width, out var height);
+                if (imageData != null)
                 {
-                    // double checked locking paradigm to avoid race conditions from multiple threads while still optimizing for the repeated call path not having to lock
+                    // mark a request in progress inside the lock to avoid race conditions.. must be done before starting async process
+                    // mark that we are in progress by putting entries in the dictionary of null until we replace with the real data
+                    // thus contains key returns true
                     lock (_requestTracker)
                     {
-                        requestInProgress = _requestTracker.TryGetValue(segmentNumber, out _);
-                        if (!requestInProgress)
-                        {
-                            foreach (var criteria in criteriaList)
-                            {
-                                
-                                var criteriaData = criteria.data as CVObjectDetectionKeyFrameCriteriaData;
-                                var imageData = ScreenshotCapture.GetCurrentScreenshot(
-                                    segmentNumber,
-                                    out var width,
-                                    out var height);
-                                var queryText = criteriaData.text;
-                                if (imageData != null)
-                                {
-                                    // mark a request in progress inside the lock to avoid race conditions.. must be done before starting async process
-                                    // mark that we are in progress by putting entries in the dictionary of null until we replace with the real data
-                                    // thus contains key returns true
-                                    _requestTracker[segmentNumber] = null;
-                                    _resultTracker[segmentNumber] = null;
+                        _requestTracker[segmentNumber] = new();
+                        _queryResultTracker[segmentNumber] = new();
+                    }
 
-                                    // do NOT await this, let it run async
-                                    _ = CVServiceManager.GetInstance().PostCriteriaObjectTextQuery(
-                                        new CVObjectDetectionRequest()
+                    for (var i = criteriaListCount - 1; i >= 0; i--)
+                    {
+                        var index = i;
+                        var criteria = criteriaList[i];
+
+                        var criteriaData = criteria.data as CVObjectDetectionKeyFrameCriteriaData;
+
+                        // mark a request in progress inside the lock to avoid race conditions.. must be done before starting async process
+                        // mark that we are in progress by putting entries in the dictionary
+                        lock (_requestTracker)
+                        {
+                            if (_requestTracker.TryGetValue(segmentNumber, out var reqValue))
+                            {
+                                reqValue[index] = null;
+                            }
+
+                            if (_queryResultTracker.TryGetValue(segmentNumber, out var resValue))
+                            {
+                                resValue[index] = null;
+                            }
+                        }
+
+                        RectInt? withinRect = null;
+
+                        if (criteriaData.withinRect != null)
+                        {
+                            // compute the relative withinRect for the request
+                            var xScale = width / criteriaData.withinRect.screenSize.x;
+                            var yScale = height / criteriaData.withinRect.screenSize.y;
+                            withinRect = new RectInt(
+                                Mathf.FloorToInt(xScale * criteriaData.withinRect.rect.x),
+                                Mathf.FloorToInt(yScale * criteriaData.withinRect.rect.y),
+                                Mathf.FloorToInt(xScale * criteriaData.withinRect.rect.width),
+                                Mathf.FloorToInt(yScale * criteriaData.withinRect.rect.height)
+                                );
+                        }
+
+                        var queryText = criteriaData.text;
+                        // do NOT await this, let it run async
+                        _ = CVServiceManager.GetInstance().PostCriteriaObjectTextQuery(
+                            new CVObjectDetectionRequest()
+                            {
+                                screenshot = new CVImageBinaryData()
+                                {
+                                    width = width,
+                                    height = height,
+                                    data = imageData
+                                },
+                                index = 1,
+                                queryImage = null,
+                                queryText = queryText
+                            },
+                            abortRegistrationHook:
+                            action =>
+                            {
+                                RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber}, index: {index} - Request - abortHook registration callback");
+                                lock (_requestTracker)
+                                {
+                                    RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber}, index: {index} - Request - abortHook registration callback - insideLock");
+
+                                    if (_requestTracker.TryGetValue(segmentNumber, out var requestValue))
+                                    {
+                                        // make sure we haven't already cleaned this up
+                                        if (requestValue.ContainsKey(index))
                                         {
-                                            screenshot = new CVImageBinaryData()
-                                            {
-                                                width = width,
-                                                height = height,
-                                                data = imageData
-                                            },
-                                            index = 1,
-                                            queryImage = null,
-                                            queryText = queryText
-                                        },
-                                        abortRegistrationHook: action =>
+                                            requestValue[index] = action;
+                                        }
+                                    }
+                                }
+                            },
+                            onSuccess:
+                            list =>
+                            {
+                                RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber}, index: {index} - Request - onSuccess callback");
+                                lock (_requestTracker)
+                                {
+                                    RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber}, index: {index} - Request - onSuccess callback - insideLock");
+                                    // make sure we haven't already cleaned this up
+                                    if (_queryResultTracker.TryGetValue(segmentNumber, out var value))
+                                    {
+                                        RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber}, index: {index} - Request - onSuccess callback - storingResult");
+                                        // store the result
+                                        value[index] = list;
+                                        // cleanup the request tracker
+                                        var reqSeg = _requestTracker[segmentNumber];
+                                        reqSeg.Remove(index, out _);
+                                        // last one to come back.. cleanup all the way
+                                        if (reqSeg.Count == 0)
                                         {
-                                            RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - Request - abortHook registration callback");
-                                            lock (_requestTracker)
-                                            {
-                                                RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - Request - abortHook registration callback - insideLock");
-                                                // make sure we haven't already cleaned this up
-                                                if (_requestTracker.ContainsKey(segmentNumber))
-                                                {
-                                                    _requestTracker[segmentNumber] = action;
-                                                }
-                                            }
-                                        },
-                                        onSuccess: list =>
+                                            _priorResultsTracker.Remove(segmentNumber);
+                                            _requestTracker.Remove(segmentNumber);
+                                        }
+                                    }
+                                }
+                            },
+                            onFailure:
+                            () =>
+                            {
+                                RGDebug.LogWarning($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber}, index: {index} - Request - onFailure callback - failure invoking CVService image criteria evaluation");
+                                lock (_requestTracker)
+                                {
+                                    RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber}, index: {index} - Request - onFailure callback - insideLock");
+                                    // make sure we haven't already cleaned this up
+                                    if (_queryResultTracker.TryGetValue(segmentNumber, out var value))
+                                    {
+                                        RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber}, index: {index} - Request - onFailure callback - storingResult");
+                                        // store the result as no result so we know we 'finished', but won't pass this criteria yet
+                                        value[index] = new();
+                                        // cleanup the request tracker
+                                        var reqSeg = _requestTracker[segmentNumber];
+                                        reqSeg.Remove(index, out _);
+                                        // last one to come back.. cleanup all the way
+                                        if (reqSeg.Count == 0)
                                         {
-                                            RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - Request - onSuccess callback");
-                                            lock (_requestTracker)
-                                            {
-                                                RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - Request - onSuccess callback - insideLock");
-                                                // make sure we haven't already cleaned this up
-                                                if (_resultTracker.ContainsKey(segmentNumber))
-                                                {
-                                                    RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - Request - onSuccess callback - storingResult");
-                                                    // store the result
-                                                    _resultTracker[segmentNumber] = list;
-                                                    // cleanup the request tracker
-                                                    _requestTracker.Remove(segmentNumber);
-                                                    _priorResultsTracker.Remove(segmentNumber);
-                                                }
-                                            }
-                                        },
-                                        onFailure: () =>
+                                            _priorResultsTracker.Remove(segmentNumber);
+                                            _requestTracker.Remove(segmentNumber);
+                                        }
+                                    }
+                                }
+
+                            });
+                        RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber}, index: {index} - Request - SENT");
+                        resultList.Add("Awaiting CV Image evaluation results ...");
+                    }
+                }
+                else
+                {
+                    resultList.Add("Awaiting screenshot data ...");
+                }
+            }
+            else
+            {
+                // we check priorResults null here so that we only evaluate a new result 1 time
+                if (!requestInProgress && (priorResults == null && objectDetectionResults != null && objectDetectionResults.Count == criteriaListCount && objectDetectionResults.All(cv => cv.Value != null)))
+                {
+                    // Evaluate the results if we have them all for each criteria
+                    for (var i = criteriaListCount - 1; i >= 0; i--)
+                    {
+                        var criteria = criteriaList[i];
+                        var found = false;
+                        if (!criteria.transient || !criteria.Replay_TransientMatched)
+                        {
+                            var criteriaData = criteria.data as CVObjectDetectionKeyFrameCriteriaData;
+
+                            if (objectDetectionResults.TryGetValue(i, out var cvImageResultList) && cvImageResultList is { Count: > 0 })
+                            {
+                                var withinRect = criteriaData.withinRect;
+                                // we had the result for this criteria
+                                if (withinRect != null)
+                                {
+                                    foreach (var cvImageResult in cvImageResultList)
+                                    {
+                                        // ensure result rect is inside
+                                        var relativeScaling = new Vector2(withinRect.screenSize.x / (float)cvImageResult.resolution.x, withinRect.screenSize.y / (float)cvImageResult.resolution.y);
+
+                                        // check the bottom left and top right to see if it intersects our rect
+                                        var bottomLeft = new Vector2Int(Mathf.CeilToInt(cvImageResult.rect.x * relativeScaling.x), Mathf.CeilToInt(cvImageResult.rect.y * relativeScaling.y));
+                                        var topRight = new Vector2Int(bottomLeft.x + Mathf.FloorToInt(cvImageResult.rect.width * relativeScaling.x), bottomLeft.y + Mathf.FloorToInt(cvImageResult.rect.height * relativeScaling.y));
+
+                                        // we currently test overlap, should we test fully inside instead ??
+                                        if (withinRect.rect.Contains(bottomLeft) || withinRect.rect.Contains(topRight))
                                         {
-                                            RGDebug.LogWarning($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - Request - onFailure callback - failure invoking CVService text criteria evaluation");
-                                            lock (_requestTracker)
-                                            {
-                                                RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - Request - onFailure callback - insideLock");
-                                                // make sure we haven't already cleaned this up
-                                                if (_resultTracker.ContainsKey(segmentNumber))
-                                                {
-                                                    RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - Request - onFailure callback - storingResult");
-                                                    // store the result as empty so we know we finished, but won't pass
-                                                    _resultTracker[segmentNumber] = new();
-                                                    // cleanup the request tracker
-                                                    _requestTracker.Remove(segmentNumber);
-                                                    _priorResultsTracker.Remove(segmentNumber);
-                                                }
-                                            }
-                                        });
-                                    RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - Request - SENT");
-                                    requestInProgress = true;
+                                            found = true;
+                                            break; // we found one, we can stop
+                                        }
+                                    }
+
+                                    if (!found)
+                                    {
+                                        resultList.Add($"CV Image result for criteria at index: {i} was not found withinRect: {RectIntJsonConverter.ToJsonString(withinRect.rect)}");
+                                    }
                                 }
                                 else
                                 {
-                                    resultList.Add("Awaiting screenshot data ...");
+                                    found = true;
                                 }
                             }
+                            else
+                            {
+                                resultList.Add($"Missing CV Image result for criteria at index: {i}");
+                            }
+                        }
+
+                        if (found)
+                        {
+                            criteria.Replay_TransientMatched = true;
                         }
                     }
-                }
 
-                if (requestInProgress)
-                {
-                    if (priorResults == null )
+                    lock (_requestTracker)
                     {
-                        resultList.Add("Awaiting CV object detection evaluation result ...");
-                    }
-                    else
-                    {
-                        // show the prior failures
-                        resultList.AddRange(priorResults);
+                        // remove this so the next update pass knows to query again
+                        _queryResultTracker.Remove(segmentNumber);
                     }
                 }
+                else
+                {
+                    resultList.Add("Awaiting CV Image evaluation results ...");
+                }
+            }
+
+            lock (_requestTracker)
+            {
+                _priorResultsTracker[segmentNumber] = resultList;
             }
 
             RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - resultList: {resultList.Count} - END");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
@@ -11,8 +11,8 @@ namespace RegressionGames.StateRecorder.BotSegments
 {
 
     /**
-     * <summary>Evaluates CV Image criteria using CVServiceManager to send/receive HTTP requests to a python server for doing the actual CV evaluations.
-     * Python 'detects' a source image template in a provided screenshot and then this class evaluates those results against the specified bot segment criteria.</summary>
+     * <summary>Evaluates CV Object Detection criteria using CVServiceManager to send/receive HTTP requests to a python server for doing the actual CV evaluations.
+     * Python 'detects' classes of objects in a provided screenshot based on image and text queries, and then this class evaluates those results against the specified bot segment criteria.</summary>
      */
     public static class CVObjectDetectionEvaluator
     {
@@ -329,8 +329,13 @@ namespace RegressionGames.StateRecorder.BotSegments
                             withinRect: null,
                             index: 1
                         ),
+                        // Cancel ongoing request in a thread safe manner.
                         abortRegistrationHook: action => AbortRegistrationHook(segmentNumber, index, action),
+                        
+                        // Stores the results, clean up the request tracker, and remove completed requests.
                         onSuccess: list => OnSuccess(segmentNumber, index, list),
+
+                        // Logs the failure, store an empty result, clean up the request tracker, and removes completed request
                         onFailure: () => OnFailure(segmentNumber, index)
                     );
                     RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber}, index: {index} - Request - SENT");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
@@ -316,7 +316,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                         );
                     }
 
-                    var queryText = criteriaData.text;
+                    var textQuery = criteriaData.textQuery;
                     // do NOT await this, let it run async
                     _ = CVServiceManager.GetInstance().PostCriteriaObjectTextQuery(
                         new CVObjectDetectionRequest(
@@ -326,7 +326,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                                 height = height,
                                 data = imageData
                             },
-                            queryText: queryText,
+                            textQuery: textQuery,
                             queryImage: null,
                             withinRect: null,
                             index: 1

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
@@ -317,18 +317,18 @@ namespace RegressionGames.StateRecorder.BotSegments
                     var queryText = criteriaData.text;
                     // do NOT await this, let it run async
                     _ = CVServiceManager.GetInstance().PostCriteriaObjectTextQuery(
-                        new CVObjectDetectionRequest()
-                        {
-                            screenshot = new CVImageBinaryData()
+                        new CVObjectDetectionRequest(
+                            screenshot: new CVImageBinaryData()
                             {
                                 width = width,
                                 height = height,
                                 data = imageData
                             },
-                            index = 1,
-                            queryImage = null,
-                            queryText = queryText
-                        },
+                            queryText: queryText,
+                            queryImage: null,
+                            withinRect: null,
+                            index: 1
+                        ),
                         abortRegistrationHook: action => AbortRegistrationHook(segmentNumber, index, action),
                         onSuccess: list => OnSuccess(segmentNumber, index, list),
                         onFailure: () => OnFailure(segmentNumber, index)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
@@ -1,0 +1,217 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using RegressionGames.StateRecorder.BotSegments.Models;
+using RegressionGames.StateRecorder.BotSegments.Models.CVService;
+using UnityEngine;
+
+namespace RegressionGames.StateRecorder.BotSegments
+{
+
+
+    /**
+     * <summary>Evaluates CV Text criteria using CVServiceManager to send/receive HTTP requests to a python server for doing the actual CV evaluations.
+     * Python 'detects' text in a provided image and then this class evaluates those results against the specified bot segment criteria.</summary>
+     */
+    public static class CVObjectDetectionEvaluator
+    {
+        // This class uses explicit locking for thread safety as we have multiple different threads affecting the state of the tracking dictionaries, as well as async web responses
+        // We manage locks by locking just on the _requestTracker for access to both dictionaries
+
+        // if an entry is missing, no request for that segment in progress
+        private static readonly Dictionary<int, Action> _requestTracker = new();
+
+        // if an entry is NULL, request is in progress for that segment
+        // if an entry has a value, then it is completed for that segment.. it should be cleared out on the next matched call if the result didn't match so it can run again
+        private static readonly Dictionary<int, List<CVObjectDetectionResult>> _resultTracker = new();
+
+        private static readonly Dictionary<int, List<string>> _priorResultsTracker = new();
+
+        public static void Reset()
+        {
+            lock (_requestTracker)
+            {
+                foreach (var keyValuePair in _requestTracker.Where((pair => pair.Value != null)))
+                {
+                    RGDebug.LogDebug($"CVObjectDetectionEvaluator - Reset - botSegment: {keyValuePair.Key} - abortingWebRequest");
+                    keyValuePair.Value.Invoke();
+                }
+
+                _requestTracker.Clear();
+                _resultTracker.Clear();
+                _priorResultsTracker.Clear();
+            }
+        }
+
+
+        // cleanup async and results tracking for that segment
+        public static void Cleanup(int segmentNumber)
+        {
+            RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Cleanup - botSegment: {segmentNumber} - BEGIN");
+            lock (_requestTracker)
+            {
+                RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Cleanup - botSegment: {segmentNumber} - insideLock");
+                if (_requestTracker.Remove(segmentNumber, out var request))
+                {
+                    try
+                    {
+                        RGDebug.LogDebug($"CVObjectDetectionEvaluator - Cleanup - botSegment: {segmentNumber} - abortingWebRequest");
+                        //try to abort the request
+                        request.Invoke();
+                    }
+                    catch (Exception)
+                    {
+                        // DO NOTHING .. we tried.. we really did
+                    }
+                }
+
+                // remove the tracked result
+                _resultTracker.Remove(segmentNumber, out _);
+                _priorResultsTracker.Remove(segmentNumber, out _);
+                RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Cleanup - botSegment: {segmentNumber} - END");
+            }
+        }
+
+        // Returns a list of non-matched entries
+        public static List<string> Matched(int segmentNumber, List<KeyFrameCriteria> criteriaList)
+        {
+            RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - BEGIN");
+            var resultList = new List<string>();
+
+            List<CVObjectDetectionResult> cvObjectDetectionResults = null;
+            List<string> priorResults = null;
+            lock (_requestTracker)
+            {
+                _resultTracker.TryGetValue(segmentNumber, out cvObjectDetectionResults);
+                _priorResultsTracker.TryGetValue(segmentNumber, out priorResults);
+                var resultsString = cvObjectDetectionResults == null ? "null":$"\n[{string.Join(",\n", cvObjectDetectionResults)}]";
+                if (cvObjectDetectionResults != null)
+                {
+                    RGDebug.LogDebug($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - CVObjectDetectionResults: {resultsString}");
+                }
+            }
+            
+            if (priorResults is not { Count: 0 } || cvObjectDetectionResults == null)
+            {
+                // Handle possibly starting the web request for evaluation
+                var requestInProgress = _requestTracker.TryGetValue(segmentNumber, out _);
+                if (!requestInProgress)
+                {
+                    // double checked locking paradigm to avoid race conditions from multiple threads while still optimizing for the repeated call path not having to lock
+                    lock (_requestTracker)
+                    {
+                        requestInProgress = _requestTracker.TryGetValue(segmentNumber, out _);
+                        if (!requestInProgress)
+                        {
+                            foreach (var criteria in criteriaList)
+                            {
+                                
+                                var criteriaData = criteria.data as CVObjectDetectionKeyFrameCriteriaData;
+                                var imageData = ScreenshotCapture.GetCurrentScreenshot(
+                                    segmentNumber,
+                                    out var width,
+                                    out var height);
+                                var queryText = criteriaData.text;
+                                if (imageData != null)
+                                {
+                                    // mark a request in progress inside the lock to avoid race conditions.. must be done before starting async process
+                                    // mark that we are in progress by putting entries in the dictionary of null until we replace with the real data
+                                    // thus contains key returns true
+                                    _requestTracker[segmentNumber] = null;
+                                    _resultTracker[segmentNumber] = null;
+
+                                    // do NOT await this, let it run async
+                                    _ = CVServiceManager.GetInstance().PostCriteriaObjectTextQuery(
+                                        new CVObjectDetectionRequest()
+                                        {
+                                            screenshot = new CVImageBinaryData()
+                                            {
+                                                width = width,
+                                                height = height,
+                                                data = imageData
+                                            },
+                                            index = 1,
+                                            queryImage = null,
+                                            queryText = queryText
+                                        },
+                                        abortRegistrationHook: action =>
+                                        {
+                                            RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - Request - abortHook registration callback");
+                                            lock (_requestTracker)
+                                            {
+                                                RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - Request - abortHook registration callback - insideLock");
+                                                // make sure we haven't already cleaned this up
+                                                if (_requestTracker.ContainsKey(segmentNumber))
+                                                {
+                                                    _requestTracker[segmentNumber] = action;
+                                                }
+                                            }
+                                        },
+                                        onSuccess: list =>
+                                        {
+                                            RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - Request - onSuccess callback");
+                                            lock (_requestTracker)
+                                            {
+                                                RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - Request - onSuccess callback - insideLock");
+                                                // make sure we haven't already cleaned this up
+                                                if (_resultTracker.ContainsKey(segmentNumber))
+                                                {
+                                                    RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - Request - onSuccess callback - storingResult");
+                                                    // store the result
+                                                    _resultTracker[segmentNumber] = list;
+                                                    // cleanup the request tracker
+                                                    _requestTracker.Remove(segmentNumber);
+                                                    _priorResultsTracker.Remove(segmentNumber);
+                                                }
+                                            }
+                                        },
+                                        onFailure: () =>
+                                        {
+                                            RGDebug.LogWarning($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - Request - onFailure callback - failure invoking CVService text criteria evaluation");
+                                            lock (_requestTracker)
+                                            {
+                                                RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - Request - onFailure callback - insideLock");
+                                                // make sure we haven't already cleaned this up
+                                                if (_resultTracker.ContainsKey(segmentNumber))
+                                                {
+                                                    RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - Request - onFailure callback - storingResult");
+                                                    // store the result as empty so we know we finished, but won't pass
+                                                    _resultTracker[segmentNumber] = new();
+                                                    // cleanup the request tracker
+                                                    _requestTracker.Remove(segmentNumber);
+                                                    _priorResultsTracker.Remove(segmentNumber);
+                                                }
+                                            }
+                                        });
+                                    RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - Request - SENT");
+                                    requestInProgress = true;
+                                }
+                                else
+                                {
+                                    resultList.Add("Awaiting screenshot data ...");
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (requestInProgress)
+                {
+                    if (priorResults == null )
+                    {
+                        resultList.Add("Awaiting CV object detection evaluation result ...");
+                    }
+                    else
+                    {
+                        // show the prior failures
+                        resultList.AddRange(priorResults);
+                    }
+                }
+            }
+
+            RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber} - resultList: {resultList.Count} - END");
+
+            return resultList;
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4e4db5644b064458a4053933d478562a
+timeCreated: 1724103397

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVServiceManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVServiceManager.cs
@@ -72,6 +72,29 @@ namespace RegressionGames
             );
         }
 
+        public async Task PostCriteriaObjectTextQuery(CVObjectDetectionRequest request, 
+                                                      Action<Action> abortRegistrationHook,
+                                                      Action<List<CVObjectDetectionResult>> onSuccess,
+                                                      Action onFailure)
+        {
+            await SendWebRequest(
+                uri: $"{GetCvServiceBaseUri()}/criteria-object-text-query",
+                method: "POST",
+                payload: request.ToJsonString(),
+                abortRegistrationHook: abortRegistrationHook.Invoke,
+                onSuccess: (s) =>
+                {
+                    var response = JsonConvert.DeserializeObject<CVObjectDetectionResultList>(s);
+                    onSuccess.Invoke(response.results);
+                },
+                onFailure: (f) =>
+                {
+                    RGDebug.LogWarning($"Failed to evaluate CV Object Detection via Text Query criteria: {f}");
+                    onFailure.Invoke();
+                }
+            );
+        }
+        
         public async Task PostCriteriaTextDiscover(CVTextCriteriaRequest request, Action<Action> abortRegistrationHook, Action<List<CVTextResult>> onSuccess, Action onFailure)
         {
             await SendWebRequest(

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/KeyFrameCriteriaJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/KeyFrameCriteriaJsonConverter.cs
@@ -38,6 +38,9 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
                 case KeyFrameCriteriaType.ActionComplete:
                     data = jObject["data"].ToObject<ActionCompleteKeyFrameCriteriaData>(serializer);
                     break;
+                case KeyFrameCriteriaType.CVObjectDetection:
+                    data = jObject["data"].ToObject<CVObjectDetectionKeyFrameCriteriaData>(serializer);
+                    break;
                 default:
                     throw new JsonSerializationException($"Unsupported KeyFrameCriteria type: '{criteria.type}'");
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/KeyFrameEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/KeyFrameEvaluator.cs
@@ -206,14 +206,14 @@ namespace RegressionGames.StateRecorder.BotSegments
                     // cvText results will be null until we get the async response back
                     if (andOr == BooleanCriteria.And)
                     {
-                        _newUnmatchedCriteria.Add("Waiting for CV Object detection evaluation results ...");
+                        _newUnmatchedCriteria.Add("Waiting for CV Object Detection evaluation results ...");
                         return false;
                     }
                 }
                 else
                 {
-                    var cvTextResultsCount = cvObjectDetectionResults.Count;
-                    for (var i = 0; i < cvTextResultsCount; i++)
+                    var cvObjectDetectionResultsCoount = cvObjectDetectionResults.Count;
+                    for (var i = 0; i < cvObjectDetectionResultsCoount; i++)
                     {
                         var resultEntry = cvObjectDetectionResults[i];
                         if (resultEntry == null)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/KeyFrameEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/KeyFrameEvaluator.cs
@@ -212,8 +212,8 @@ namespace RegressionGames.StateRecorder.BotSegments
                 }
                 else
                 {
-                    var cvObjectDetectionResultsCoount = cvObjectDetectionResults.Count;
-                    for (var i = 0; i < cvObjectDetectionResultsCoount; i++)
+                    var cvObjectDetectionResultsCount = cvObjectDetectionResults.Count;
+                    for (var i = 0; i < cvObjectDetectionResultsCount; i++)
                     {
                         var resultEntry = cvObjectDetectionResults[i];
                         if (resultEntry == null)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionKeyFrameCriteriaData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionKeyFrameCriteriaData.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Text;
+using System.Threading;
+using JetBrains.Annotations;
+using RegressionGames.StateRecorder.BotSegments.JsonConverters;
+using RegressionGames.StateRecorder.JsonConverters;
+
+namespace RegressionGames.StateRecorder.BotSegments.Models
+{
+    [Serializable]
+    public class CVObjectDetectionKeyFrameCriteriaData : IKeyFrameCriteriaData
+    {
+        // update this if this schema changes
+        public int apiVersion = SdkApiVersion.VERSION_9;
+
+        public string text;
+        /**
+       * base64 encoded byte[] of jpg image data , NOT the raw pixel data, the full jpg file bytes
+       */
+        // public string imageData; This will be added in the next PR.
+        
+        public TextMatchingRule textMatchingRule = TextMatchingRule.Matches;
+        public TextCaseRule textCaseRule = TextCaseRule.Matches;
+
+        [CanBeNull]
+        public CVWithinRect withinRect;
+
+        public void WriteToStringBuilder(StringBuilder stringBuilder)
+        {
+            stringBuilder.Append("{\"text\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, text);
+            stringBuilder.Append(",\"apiVersion\":");
+            IntJsonConverter.WriteToStringBuilder(stringBuilder, apiVersion);
+            stringBuilder.Append(",\"textMatchingRule\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, textMatchingRule.ToString());
+            stringBuilder.Append(",\"textCaseRule\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, textCaseRule.ToString());
+            stringBuilder.Append(",\"withinRect\":");
+            CVWithinRectJsonConverter.WriteToStringBuilderNullable(stringBuilder, withinRect);
+            stringBuilder.Append("}");
+        }
+
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(1000));
+
+        public override string ToString()
+        {
+            WriteToStringBuilder(_stringBuilder.Value);
+            return _stringBuilder.Value.ToString();
+        }
+
+        public int EffectiveApiVersion()
+        {
+            return apiVersion;
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionKeyFrameCriteriaData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionKeyFrameCriteriaData.cs
@@ -11,7 +11,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
     public class CVObjectDetectionKeyFrameCriteriaData : IKeyFrameCriteriaData
     {
         // update this if this schema changes
-        public int apiVersion = SdkApiVersion.VERSION_9;
+        public int apiVersion = SdkApiVersion.VERSION_15;
 
         public string text;
         /**

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionKeyFrameCriteriaData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionKeyFrameCriteriaData.cs
@@ -11,7 +11,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
     public class CVObjectDetectionKeyFrameCriteriaData : IKeyFrameCriteriaData
     {
         // update this if this schema changes
-        public int apiVersion = SdkApiVersion.VERSION_15;
+        public int apiVersion = SdkApiVersion.VERSION_16;
 
         /// <summary>
         /// The text query used for object detection.

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionKeyFrameCriteriaData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionKeyFrameCriteriaData.cs
@@ -13,28 +13,54 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         // update this if this schema changes
         public int apiVersion = SdkApiVersion.VERSION_15;
 
-        public string text;
-        /**
-       * base64 encoded byte[] of jpg image data , NOT the raw pixel data, the full jpg file bytes
-       */
-        // TODO(REG-1915) Add supporting image queries.
-        // public string imageData; 
-        public TextMatchingRule textMatchingRule = TextMatchingRule.Matches;
-        public TextCaseRule textCaseRule = TextCaseRule.Matches;
+        /// <summary>
+        /// The text query used for object detection.
+        /// This string is used to describe or identify the object to be detected in the image.
+        /// </summary>
+        [CanBeNull]
+        public string textQuery;
 
+        /// <summary>
+        /// The image query used for object detection.
+        /// This string represents a base64-encoded image to be used as a reference for object detection.
+        /// </summary>
+        [CanBeNull]
+        public string imageQuery;
+   
         [CanBeNull]
         public CVWithinRect withinRect;
 
+        /// <summary>
+        /// Constructor for CVObjectDetectionKeyFrameCriteriaData.
+        /// </summary>
+        /// <param name="textQuery">The text query used for object detection.</param>
+        /// <param name="imageQuery">Currently not supported. The image query used for object detection.</param>
+        /// <param name="withinRect">Optional rectangle defining the region of interest within the image.</param>
+        public CVObjectDetectionKeyFrameCriteriaData(string textQuery = null, string imageQuery = null, CVWithinRect withinRect = null)
+        {
+            
+            if (textQuery != null && imageQuery != null)
+            {
+                RGDebug.LogError("Both textQuery and imageQuery cannot be provided simultaneously. Use only one.");
+                throw new ArgumentException("Both textQuery and imageQuery cannot be provided simultaneously. Use only one.");
+            }
+            else if (textQuery == null && imageQuery == null)
+            {
+                RGDebug.LogError("Neither textQuery nor queryImage is provided. One should be specified.");
+                throw new ArgumentException("Neither textQuery nor queryImage is provided. One should be specified.");
+            }
+
+            this.textQuery = textQuery;
+            this.imageQuery = imageQuery;
+            this.withinRect = withinRect;
+        }
+
         public void WriteToStringBuilder(StringBuilder stringBuilder)
         {
-            stringBuilder.Append("{\"text\":");
-            StringJsonConverter.WriteToStringBuilder(stringBuilder, text);
+            stringBuilder.Append("{\"textQuery\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, textQuery);
             stringBuilder.Append(",\"apiVersion\":");
             IntJsonConverter.WriteToStringBuilder(stringBuilder, apiVersion);
-            stringBuilder.Append(",\"textMatchingRule\":");
-            StringJsonConverter.WriteToStringBuilder(stringBuilder, textMatchingRule.ToString());
-            stringBuilder.Append(",\"textCaseRule\":");
-            StringJsonConverter.WriteToStringBuilder(stringBuilder, textCaseRule.ToString());
             stringBuilder.Append(",\"withinRect\":");
             CVWithinRectJsonConverter.WriteToStringBuilderNullable(stringBuilder, withinRect);
             stringBuilder.Append("}");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionKeyFrameCriteriaData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionKeyFrameCriteriaData.cs
@@ -17,8 +17,8 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         /**
        * base64 encoded byte[] of jpg image data , NOT the raw pixel data, the full jpg file bytes
        */
-        // public string imageData; This will be added in the next PR.
-        
+        // TODO(REG-1915) Add supporting image queries.
+        // public string imageData; 
         public TextMatchingRule textMatchingRule = TextMatchingRule.Matches;
         public TextCaseRule textCaseRule = TextCaseRule.Matches;
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionKeyFrameCriteriaData.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionKeyFrameCriteriaData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ad2a5724f52d97a4aa0c9bedcf8d472a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionRequest.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionRequest.cs
@@ -19,6 +19,30 @@ namespace RegressionGames.StateRecorder.BotSegments.Models.CVService
         // track the index in this bot segment for correlation of the responses
         public int index;
 
+        public CVObjectDetectionRequest(CVImageBinaryData screenshot,
+                                        string? queryText,
+                                        CVImageBinaryData? queryImage,
+                                        RectInt? withinRect,
+                                        int index)
+        {
+            this.screenshot = screenshot;
+            this.queryText = queryText;
+            this.queryImage = queryImage;
+            this.withinRect = withinRect;
+            this.index = index;
+
+            // !!! TODO(REG-1915) Move this check to where the json is parsed.
+            if (queryText != null && queryImage != null)
+            {
+                RGDebug.LogError("Both queryText and queryImage are provided. Only one should be used.");
+                return;
+            }
+            else if (queryText == null && queryImage == null)
+            {
+                RGDebug.LogError("Neither queryText nor queryImage is provided. One should be specified.");
+                return;
+            }
+        }
         
         private static readonly ThreadLocal<StringBuilder> _stringBuilder = new (() => new(1000));
         public string ToJsonString()
@@ -31,29 +55,16 @@ namespace RegressionGames.StateRecorder.BotSegments.Models.CVService
         public void WriteToStringBuilder(StringBuilder stringBuilder)
         {
 
-            bool textQuery = queryText != null;
-            bool imageQuery = queryImage != null;
-
-            if (textQuery && imageQuery)
-            {
-                RGDebug.LogError("You need to use either textQuery or imageQuery. You can not have both.");
-            }
-            
-            if (!textQuery && !imageQuery)
-            {
-                RGDebug.LogError("You need to use either textQuery or imageQuery. You need to have at least one.");
-            }
-            
             stringBuilder.Append("{\"screenshot\":");
             screenshot.WriteToStringBuilder(stringBuilder);
             
-            if (textQuery)
+            if (queryText != null)
             {
                 stringBuilder.Append(",\"queryText\":");
                 StringJsonConverter.WriteToStringBuilder(stringBuilder, queryText);
             }
 
-            if (imageQuery)
+            if (queryImage != null)
             {
                 stringBuilder.Append(",\"imageToMatch\":");
                 queryImage.WriteToStringBuilder(stringBuilder);

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionRequest.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionRequest.cs
@@ -1,0 +1,70 @@
+﻿using System.Text;
+using System.Threading;
+using JetBrains.Annotations;
+using UnityEngine;
+using RegressionGames.StateRecorder.JsonConverters;
+
+namespace RegressionGames.StateRecorder.BotSegments.Models.CVService
+{
+    public class CVObjectDetectionRequest
+    {
+        public CVImageBinaryData screenshot;
+        [CanBeNull] public CVImageBinaryData queryImage;
+        [CanBeNull] public string queryText;
+        /*
+         * <summary>Rect relative to the screenshot resolution</summary>
+        */
+        public RectInt? withinRect;
+
+        // track the index in this bot segment for correlation of the responses
+        public int index;
+
+        
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new (() => new(1000));
+        public string ToJsonString()
+        {
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value);
+            return _stringBuilder.Value.ToString();
+        }
+
+        public void WriteToStringBuilder(StringBuilder stringBuilder)
+        {
+
+            bool textQuery = queryText != null;
+            bool imageQuery = queryImage != null;
+
+            if (textQuery && imageQuery)
+            {
+                RGDebug.LogError("You need to use either textQuery or imageQuery. You can not have both.");
+            }
+            
+            if (!textQuery && !imageQuery)
+            {
+                RGDebug.LogError("You need to use either textQuery or imageQuery. You need to have at least one.");
+            }
+            
+            stringBuilder.Append("{\"screenshot\":");
+            screenshot.WriteToStringBuilder(stringBuilder);
+            
+            if (textQuery)
+            {
+                stringBuilder.Append(",\"queryText\":");
+                StringJsonConverter.WriteToStringBuilder(stringBuilder, queryText);
+            }
+
+            if (imageQuery)
+            {
+                stringBuilder.Append(",\"imageToMatch\":");
+                queryImage.WriteToStringBuilder(stringBuilder);
+            }
+            stringBuilder.Append(",\"withinRect\":");
+            RectIntJsonConverter.WriteToStringBuilderNullable(stringBuilder, withinRect);
+            stringBuilder.Append(",\"index\":");
+            IntJsonConverter.WriteToStringBuilder(stringBuilder, index);
+            stringBuilder.Append("}");
+        }
+    }
+
+
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionRequest.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionRequest.cs
@@ -21,7 +21,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models.CVService
         /// <summary>
         /// Optional text query for object detection.
         /// </summary>
-        [CanBeNull] public string queryText;
+        [CanBeNull] public string textQuery;
 
         /// <summary>
         /// Optional rectangle defining a region of interest within the screenshot.
@@ -35,26 +35,25 @@ namespace RegressionGames.StateRecorder.BotSegments.Models.CVService
         public int index;
 
         public CVObjectDetectionRequest(CVImageBinaryData screenshot,
-                                        string? queryText,
+                                        string? textQuery,
                                         CVImageBinaryData? queryImage,
                                         RectInt? withinRect,
                                         int index)
         {
             this.screenshot = screenshot;
-            this.queryText = queryText;
+            this.textQuery = textQuery;
             this.queryImage = queryImage;
             this.withinRect = withinRect;
             this.index = index;
 
-            // !!! TODO(REG-1915) Move this check to where the json is parsed.
-            if (queryText != null && queryImage != null)
+            if (textQuery != null && queryImage != null)
             {
-                RGDebug.LogError("Both queryText and queryImage are provided. Only one should be used.");
+                RGDebug.LogError("Both textQuery and queryImage are provided. Only one should be used.");
                 return;
             }
-            else if (queryText == null && queryImage == null)
+            else if (textQuery == null && queryImage == null)
             {
-                RGDebug.LogError("Neither queryText nor queryImage is provided. One should be specified.");
+                RGDebug.LogError("Neither textQuery nor queryImage is provided. One should be specified.");
                 return;
             }
         }
@@ -73,10 +72,10 @@ namespace RegressionGames.StateRecorder.BotSegments.Models.CVService
             stringBuilder.Append("{\"screenshot\":");
             screenshot.WriteToStringBuilder(stringBuilder);
             
-            if (queryText != null)
+            if (textQuery != null)
             {
-                stringBuilder.Append(",\"queryText\":");
-                StringJsonConverter.WriteToStringBuilder(stringBuilder, queryText);
+                stringBuilder.Append(",\"textQuery\":");
+                StringJsonConverter.WriteToStringBuilder(stringBuilder, textQuery);
             }
 
             if (queryImage != null)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionRequest.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionRequest.cs
@@ -8,15 +8,30 @@ namespace RegressionGames.StateRecorder.BotSegments.Models.CVService
 {
     public class CVObjectDetectionRequest
     {
+        /// <summary>
+        /// The screenshot image data to be analyzed.
+        /// </summary>
         public CVImageBinaryData screenshot;
+
+        /// <summary>
+        /// Optional image data to be used as a query for object detection.
+        /// </summary>
         [CanBeNull] public CVImageBinaryData queryImage;
+
+        /// <summary>
+        /// Optional text query for object detection.
+        /// </summary>
         [CanBeNull] public string queryText;
-        /*
-         * <summary>Rect relative to the screenshot resolution</summary>
-        */
+
+        /// <summary>
+        /// Optional rectangle defining a region of interest within the screenshot.
+        /// The coordinates are relative to the screenshot.
+        /// </summary>
         public RectInt? withinRect;
 
-        // track the index in this bot segment for correlation of the responses
+        /// <summary>
+        /// Index to track requests and results for each criteria within a segment.
+        /// </summary>
         public int index;
 
         public CVObjectDetectionRequest(CVImageBinaryData screenshot,

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionRequest.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionRequest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 02a90c6ccaa645d196aa0ec567ed4440
+timeCreated: 1724103814

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionResult.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionResult.cs
@@ -1,0 +1,27 @@
+﻿using System.Text;
+using RegressionGames.StateRecorder.JsonConverters;
+using UnityEngine;
+
+namespace RegressionGames.StateRecorder.BotSegments.Models.CVService
+{
+    public class CVObjectDetectionResult
+    {
+        public string text;
+        public Vector2Int resolution;
+        public RectInt rect;
+
+        public override string ToString()
+        {
+            StringBuilder sb = new(1000);
+            sb.Append("{\"text\":");
+            StringJsonConverter.WriteToStringBuilder(sb, text);
+            sb.Append(",\"resolution\":");
+            VectorIntJsonConverter.WriteToStringBuilder(sb, resolution);
+            sb.Append(",\"rect\":");
+            RectIntJsonConverter.WriteToStringBuilder(sb, rect);
+            sb.Append("}");
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionResult.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionResult.cs
@@ -6,19 +6,30 @@ namespace RegressionGames.StateRecorder.BotSegments.Models.CVService
 {
     public class CVObjectDetectionResult
     {
-        public string text;
+        /// <summary>
+        /// The resolution of the image in which the object was detected.
+        /// </summary>
         public Vector2Int resolution;
+
+        /// <summary>
+        /// The bounding box of the detected object within the image.
+        /// </summary>
         public RectInt rect;
+
+        /// <summary>
+        /// The segment index associated with this detection result.
+        /// </summary>
+        public int index;
 
         public override string ToString()
         {
             StringBuilder sb = new(1000);
-            sb.Append("{\"text\":");
-            StringJsonConverter.WriteToStringBuilder(sb, text);
-            sb.Append(",\"resolution\":");
+            sb.Append("{\"resolution\":");
             VectorIntJsonConverter.WriteToStringBuilder(sb, resolution);
             sb.Append(",\"rect\":");
             RectIntJsonConverter.WriteToStringBuilder(sb, rect);
+            sb.Append(",\"index\":");
+            IntJsonConverter.WriteToStringBuilder(sb, index);
             sb.Append("}");
 
             return sb.ToString();

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionResult.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionResult.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 686d7246789c47bf9affcd0ecb120700
+timeCreated: 1724105951

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionResultList.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionResultList.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace RegressionGames.StateRecorder.BotSegments.Models.CVService
+{
+    public class CVObjectDetectionResultList
+    {
+        public List<CVObjectDetectionResult> results;
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionResultList.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionResultList.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4e2f355e61bd465e84b147bf6aa290d8
+timeCreated: 1724106526

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/KeyFrameCriteriaType.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/KeyFrameCriteriaType.cs
@@ -10,7 +10,7 @@
         CVText,
         CVImage,
         ActionComplete,
-        CVObjectDetectionQuery,
+        CVObjectDetection,
 
         //FUTURE
         //Path,

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/KeyFrameCriteriaType.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/KeyFrameCriteriaType.cs
@@ -9,7 +9,8 @@
         PartialNormalizedPath,
         CVText,
         CVImage,
-        ActionComplete
+        ActionComplete,
+        CVObjectDetectionQuery,
 
         //FUTURE
         //Path,

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/SdkApiVersion.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/SdkApiVersion.cs
@@ -70,7 +70,12 @@
          */
         public const int VERSION_15 = 15;
 
+        /*
+         * <summary> Added CV Object Detection Key Frame Criteria. </summary>
+         */
+        public const int VERSION_16 = 16;
+
         // Update this when new features are used in the SDK
-        public const int CURRENT_VERSION = VERSION_15;
+        public const int CURRENT_VERSION = VERSION_16;
     }
 }


### PR DESCRIPTION
[Loom video](https://www.loom.com/share/7d55604f8e2c445daabbf32dab9569c5?sid=613050f0-da98-48c3-9078-fcb358121575).

Implemented the open vocab text query bot segment criteria. 

[Example segments on Boss Room.](https://github.com/Regression-Games/RGBossRoom/pull/67)

There are some follow up tasks that are related to this:
- [Refactor this and CV Image match evaluators.](https://linear.app/regression-games/issue/REG-1928/refactor-cv-object-detection-evaluator)
- [Update Python endpoints to match.](https://linear.app/regression-games/issue/REG-1920/update-python-object-detection-endpoints-to-match-sdk)


---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
