### PR TITLE
[REG-1935] Add missing UnityEngine import

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSequence.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSequence.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json;
 using RegressionGames.StateRecorder.BotSegments.JsonConverters;
 using RegressionGames.StateRecorder.JsonConverters;
 using StateRecorder.BotSegments;
+using UnityEngine;
 
 namespace RegressionGames.StateRecorder.BotSegments.Models
 {


### PR DESCRIPTION
It just so happens that the BotSequences file got by without using any UnityEngine imports when used in the editor, but does rely on the import inside of builds. Added the missing import (this wasn't caught before because the lines that use this import are inside of `!UNITY_EDITOR` pragmas.