### PR TITLE
[REG-1915] Implement bot segment action for clicking based on open vocab image queries.

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotActionJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotActionJsonConverter.cs
@@ -44,7 +44,7 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
                     case BotActionType.Mouse_CVText:
                         data = jObject["data"].ToObject<CVTextMouseActionData>(serializer);
                         break;
-                    case BotActionType.Mouse_ObjectDetectionText:
+                    case BotActionType.Mouse_ObjectDetection:
                         data = jObject["data"].ToObject<CVObjectDetectionMouseActionData>(serializer);
                         break;
                     default:

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/CVObjectDetectionMouseActionDataJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/CVObjectDetectionMouseActionDataJsonConverter.cs
@@ -21,7 +21,7 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
                 // ReSharper disable once UseObjectOrCollectionInitializer - easier to debug when on separate lines
                 CVObjectDetectionMouseActionData actionModel = new();
                 actionModel.apiVersion = jObject.GetValue("apiVersion").ToObject<int>(serializer);
-                actionModel.imageQuery = jObject.GetValue("imageData")?.ToObject<string>(serializer);
+                actionModel.imageQuery = jObject.GetValue("imageQuery")?.ToObject<string>(serializer);
                 actionModel.textQuery = jObject.GetValue("textQuery")?.ToObject<string>(serializer);
                 actionModel.withinRect = jObject.GetValue("withinRect")?.ToObject<CVWithinRect>(serializer);
                 actionModel.actions = jObject.GetValue("actions").ToObject<List<CVMouseActionDetails>>(serializer);

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotActionType.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotActionType.cs
@@ -10,7 +10,7 @@
         MonkeyBot,
         Mouse_CVImage,
         Mouse_CVText,
-        Mouse_ObjectDetectionText,
+        Mouse_ObjectDetection,
 
         //POSSIBLE_FUTURE_ACTIONS
         //Timer,

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionMouseActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionMouseActionData.cs
@@ -24,7 +24,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public int apiVersion = SdkApiVersion.VERSION_17;
 
         [NonSerialized]
-        public static readonly BotActionType Type = BotActionType.Mouse_ObjectDetectionText;
+        public static readonly BotActionType Type = BotActionType.Mouse_ObjectDetection;
 
         /**
          * base64 encoded byte[] of jpg image data , NOT the raw pixel data, the full jpg file bytes
@@ -97,10 +97,10 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public void StartAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
         {
             // get the CV evaluate started...
-            RequestCVObjectDetectionTextEvaluation(segmentNumber);
+            RequestCVObjectDetectionEvaluation(segmentNumber);
         }
 
-        private void RequestCVObjectDetectionTextEvaluation(int segmentNumber)
+        private void RequestCVObjectDetectionEvaluation(int segmentNumber)
         {
             lock (_syncLock)
             {
@@ -138,7 +138,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                                     data = screenshot
                                 },
                                 textQuery: textQuery,
-                                imageQuery: null,
+                                imageQuery: imageQuery,
                                 withinRect: queryWithinRect
                             ),
                             // Register the abort action.
@@ -150,7 +150,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                             // Log the failure, reset relevant state variables, and clean up resources.
                             onFailure: () => OnFailure(segmentNumber)
                         );
-                        RGDebug.LogDebug($"CVImageMouseActionData - RequestCVObjectDetectionTextEvaluation - botSegment: {segmentNumber} - Request - SENT");
+                        RGDebug.LogDebug($"CVObjectDetectionMouseActionData - RequestCVObjectDetectionEvaluation - botSegment: {segmentNumber} - Request - SENT");
                     }
                 }
             }
@@ -163,10 +163,10 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         /// <param name="action">The abort action to be registered.</param>
         private void OnAbort(int segmentNumber, Action action)
         {
-            RGDebug.LogVerbose($"CVImageMouseActionData - RequestCVObjectDetectionTextEvaluation - botSegment: {segmentNumber} - Request - abortHook registration callback");
+            RGDebug.LogVerbose($"CVObjectDetectionMouseActionData - RequestCVObjectDetectionEvaluation - botSegment: {segmentNumber} - Request - abortHook registration callback");
             lock (_syncLock)
             {
-                RGDebug.LogVerbose($"CVImageMouseActionData - RequestCVObjectDetectionTextEvaluation - botSegment: {segmentNumber} - abortHook registration callback - insideLock");
+                RGDebug.LogVerbose($"CVObjectDetectionMouseActionData - RequestCVObjectDetectionEvaluation - botSegment: {segmentNumber} - abortHook registration callback - insideLock");
                 _requestAbortAction = action;
             }
         }
@@ -179,14 +179,14 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         /// <param name="segmentNumber">The segment number of the bot action, used for logging and debugging purposes.</param>
         private void OnFailure(int segmentNumber)
         {
-            RGDebug.LogWarning($"CVImageMouseActionData - RequestCVObjectDetectionTextEvaluation - botSegment: {segmentNumber} - Request - onFailure callback - failure invoking CVService criteria-object-text-query evaluation");
+            RGDebug.LogWarning($"CVObjectDetectionMouseActionData - RequestCVObjectDetectionEvaluation - botSegment: {segmentNumber} - Request - onFailure callback - failure invoking CVService criteria-object-text-query evaluation");
             lock (_syncLock)
             {
-                RGDebug.LogVerbose($"CVImageMouseActionData - RequestCVObjectDetectionTextEvaluation - botSegment: {segmentNumber} - Request - onFailure callback - insideLock");
+                RGDebug.LogVerbose($"CVObjectDetectionMouseActionData - RequestCVObjectDetectionEvaluation - botSegment: {segmentNumber} - Request - onFailure callback - insideLock");
                 // make sure we haven't already cleaned this up
                 if (_requestAbortAction != null)
                 {
-                    RGDebug.LogVerbose($"CVImageMouseActionData - RequestCVObjectDetectionTextEvaluation - botSegment: {segmentNumber} - Request - onFailure callback - storingResult");
+                    RGDebug.LogVerbose($"CVObjectDetectionMouseActionData - RequestCVObjectDetectionEvaluation - botSegment: {segmentNumber} - Request - onFailure callback - storingResult");
                     _resultReceived = true;
                     _cvResultsBoundsRect = null;
 
@@ -207,19 +207,19 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         /// <param name="list">A list of CVObjectDetectionResult objects returned from the CV evaluation.</param>
         private void OnSuccess(int segmentNumber, List<CVObjectDetectionResult> list)
         {
-            RGDebug.LogDebug($"CVImageMouseActionData - RequestCVObjectDetectionTextEvaluation - botSegment: {segmentNumber} - Request - onSuccess callback");
+            RGDebug.LogDebug($"CVObjectDetectionMouseActionData - RequestCVObjectDetectionEvaluation - botSegment: {segmentNumber} - Request - onSuccess callback");
             lock (_syncLock)
             {
-                RGDebug.LogVerbose($"CVImageMouseActionData - RequestCVObjectDetectionTextEvaluation - botSegment: {segmentNumber} - Request - onSuccess callback - insideLock");
+                RGDebug.LogVerbose($"CVObjectDetectionMouseActionData - RequestCVObjectDetectionEvaluation - botSegment: {segmentNumber} - Request - onSuccess callback - insideLock");
                 // make sure we haven't already cleaned this up
                 if (_requestAbortAction != null)
                 {
-                    RGDebug.LogVerbose($"CVImageMouseActionData - RequestCVObjectDetectionTextEvaluation - botSegment: {segmentNumber} - Request - onSuccess callback - storingResult");
+                    RGDebug.LogVerbose($"CVObjectDetectionMouseActionData - RequestCVObjectDetectionEvaluation - botSegment: {segmentNumber} - Request - onSuccess callback - storingResult");
 
                     // pick a random rect from the results, if they didn't want this random, they should have specified within rect
                     if (list.Count > 1)
                     {
-                        RGDebug.LogInfo($"({segmentNumber}) CVImageMouseActionData - Multiple results were returned for CV Image evaluation.  A random one of these will be saved as the result.  Consider specifying a precise `withinRect` in your action definition to get a singular result.");
+                        RGDebug.LogInfo($"({segmentNumber}) CVObjectDetectionMouseActionData - Multiple results were returned for CV Image evaluation.  A random one of these will be saved as the result.  Consider specifying a precise `withinRect` in your action definition to get a singular result.");
                     }
 
                     if (list.Count > 0)
@@ -272,7 +272,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                                     var rect = _cvResultsBoundsRect.Value;
 
                                     var position = new Vector2Int((int)rect.center.x, (int)rect.center.y);
-                                    RGDebug.LogDebug($"CVImageMouseActionData - ProcessAction - botSegment: {segmentNumber} - frame: {Time.frameCount} - Sending Raw Position Mouse Event: {currentAction} at position: {VectorIntJsonConverter.ToJsonString(position)}");
+                                    RGDebug.LogDebug($"CVObjectDetectionMouseActionData - ProcessAction - botSegment: {segmentNumber} - frame: {Time.frameCount} - Sending Raw Position Mouse Event: {currentAction} at position: {VectorIntJsonConverter.ToJsonString(position)}");
                                     MouseEventSender.SendRawPositionMouseEvent(
                                         replaySegment: segmentNumber,
                                         normalizedPosition: position,
@@ -289,21 +289,21 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                                 }
                                 else
                                 {
-                                    RGDebug.LogDebug($"CVImageMouseActionData - ProcessAction - botSegment: {segmentNumber} - frame: {Time.frameCount} - imageData not found in current screen ...");
-                                    _lastError = "CVImageMouseActionData - imageData not found in current screen ...";
+                                    RGDebug.LogDebug($"CVObjectDetectionMouseActionData - ProcessAction - botSegment: {segmentNumber} - frame: {Time.frameCount} - imageData not found in current screen ...");
+                                    _lastError = "CVObjectDetectionMouseActionData - imageData not found in current screen ...";
                                     error = _lastError;
                                     // start a new request
-                                    RequestCVObjectDetectionTextEvaluation(segmentNumber);
+                                    RequestCVObjectDetectionEvaluation(segmentNumber);
                                     return false;
                                 }
                             }
                             else
                             {
-                                RGDebug.LogDebug($"CVImageMouseActionData - ProcessAction - botSegment: {segmentNumber} - frame: {Time.frameCount} - waiting for CV Object Detection results ...");
-                                _lastError = "CVImageMouseActionData - waiting for CV Object Detection results ...";
+                                RGDebug.LogDebug($"CVObjectDetectionMouseActionData - ProcessAction - botSegment: {segmentNumber} - frame: {Time.frameCount} - waiting for CV Object Detection results ...");
+                                _lastError = "CVObjectDetectionMouseActionData - waiting for CV Object Detection results ...";
                                 error = _lastError;
                                 // make sure we have a request in progress (this call checks internally to make sure one isn't already in progress)
-                                RequestCVObjectDetectionTextEvaluation(segmentNumber);
+                                RequestCVObjectDetectionEvaluation(segmentNumber);
                                 return false;
                             }
                         }
@@ -330,7 +330,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         public void StopAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
         {
-            // for cv image analysis, we finish the action queue even if criteria match before hand... don't set _isStopped;
+            // for cv object detection, we finish the action queue even if criteria match before hand... don't set _isStopped;
         }
 
         public void WriteToStringBuilder(StringBuilder stringBuilder)


### PR DESCRIPTION
[Loom video.](https://www.loom.com/share/a6657745b2674b7e8c08da81000b8503?sid=da3f217b-1e1d-4a7c-93a9-d38ccc057a13)

[Related Unity Boss Room example.](https://github.com/Regression-Games/RGBossRoom/pull/70)

Implement the bot segment action using image queries.

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
