### PR TITLE
[REG-1912] Implement bot segment criteria for open vocab image queries.

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
@@ -317,8 +317,9 @@ namespace RegressionGames.StateRecorder.BotSegments
                     }
 
                     var textQuery = criteriaData.textQuery;
+                    var imageQuery = criteriaData.imageQuery;
                     // do NOT await this, let it run async
-                    _ = CVServiceManager.GetInstance().PostCriteriaObjectTextQuery(
+                    _ = CVServiceManager.GetInstance().PostCriteriaObjectDetection(
                         new CVObjectDetectionRequest(
                             screenshot: new CVImageBinaryData()
                             {
@@ -327,7 +328,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                                 data = imageData
                             },
                             textQuery: textQuery,
-                            imageQuery: null,
+                            imageQuery: imageQuery,
                             withinRect: withinRect,
                             index: index
                         ),

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVServiceManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVServiceManager.cs
@@ -72,13 +72,29 @@ namespace RegressionGames
             );
         }
 
-        public async Task PostCriteriaObjectTextQuery(CVObjectDetectionRequest request, 
+        public async Task PostCriteriaObjectDetection(CVObjectDetectionRequest request, 
                                                       Action<Action> abortRegistrationHook,
                                                       Action<List<CVObjectDetectionResult>> onSuccess,
                                                       Action onFailure)
         {
+            
+            string endpoint;
+            if (!string.IsNullOrEmpty(request.textQuery))
+            {
+                endpoint = "/criteria-object-text-query";
+            }
+            else if (request.imageQuery != null)
+            {
+                endpoint = "/criteria-object-image-query";
+            }
+            else
+            {
+                RGDebug.LogError("Invalid CVObjectDetectionRequest: Both textQuery and queryImage are null or empty.");
+                onFailure.Invoke();
+                return;
+            }
             await SendWebRequest(
-                uri: $"{GetCvServiceBaseUri()}/criteria-object-text-query",
+                uri: $"{GetCvServiceBaseUri()}/{endpoint}",
                 method: "POST",
                 payload: request.ToJsonString(),
                 abortRegistrationHook: abortRegistrationHook.Invoke,
@@ -94,6 +110,7 @@ namespace RegressionGames
                 }
             );
         }
+
         
         public async Task PostCriteriaTextDiscover(CVTextCriteriaRequest request, Action<Action> abortRegistrationHook, Action<List<CVTextResult>> onSuccess, Action onFailure)
         {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVServiceManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVServiceManager.cs
@@ -81,18 +81,24 @@ namespace RegressionGames
             string endpoint;
             if (!string.IsNullOrEmpty(request.textQuery))
             {
-                endpoint = "/criteria-object-text-query";
+                endpoint = "criteria-object-text-query";
             }
             else if (request.imageQuery != null)
             {
-                endpoint = "/criteria-object-image-query";
+                endpoint = "criteria-object-image-query";
             }
-            else
-            {
-                RGDebug.LogError("Invalid CVObjectDetectionRequest: Both textQuery and queryImage are null or empty.");
+            else if (request.imageQuery != null && request.textQuery != null){
+                RGDebug.LogError("Invalid CVObjectDetectionRequest: Both textQuery and queryImage are both set. Please set one or the other.");
                 onFailure.Invoke();
                 return;
             }
+            else
+            {
+                RGDebug.LogError("Invalid CVObjectDetectionRequest: Both textQuery and queryImage are null or empty. Please set at least one of them.");
+                onFailure.Invoke();
+                return;
+            }
+            
             await SendWebRequest(
                 uri: $"{GetCvServiceBaseUri()}/{endpoint}",
                 method: "POST",

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionMouseActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionMouseActionData.cs
@@ -129,7 +129,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                         _cvResultsBoundsRect = null;
 
                         // do NOT await this, let it run async
-                        _ = CVServiceManager.GetInstance().PostCriteriaObjectTextQuery(
+                        _ = CVServiceManager.GetInstance().PostCriteriaObjectDetection(
                             new CVObjectDetectionRequest(
                                 screenshot: new CVImageBinaryData()
                                 {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionRequest.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionRequest.cs
@@ -37,7 +37,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models.CVService
         public CVObjectDetectionRequest(CVImageBinaryData screenshot,
                                         [CanBeNull] string textQuery,
                                         [CanBeNull] string imageQuery,
-                                        [CanBeNull] RectInt? withinRect,
+                                        RectInt? withinRect,
                                         int index = 0)
         {
             this.screenshot = screenshot;
@@ -71,18 +71,10 @@ namespace RegressionGames.StateRecorder.BotSegments.Models.CVService
 
             stringBuilder.Append("{\"screenshot\":");
             screenshot.WriteToStringBuilder(stringBuilder);
-            
-            if (textQuery != null)
-            {
-                stringBuilder.Append(",\"textQuery\":");
-                StringJsonConverter.WriteToStringBuilder(stringBuilder, textQuery);
-            }
-
-            if (imageQuery != null)
-            {
-                stringBuilder.Append(",\"imageToMatch\":");
-                StringJsonConverter.WriteToStringBuilder(stringBuilder, imageQuery);
-            }
+            stringBuilder.Append(",\"textQuery\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, textQuery);
+            stringBuilder.Append(",\"imageToMatch\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, imageQuery);
             stringBuilder.Append(",\"withinRect\":");
             RectIntJsonConverter.WriteToStringBuilderNullable(stringBuilder, withinRect);
             stringBuilder.Append(",\"index\":");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionRequest.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVService/CVObjectDetectionRequest.cs
@@ -14,9 +14,9 @@ namespace RegressionGames.StateRecorder.BotSegments.Models.CVService
         public CVImageBinaryData screenshot;
 
         /// <summary>
-        /// Optional image data to be used as a query for object detection.
+        /// Optional image data to be used as a query for object detection in base64 encoded string format.
         /// </summary>
-        [CanBeNull] public CVImageBinaryData imageQuery;
+        [CanBeNull] public string imageQuery;
 
         /// <summary>
         /// Optional text query for object detection.
@@ -36,8 +36,8 @@ namespace RegressionGames.StateRecorder.BotSegments.Models.CVService
 
         public CVObjectDetectionRequest(CVImageBinaryData screenshot,
                                         [CanBeNull] string textQuery,
-                                        [CanBeNull] CVImageBinaryData imageQuery,
-                                        RectInt? withinRect,
+                                        [CanBeNull] string imageQuery,
+                                        [CanBeNull] RectInt? withinRect,
                                         int index = 0)
         {
             this.screenshot = screenshot;
@@ -81,7 +81,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models.CVService
             if (imageQuery != null)
             {
                 stringBuilder.Append(",\"imageToMatch\":");
-                imageQuery.WriteToStringBuilder(stringBuilder);
+                StringJsonConverter.WriteToStringBuilder(stringBuilder, imageQuery);
             }
             stringBuilder.Append(",\"withinRect\":");
             RectIntJsonConverter.WriteToStringBuilderNullable(stringBuilder, withinRect);


### PR DESCRIPTION
[Loom video.](https://www.loom.com/share/1bd67e94a1624c109b7a9a555251aa4c)
Related [Unity Boss Room example](https://github.com/Regression-Games/RGBossRoom/pull/69).

Implemented object detection criteria match using image query.
---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
