### PR TITLE
[REG-1879] Default configuration for AIService to prod

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGSettings.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGSettings.cs
@@ -41,8 +41,8 @@ namespace RegressionGames
         [SerializeField] private string rgHostAddress;
         [SerializeField] private string apiKey;
 
-        // CV Settings
-        [SerializeField] private string cvHostAddress;
+        // AI Service Settings
+        [SerializeField] private string aiServiceHostAddress;
 
         /*
          * This is setup to be safely callable on the non-main thread.
@@ -71,7 +71,8 @@ namespace RegressionGames
                 _settings = CreateInstance<RGSettings>();
                 _settings.useSystemSettings = true;
                 _settings.rgHostAddress = "https://play.regression.gg";
-                _settings.cvHostAddress = "http://127.0.0.1:18888";
+                /* Use "http://127.0.0.1:18888/" for local aiservice dev testing */
+                _settings.aiServiceHostAddress = "https://play.regression.gg";
                 _settings.logLevel = DebugLogLevel.Info;
 
                 _settings.feature_StateRecordingAndReplay = true;
@@ -89,9 +90,9 @@ namespace RegressionGames
             }
 
             // handle settings saved without a cv host address
-            if (_settings.cvHostAddress == null)
+            if (_settings.aiServiceHostAddress == null)
             {
-                _settings.cvHostAddress = "http://127.0.0.1:18888";
+                _settings.aiServiceHostAddress = "https://play.regression.gg";
             }
 
             return _settings;
@@ -147,9 +148,9 @@ namespace RegressionGames
             return rgHostAddress;
         }
 
-        public string GetCvHostAddress()
+        public string GetAIServiceHostAddress()
         {
-            return cvHostAddress;
+            return aiServiceHostAddress;
         }
 
         public bool GetFeatureStateRecordingAndReplay()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGSettings.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGSettings.cs
@@ -41,7 +41,8 @@ namespace RegressionGames
         [SerializeField] private string rgHostAddress;
         [SerializeField] private string apiKey;
 
-        // AI Service Settings
+        // AI Service Settings - Use "http://127.0.0.1:18888/" for local aiservice dev testing
+        // NOTE: By default this is left as NULL and tracks rgHostAddress value unless overridden
         [SerializeField] private string aiServiceHostAddress;
 
         /*
@@ -71,8 +72,6 @@ namespace RegressionGames
                 _settings = CreateInstance<RGSettings>();
                 _settings.useSystemSettings = true;
                 _settings.rgHostAddress = "https://play.regression.gg";
-                /* Use "http://127.0.0.1:18888/" for local aiservice dev testing */
-                _settings.aiServiceHostAddress = "https://play.regression.gg";
                 _settings.logLevel = DebugLogLevel.Info;
 
                 _settings.feature_StateRecordingAndReplay = true;
@@ -87,12 +86,6 @@ namespace RegressionGames
 #if !UNITY_EDITOR
                 Debug.LogWarning("RG settings could not be loaded. Make sure to log into Regression Games within the Unity Editor before building your project. For now, an empty user settings object will be used.");
 #endif
-            }
-
-            // handle settings saved without a cv host address
-            if (_settings.aiServiceHostAddress == null)
-            {
-                _settings.aiServiceHostAddress = "https://play.regression.gg";
             }
 
             return _settings;
@@ -150,6 +143,11 @@ namespace RegressionGames
 
         public string GetAIServiceHostAddress()
         {
+            // Tracks 'rgHostAddress' unless explicitly overridden
+            if (string.IsNullOrEmpty(aiServiceHostAddress))
+            {
+                return rgHostAddress;
+            }
             return aiServiceHostAddress;
         }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVServiceManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVServiceManager.cs
@@ -27,7 +27,7 @@ namespace RegressionGames
         private String GetCvServiceBaseUri()
         {
             RGSettings rgSettings = RGSettings.GetOrCreateSettings();
-            string host = rgSettings.GetCvHostAddress();
+            string host = rgSettings.GetAIServiceHostAddress();
 
             // If env var is set, use that instead
             string hostOverride = RGEnvConfigs.ReadCvHost();
@@ -44,7 +44,7 @@ namespace RegressionGames
             Uri hostUri = new(host);
             if (!hostUri.IsLoopback)
             {
-                //return $"{host}/rgcvservice";
+                return $"{host}/aiservice";
             }
             return $"{host}";
         }


### PR DESCRIPTION
- Update default endpoint for aiService to be production.  Empty or null string for the new config option will default to using the rgHostAddress

Developers can edit `RGSettings` scriptableObject asset in `Assets/Resources/RGSettings.asset` if they need to override this to `http://localhost:18888/` for local development.

![image](https://github.com/user-attachments/assets/a1981e47-a8c8-4c62-80cc-7b6f758793d7)


---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
