### PR TITLE
[REG-1981] Implement the Object Detection threshold parameter in sdk.

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/DeleteSequenceDialog.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/DeleteSequenceDialog.prefab
@@ -1,0 +1,2013 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &352325880016845589
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8559602234941710125}
+  - component: {fileID: 5879958647783266825}
+  - component: {fileID: 2876990729521185396}
+  m_Layer: 0
+  m_Name: CardIcon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8559602234941710125
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 352325880016845589}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1362750833803285249}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 18, y: -20}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5879958647783266825
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 352325880016845589}
+  m_CullTransparentMesh: 1
+--- !u!114 &2876990729521185396
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 352325880016845589}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: bd6e947eec7a141eca1757ae4e8edc8f, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3095744524802668802
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7572337814382127804}
+  - component: {fileID: 5887954076049798420}
+  - component: {fileID: 1100989587491364780}
+  m_Layer: 0
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7572337814382127804
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3095744524802668802}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7710064582303911948}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 64.5, y: -20}
+  m_SizeDelta: {x: 50, y: 24}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5887954076049798420
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3095744524802668802}
+  m_CullTransparentMesh: 1
+--- !u!114 &1100989587491364780
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3095744524802668802}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Cancel
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &3295359687824217528
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2591107558348843798}
+  - component: {fileID: 6969905283881697303}
+  - component: {fileID: 8875180094165963757}
+  - component: {fileID: 7995040213816328390}
+  - component: {fileID: 2967997487976718605}
+  - component: {fileID: 3716949323108867443}
+  m_Layer: 0
+  m_Name: Cancel Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2591107558348843798
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3295359687824217528}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5739518917602435401}
+  - {fileID: 7710064582303911948}
+  m_Father: {fileID: 8355597630735644262}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 50, y: -20}
+  m_SizeDelta: {x: 100, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6969905283881697303
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3295359687824217528}
+  m_CullTransparentMesh: 1
+--- !u!114 &8875180094165963757
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3295359687824217528}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 504645b56eb2b4b49818688fc0d29e70, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1.5
+--- !u!114 &7995040213816328390
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3295359687824217528}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 0.101960786}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 0.7490196}
+    m_PressedColor: {r: 1, g: 1, b: 1, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 6816270505419979482}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2967997487976718605}
+        m_TargetAssemblyTypeName: RGCancelSequenceEditButton, RegressionGames
+        m_MethodName: OnClick
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &2967997487976718605
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3295359687824217528}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b20d18a80dc2841b9a5c2e324cc921e6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  overlayContainer: {fileID: 7029756735420670719, guid: 1ebf553132a9f403a83fb39025c3fbff, type: 3}
+--- !u!114 &3716949323108867443
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3295359687824217528}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: 100
+  m_PreferredHeight: -1
+  m_FlexibleWidth: 0
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &3302924962423838768
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8355597630735644262}
+  - component: {fileID: 7284767821714419639}
+  - component: {fileID: 3704677351544485686}
+  m_Layer: 0
+  m_Name: Bottom Buttons
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8355597630735644262
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3302924962423838768}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2591107558348843798}
+  - {fileID: 6908950803480599689}
+  m_Father: {fileID: 5020629288057838675}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7284767821714419639
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3302924962423838768}
+  m_CullTransparentMesh: 1
+--- !u!114 &3704677351544485686
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3302924962423838768}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: 1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &3344671489940990385
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7750639364715422709}
+  - component: {fileID: 9174921897374675488}
+  - component: {fileID: 4866633913108977741}
+  - component: {fileID: 864267604389426403}
+  m_Layer: 5
+  m_Name: Description
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7750639364715422709
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3344671489940990385}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6974553987836872862}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 539.38, y: 0}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &9174921897374675488
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3344671489940990385}
+  m_CullTransparentMesh: 1
+--- !u!114 &4866633913108977741
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3344671489940990385}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: The Segments composing your Sequence will not be deleted
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &864267604389426403
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3344671489940990385}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 0
+  m_VerticalFit: 2
+--- !u!1 &3440159816827592086
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6908950803480599689}
+  - component: {fileID: 5501198405099729597}
+  - component: {fileID: 6154526166515430080}
+  - component: {fileID: 3917231402918375064}
+  - component: {fileID: 6675908072984854723}
+  - component: {fileID: 9089944729806318628}
+  m_Layer: 0
+  m_Name: Confrim Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6908950803480599689
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3440159816827592086}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8907518529459168435}
+  - {fileID: 1362750833803285249}
+  m_Father: {fileID: 8355597630735644262}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -70, y: -20}
+  m_SizeDelta: {x: 140, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5501198405099729597
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3440159816827592086}
+  m_CullTransparentMesh: 1
+--- !u!114 &6154526166515430080
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3440159816827592086}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 504645b56eb2b4b49818688fc0d29e70, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1.5
+--- !u!114 &3917231402918375064
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3440159816827592086}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 0.101960786}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 0.7490196}
+    m_PressedColor: {r: 1, g: 1, b: 1, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 1, g: 1, b: 1, a: 0}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 6122776501234296025}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &6675908072984854723
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3440159816827592086}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 0
+  m_VerticalFit: 0
+--- !u!114 &9089944729806318628
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3440159816827592086}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b4c14b74db70442987a600bc2eb0f06a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  overlayContainer: {fileID: 7029756735420670719, guid: 1ebf553132a9f403a83fb39025c3fbff, type: 3}
+--- !u!1 &3868426123100791526
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6448674239935938532}
+  - component: {fileID: 3548536268950093500}
+  - component: {fileID: 3229410208320690648}
+  m_Layer: 0
+  m_Name: CardIcon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6448674239935938532
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3868426123100791526}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7710064582303911948}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 20.5, y: -20}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3548536268950093500
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3868426123100791526}
+  m_CullTransparentMesh: 1
+--- !u!114 &3229410208320690648
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3868426123100791526}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 1b3a412e721a74c23a82c98f7e27f8b6, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4349990721754939226
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 513760574875140303}
+  - component: {fileID: 1996402713051222515}
+  - component: {fileID: 2472625596724639132}
+  - component: {fileID: 2202142764604086899}
+  - component: {fileID: 5245023277716048602}
+  m_Layer: 5
+  m_Name: Sequence Name
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &513760574875140303
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4349990721754939226}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2653587487447981162}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 340.63, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &1996402713051222515
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4349990721754939226}
+  m_CullTransparentMesh: 1
+--- !u!114 &2472625596724639132
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4349990721754939226}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: A Placeholder Sequence
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 16
+  m_fontSizeBase: 16
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &2202142764604086899
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4349990721754939226}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 2
+--- !u!114 &5245023277716048602
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4349990721754939226}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &5173618209008028305
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6974553987836872862}
+  - component: {fileID: 8359681705368220126}
+  - component: {fileID: 8051207003241175365}
+  m_Layer: 0
+  m_Name: Content Container
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6974553987836872862
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5173618209008028305}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2653587487447981162}
+  - {fileID: 7750639364715422709}
+  m_Father: {fileID: 5020629288057838675}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 285.69, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8359681705368220126
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5173618209008028305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 2
+--- !u!114 &8051207003241175365
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5173618209008028305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 24
+  m_ChildAlignment: 1
+  m_Spacing: 16
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!1 &5209547121937876819
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4942844073237141754}
+  - component: {fileID: 2713883705951966115}
+  - component: {fileID: 1042340843727526981}
+  - component: {fileID: 7537918742048164994}
+  m_Layer: 0
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4942844073237141754
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5209547121937876819}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1362750833803285249}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 78.685, y: -20}
+  m_SizeDelta: {x: 93.37, y: 24}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2713883705951966115
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5209547121937876819}
+  m_CullTransparentMesh: 1
+--- !u!114 &1042340843727526981
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5209547121937876819}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Confirm Delete
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &7537918742048164994
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5209547121937876819}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 0
+--- !u!1 &5671917730814084334
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2653587487447981162}
+  - component: {fileID: 5374648963143202249}
+  - component: {fileID: 7546698920990503860}
+  - component: {fileID: 6728823379289593944}
+  m_Layer: 0
+  m_Name: Headline Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2653587487447981162
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5671917730814084334}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 210366935220034040}
+  - {fileID: 513760574875140303}
+  m_Father: {fileID: 6974553987836872862}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 269.69, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5374648963143202249
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5671917730814084334}
+  m_CullTransparentMesh: 1
+--- !u!114 &7546698920990503860
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5671917730814084334}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 1
+  m_Spacing: 8
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &6728823379289593944
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5671917730814084334}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 2
+--- !u!1 &7561389278646583383
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8907518529459168435}
+  - component: {fileID: 105923719357499023}
+  - component: {fileID: 6122776501234296025}
+  - component: {fileID: 1738637352341324064}
+  m_Layer: 0
+  m_Name: ConfirmButtonBackground
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8907518529459168435
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7561389278646583383}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6908950803480599689}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &105923719357499023
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7561389278646583383}
+  m_CullTransparentMesh: 1
+--- !u!114 &6122776501234296025
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7561389278646583383}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.7372549, g: 0.20392157, b: 0.16862746, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 90bd71d4d6f9b407f8764062a947ee0b, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1.5
+--- !u!114 &1738637352341324064
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7561389278646583383}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 0
+  m_VerticalFit: 0
+--- !u!1 &7767635361911652193
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6790062799219569191}
+  - component: {fileID: 8362736538257294569}
+  - component: {fileID: 7965932967181527208}
+  - component: {fileID: 9084201445455389861}
+  m_Layer: 0
+  m_Name: DeleteSequenceDialog
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6790062799219569191
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7767635361911652193}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5020629288057838675}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8362736538257294569
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7767635361911652193}
+  m_CullTransparentMesh: 1
+--- !u!114 &7965932967181527208
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7767635361911652193}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.9882353}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 6ff773ea42aedd04c8bb96a1fe9a73b8, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1.5
+--- !u!114 &9084201445455389861
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7767635361911652193}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aac88dd6460c402ea0510a7e7d10fb32, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sequenceNamePrefab: {fileID: 2472625596724639132}
+  confirmButton: {fileID: 3917231402918375064}
+  cancelButton: {fileID: 7995040213816328390}
+  sequencePath: 
+--- !u!1 &7906224119633392473
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5020629288057838675}
+  - component: {fileID: 462404351855912097}
+  - component: {fileID: 9017673168987668619}
+  - component: {fileID: 7132650940901615279}
+  - component: {fileID: 6022871033085762346}
+  m_Layer: 0
+  m_Name: Dialog Container
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5020629288057838675
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7906224119633392473}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6974553987836872862}
+  - {fileID: 8355597630735644262}
+  m_Father: {fileID: 6790062799219569191}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &462404351855912097
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7906224119633392473}
+  m_CullTransparentMesh: 1
+--- !u!114 &9017673168987668619
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7906224119633392473}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: b21fb9f9e75d64529990b72edb231470, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7132650940901615279
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7906224119633392473}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 2
+--- !u!114 &6022871033085762346
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7906224119633392473}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 16
+    m_Right: 16
+    m_Top: 16
+    m_Bottom: 16
+  m_ChildAlignment: 4
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!1 &7923157158415574749
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7710064582303911948}
+  - component: {fileID: 548545922943541116}
+  - component: {fileID: 5140475386086178870}
+  m_Layer: 0
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7710064582303911948
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7923157158415574749}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6448674239935938532}
+  - {fileID: 7572337814382127804}
+  m_Father: {fileID: 2591107558348843798}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &548545922943541116
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7923157158415574749}
+  m_CullTransparentMesh: 1
+--- !u!114 &5140475386086178870
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7923157158415574749}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 8
+    m_Right: 8
+    m_Top: 8
+    m_Bottom: 8
+  m_ChildAlignment: 4
+  m_Spacing: 4
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!1 &8234154922869866732
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 210366935220034040}
+  - component: {fileID: 3467256996024105745}
+  - component: {fileID: 4705857070167017754}
+  - component: {fileID: 9216330243083148525}
+  m_Layer: 5
+  m_Name: Are you sure text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &210366935220034040
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8234154922869866732}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2653587487447981162}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &3467256996024105745
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8234154922869866732}
+  m_CullTransparentMesh: 1
+--- !u!114 &4705857070167017754
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8234154922869866732}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Are you sure you want to delete the Sequence:'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 16
+  m_fontSizeBase: 16
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &9216330243083148525
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8234154922869866732}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 0
+--- !u!1 &8655402374862502120
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1362750833803285249}
+  - component: {fileID: 5761787994209308041}
+  - component: {fileID: 1220939632043839844}
+  - component: {fileID: 176149529477073036}
+  m_Layer: 0
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1362750833803285249
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8655402374862502120}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8559602234941710125}
+  - {fileID: 4942844073237141754}
+  m_Father: {fileID: 6908950803480599689}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 69.9, y: -20}
+  m_SizeDelta: {x: 0, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5761787994209308041
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8655402374862502120}
+  m_CullTransparentMesh: 1
+--- !u!114 &1220939632043839844
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8655402374862502120}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 8
+    m_Right: 8
+    m_Top: 8
+    m_Bottom: 8
+  m_ChildAlignment: 4
+  m_Spacing: 4
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &176149529477073036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8655402374862502120}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 0
+--- !u!1 &9123573312774448513
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5739518917602435401}
+  - component: {fileID: 5536940672507413890}
+  - component: {fileID: 6816270505419979482}
+  m_Layer: 0
+  m_Name: CancelButtonBackground
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5739518917602435401
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9123573312774448513}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2591107558348843798}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0.25}
+  m_SizeDelta: {x: -2.0000007, y: -1.5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5536940672507413890
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9123573312774448513}
+  m_CullTransparentMesh: 1
+--- !u!114 &6816270505419979482
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9123573312774448513}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3962264, g: 0.3962264, b: 0.3962264, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 90bd71d4d6f9b407f8764062a947ee0b, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1.5

--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/DeleteSequenceDialog.prefab.meta
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/DeleteSequenceDialog.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b173f524aed5741e7bf7718478ebfae9
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/Sequence Editor.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/Sequence Editor.prefab
@@ -1052,7 +1052,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1.75
+  m_PixelsPerUnitMultiplier: 1.5
 --- !u!1 &3438822981101495124
 GameObject:
   m_ObjectHideFlags: 0
@@ -1132,7 +1132,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1.5
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &2714723401516955631
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1577,7 +1577,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 3
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3979334621455181221
 GameObject:
   m_ObjectHideFlags: 0
@@ -4161,7 +4161,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.735849, g: 0.20201701, b: 0.17007832, a: 1}
+  m_Color: {r: 0.4, g: 0.4, b: 0.4, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -4177,7 +4177,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1.75
+  m_PixelsPerUnitMultiplier: 1.5
 --- !u!1 &8199636628222546838
 GameObject:
   m_ObjectHideFlags: 0

--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/SequenceCard.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/SequenceCard.prefab
@@ -289,7 +289,7 @@ MonoBehaviour:
     m_HighlightedColor: {r: 1, g: 1, b: 1, a: 0.5019608}
     m_PressedColor: {r: 1, g: 1, b: 1, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 0.8}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_DisabledColor: {r: 0.2830189, g: 0.2830189, b: 0.2830189, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
@@ -341,6 +341,7 @@ RectTransform:
   m_Children:
   - {fileID: 1883248460156222526}
   - {fileID: 8475846025723501542}
+  - {fileID: 879949454364062997}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -401,7 +402,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   sequenceName: 
   description: 
+  sequencePath: 
   playButton: {fileID: 2445726624697383442}
+  deleteButton: {fileID: 3433092397220868272}
   nameComponent: {fileID: 714608286913792316}
   descriptionComponent: {fileID: 0}
 --- !u!1 &6874878903579090770
@@ -661,3 +664,172 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1001 &7690256345569702806
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4383038157323776768}
+    m_Modifications:
+    - target: {fileID: 918782215118182803, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_Name
+      value: Tooltip
+      objectReference: {fileID: 0}
+    - target: {fileID: 918782215118182803, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4468322868359764295, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4468322868359764295, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4468322868359764295, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4468322868359764295, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4468322868359764295, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4468322868359764295, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6390629013674929572, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_PixelPerfect
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -31.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -45.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7880013214154317321, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_text
+      value: 'Sequences cannot be deleted
+
+        from runtime builds'
+      objectReference: {fileID: 0}
+    - target: {fileID: 8240398802560070304, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: target
+      value: 
+      objectReference: {fileID: 1228593664738224843}
+    - target: {fileID: 8240398802560070304, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: content
+      value: 'Sequences cannot be deleted
+
+        from runtime builds'
+      objectReference: {fileID: 0}
+    - target: {fileID: 8240398802560070304, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: backgroundPrefab
+      value: 
+      objectReference: {fileID: 1413688188443400737}
+    - target: {fileID: 8729993183904508343, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+      propertyPath: m_PixelsPerUnitMultiplier
+      value: 1.5
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+--- !u!224 &879949454364062997 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+  m_PrefabInstance: {fileID: 7690256345569702806}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1413688188443400737 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8729993183904508343, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
+  m_PrefabInstance: {fileID: 7690256345569702806}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/Tooltip.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/Tooltip.prefab
@@ -1,0 +1,296 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &330467426803620381
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4468322868359764295}
+  - component: {fileID: 5334096102153865227}
+  - component: {fileID: 7880013214154317321}
+  m_Layer: 0
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4468322868359764295
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 330467426803620381}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7390251111716423299}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5334096102153865227
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 330467426803620381}
+  m_CullTransparentMesh: 1
+--- !u!114 &7880013214154317321
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 330467426803620381}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Tooltip Text goes here
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 12
+  m_fontSizeBase: 12
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &918782215118182803
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7390251111716423299}
+  - component: {fileID: 6664440391961094574}
+  - component: {fileID: 8729993183904508343}
+  - component: {fileID: 3208593152498659897}
+  - component: {fileID: 593889231024808492}
+  - component: {fileID: 8240398802560070304}
+  - component: {fileID: 6390629013674929572}
+  m_Layer: 0
+  m_Name: Tooltip
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7390251111716423299
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 918782215118182803}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4468322868359764295}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6664440391961094574
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 918782215118182803}
+  m_CullTransparentMesh: 1
+--- !u!114 &8729993183904508343
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 918782215118182803}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: b21fb9f9e75d64529990b72edb231470, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1.5
+--- !u!114 &3208593152498659897
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 918782215118182803}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 2
+--- !u!114 &593889231024808492
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 918782215118182803}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 8
+    m_Right: 8
+    m_Top: 8
+    m_Bottom: 8
+  m_ChildAlignment: 4
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &8240398802560070304
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 918782215118182803}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6cdb322fd954c6a84d9f26a02b5228d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  content: 
+  contentPrefab: {fileID: 7880013214154317321}
+  backgroundPrefab: {fileID: 8729993183904508343}
+  target: {fileID: 0}
+  isEnabled: 1
+--- !u!223 &6390629013674929572
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 918782215118182803}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 1
+  m_OverridePixelPerfect: 1
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_SortingLayerID: 0
+  m_SortingOrder: 32767
+  m_TargetDisplay: 0

--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/Tooltip.prefab.meta
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/Tooltip.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e49ee355d192d4b3baa7709272c0cd36
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlayCanvas.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlayCanvas.prefab
@@ -2740,7 +2740,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 183.9, y: 146.6}
+  m_SizeDelta: {x: 110, y: 90}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &366506122720462741
 CanvasRenderer:
@@ -2771,9 +2771,9 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: 21300000, guid: 80e38a6b34daf447cb5a1b0db7ab6c06, type: 3}
-  m_Type: 1
+  m_Type: 0
   m_PreserveAspect: 0
-  m_FillCenter: 0
+  m_FillCenter: 1
   m_FillMethod: 4
   m_FillAmount: 1
   m_FillClockwise: 1
@@ -2918,6 +2918,7 @@ RectTransform:
   m_Children:
   - {fileID: 1090041802443136416}
   - {fileID: 1094668923711103164}
+  - {fileID: 8701351736407767869}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3021,6 +3022,7 @@ MonoBehaviour:
   sequencesPanel: {fileID: 3545653956877431460}
   sequenceCardPrefab: {fileID: 4199513441948227604, guid: 1286929087b3c4db0aa7ebfeba68731c, type: 3}
   sequenceEditor: {fileID: 1768688999565580427}
+  deleteSequenceDialog: {fileID: 5563740331335366267}
 --- !u!114 &3883112371070943306
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4156,6 +4158,321 @@ GameObject:
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
   m_PrefabInstance: {fileID: 2346971118752932893}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2808644653837158682
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 5224021696837641672}
+    m_Modifications:
+    - target: {fileID: 210366935220034040, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 210366935220034040, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 210366935220034040, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 457.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 513760574875140303, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 513760574875140303, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 513760574875140303, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 323.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 513760574875140303, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 473.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 1362750833803285249, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 133.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 2653587487447981162, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2653587487447981162, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2653587487447981162, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 796.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2653587487447981162, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 2653587487447981162, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 398.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 2653587487447981162, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -15
+      objectReference: {fileID: 0}
+    - target: {fileID: 2967997487976718605, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: overlayContainer
+      value: 
+      objectReference: {fileID: 7029756735420670719}
+    - target: {fileID: 4942844073237141754, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4942844073237141754, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4942844073237141754, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 93.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 4942844073237141754, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 78.685
+      objectReference: {fileID: 0}
+    - target: {fileID: 4942844073237141754, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5020629288057838675, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 828.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5020629288057838675, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 154.11
+      objectReference: {fileID: 0}
+    - target: {fileID: 6448674239935938532, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6448674239935938532, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6448674239935938532, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 20.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6448674239935938532, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -20
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6974553987836872862, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6974553987836872862, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6974553987836872862, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 796.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6974553987836872862, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 82.11
+      objectReference: {fileID: 0}
+    - target: {fileID: 6974553987836872862, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 414.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 6974553987836872862, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -57.055
+      objectReference: {fileID: 0}
+    - target: {fileID: 7572337814382127804, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7572337814382127804, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7572337814382127804, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 64.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7572337814382127804, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -20
+      objectReference: {fileID: 0}
+    - target: {fileID: 7750639364715422709, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7750639364715422709, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7750639364715422709, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 484.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 7750639364715422709, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 20.11
+      objectReference: {fileID: 0}
+    - target: {fileID: 7750639364715422709, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 156.125
+      objectReference: {fileID: 0}
+    - target: {fileID: 7750639364715422709, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -46
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767635361911652193, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_Name
+      value: DeleteSequenceDialog
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767635361911652193, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8355597630735644262, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8355597630735644262, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8355597630735644262, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 346
+      objectReference: {fileID: 0}
+    - target: {fileID: 8355597630735644262, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -118.11
+      objectReference: {fileID: 0}
+    - target: {fileID: 8559602234941710125, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8559602234941710125, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8559602234941710125, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 8559602234941710125, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -20
+      objectReference: {fileID: 0}
+    - target: {fileID: 9089944729806318628, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+      propertyPath: overlayContainer
+      value: 
+      objectReference: {fileID: 7029756735420670719}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+--- !u!1 &5563740331335366267 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7767635361911652193, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+  m_PrefabInstance: {fileID: 2808644653837158682}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &8701351736407767869 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+  m_PrefabInstance: {fileID: 2808644653837158682}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8127591394754714046
 PrefabInstance:

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGBotManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGBotManager.cs
@@ -62,6 +62,14 @@ public class RGBotManager : MonoBehaviour
                 recordingToolbar.SetActive(false);
             }
         }
+
+        // if the Sequence Manager is present, we do not need to initialize the bot/behavior
+        // dropdowns. They are only kept in this script for backwards compatibility
+        var sequenceManager = GetComponentInChildren<RGSequenceManager>();
+        if (sequenceManager != null)
+        {
+            _initialized = true;
+        }
     }
 
     private void InitializeDropdown()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGDeleteSequence.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGDeleteSequence.cs
@@ -1,0 +1,128 @@
+using System;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace RegressionGames
+{
+    /**
+     * <summary>
+     * Initializes the delete sequence dialog with the correct content, and is responsible for
+     * deleting sequences via RGSequenceManager
+     * </summary>
+     */
+    public class RGDeleteSequence : MonoBehaviour
+    {
+        public TMP_Text sequenceNamePrefab; 
+        
+        public Button confirmButton;
+        
+        public Button cancelButton;
+
+        public string sequencePath;
+
+        /**
+         * <summary>
+         * Initializes the delete sequence dialog with the correct content
+         * </summary>
+         */
+        public void Start()
+        {
+            if (confirmButton != null)
+            {
+                confirmButton.onClick.AddListener(OnDelete);
+            }
+            else
+            {
+                Debug.LogError("RGDeleteSequence is missing its confirmButton");
+            }
+            
+            if (cancelButton != null)
+            {
+                cancelButton.onClick.AddListener(OnCancel);
+            }
+            else
+            {
+                Debug.LogError("RGDeleteSequence is missing its cancelButton");
+            }
+        }
+
+        /**
+         * <summary>
+         * Set the path and name of the Sequence the user is wanting to delete
+         * </summary>
+         * <param name="sequence">The Sequence Entry to delete</param>
+         */
+        public void Initialize(RGSequenceEntry sequence)
+        {
+            sequencePath = sequence.sequencePath;
+            
+            if (sequenceNamePrefab != null)
+            {
+                sequenceNamePrefab.text = sequence.sequenceName;
+            }
+            else
+            {
+                Debug.LogError("RGDeleteSequence is missing its sequenceNamePrefab");
+            }
+        }
+
+        /**
+         * <summary>
+         * When the deletion is confirmed, ensure that the initialized Sequence path is valid and complete the deletion
+         * and reset the dialog's contents
+         * </summary>
+         */
+        public void OnDelete()
+        {
+            if (string.IsNullOrEmpty(sequencePath))
+            {
+                throw new Exception($"RGDeleteSequence is missing its _sequencePath when attempting to delete a Sequence");
+            }
+            
+            var botManager = RGBotManager.GetInstance();
+            if (botManager != null)
+            {
+                var sequenceManager = botManager.GetComponent<RGSequenceManager>();
+                if (sequenceManager != null)
+                {
+                    sequenceManager.DeleteSequenceByPath(sequencePath);
+                    sequenceManager.HideDeleteSequenceDialog();
+                }
+            }
+
+            Reset();
+        }
+
+        /**
+         * <summary>
+         * When the deletion is canceled, hide this dialog and reset its contents
+         * </summary>
+         */
+        public void OnCancel()
+        {
+            var botManager = RGBotManager.GetInstance();
+            if (botManager != null)
+            {
+                var sequenceManager = botManager.GetComponent<RGSequenceManager>();
+                if (sequenceManager != null)
+                {
+                    sequenceManager.HideDeleteSequenceDialog();
+                }
+            }
+
+            Reset();
+        }
+
+        /**
+         * <summary>
+         * Reset the Sequence to delete path and name in the dialog
+         * </summary>
+         */
+        private void Reset()
+        {
+            sequenceNamePrefab.text = string.Empty;
+            sequencePath = string.Empty;
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGDeleteSequence.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGDeleteSequence.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: aac88dd6460c402ea0510a7e7d10fb32
+timeCreated: 1726154187

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceEntry.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceEntry.cs
@@ -1,9 +1,8 @@
 using System;
+using RegressionGames;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
-using UnityEngine.EventSystems;
-using RegressionGames.StateRecorder;
 
 /**
  * <summary>Displays the high-level information for a Sequence</summary>
@@ -14,10 +13,15 @@ public class RGSequenceEntry : MonoBehaviour
 
     public string description;
 
+    public string sequencePath;
+    
     public Action playAction;
 
     [SerializeField]
     public Button playButton;
+    
+    [SerializeField]
+    public Button deleteButton;
 
     /**
      * UI component fields
@@ -44,15 +48,56 @@ public class RGSequenceEntry : MonoBehaviour
         {
             playButton.onClick.AddListener(OnPlay);
         }
+        
+        if (deleteButton != null)
+        {
+            /*
+             * Sequences cannot be deleted in runtime builds, as we cannot delete resources
+             * that have been loaded using Resources.Load()
+             */
+#if UNITY_EDITOR
+                deleteButton.onClick.AddListener(OnDelete);
+                
+                // hide the delete button tooltip. We CAN delete
+                // Sequences while playing in the editor
+                var tooltip = GetComponentInChildren<RGTooltip>();
+                if (tooltip != null)
+                {
+                    tooltip.SetEnabled(false);
+                }
+#else
+                deleteButton.interactable = false;
+#endif
+        }
     }
 
     /**
-     * <summary>When the play button is clicked, start the Sequence and close the RGOverlay</summary>
+     * <summary>
+     * When the play button is clicked, start the Sequence and close the RGOverlay
+     * </summary>
      */
     public void OnPlay()
     {
         var botManager = RGBotManager.GetInstance();
         botManager?.OnBeginPlaying();
         playAction?.Invoke();
+    }
+
+    /**
+     * <summary>
+     * When the delete button is pressed, show a confirmation dialog
+     * </summary>
+     */
+    public void OnDelete()
+    {
+        var botManager = RGBotManager.GetInstance();
+        if (botManager != null)
+        {
+            var sequenceManager = botManager.GetComponent<RGSequenceManager>();
+            if (sequenceManager != null)
+            {
+                sequenceManager.ShowDeleteSequenceDialog(this);
+            }
+        }
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using RegressionGames;
+using RegressionGames.StateRecorder;
 using UnityEngine;
 using RegressionGames.StateRecorder.BotSegments.Models;
 
@@ -23,6 +24,8 @@ public class RGSequenceManager : MonoBehaviour
     public GameObject deleteSequenceDialog;
     
     private static RGSequenceManager _this;
+    
+    private ReplayToolbarManager _replayToolbarManager;
 
     public static RGSequenceManager GetInstance()
     {
@@ -34,6 +37,7 @@ public class RGSequenceManager : MonoBehaviour
         var sequences = ResolveSequenceFiles();
         InstantiateSequences(sequences);
 
+        _replayToolbarManager = FindObjectOfType<ReplayToolbarManager>();
         _this = this;
         DontDestroyOnLoad(_this.gameObject);
     }
@@ -165,7 +169,11 @@ public class RGSequenceManager : MonoBehaviour
                 prefabComponent.sequenceName = sequence.name;
                 prefabComponent.sequencePath = path;
                 prefabComponent.description = sequence.description;
-                prefabComponent.playAction = sequence.Play;
+                prefabComponent.playAction = () =>
+                {
+                    _replayToolbarManager.selectedReplayFilePath = null;
+                    sequence.Play();
+                };
             }
         }
     }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGTooltip.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGTooltip.cs
@@ -1,0 +1,106 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace RegressionGames
+{
+    /**
+     * <summary>
+     * A simple tooltip that adds listeners for PointerEnter/PointerExit events on the `target`.
+     * When moused over, the `target` will display the tooltip
+     * </summary>
+     */
+    public class RGTooltip : MonoBehaviour
+    {
+        [Multiline]
+        public string content;
+
+        public TMP_Text contentPrefab;
+
+        public Image backgroundPrefab;
+
+        public GameObject target;
+        
+        public bool isEnabled;
+
+        public void Start()
+        {
+            if (contentPrefab != null)
+            {
+                contentPrefab.text = content;
+            }
+            else
+            {
+                Debug.LogError("RGTooltip is missing its contentPrefab");
+            }
+
+            // Add OnPointerEnter + OnPointerExit events to the target. This will show and hide the
+            // tooltip's contents respectively
+            if (target != null)
+            {
+                var eventTrigger = target.AddComponent<EventTrigger>();
+                var entry = new EventTrigger.Entry();
+                entry.eventID = EventTriggerType.PointerEnter;
+                entry.callback.AddListener(_ => { OnShow(); });
+                eventTrigger.triggers.Add(entry);
+                
+                var eventTrigger2 = target.AddComponent<EventTrigger>();
+                var entry2 = new EventTrigger.Entry();
+                entry2.eventID = EventTriggerType.PointerExit;
+                entry2.callback.AddListener(_ => { OnHide(); });
+                eventTrigger2.triggers.Add(entry2);
+            }
+            else
+            {
+                Debug.LogError("RGTooltip is missing its target");
+            }
+
+            gameObject.SetActive(isEnabled);
+
+            // the tooltip is hidden by default
+            contentPrefab.CrossFadeAlpha(0, 0, false);
+            backgroundPrefab.CrossFadeAlpha(0, 0, false);
+        }
+
+        /**
+         * <summary>
+         * Enable the tooltip to allow it to show and hide its contents
+         * </summary>
+         * <param name="newEnabled">The new enabled state</param>
+         */
+        public void SetEnabled(bool newEnabled)
+        {
+            isEnabled = newEnabled;
+            gameObject.SetActive(isEnabled);
+        }
+
+        /**
+         * <summary>
+         * If this tooltip is enabled, show its contents
+         * </summary>
+         */
+        public void OnShow()
+        {
+            if (isEnabled)
+            {
+                contentPrefab.CrossFadeAlpha(1, 0.1f, false);
+                backgroundPrefab.CrossFadeAlpha(1, 0.1f, false);
+            }
+        }
+
+        /**
+         * <summary>
+         * If this tooltip is enabled, hide its contents
+         * </summary>
+         */
+        public void OnHide()
+        {
+            if (isEnabled)
+            {
+                contentPrefab.CrossFadeAlpha(0, 0.1f, false);
+                backgroundPrefab.CrossFadeAlpha(0, 0.1f, false);
+            }
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGTooltip.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGTooltip.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c6cdb322fd954c6a84d9f26a02b5228d
+timeCreated: 1726505783

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGSettings.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGSettings.cs
@@ -43,7 +43,7 @@ namespace RegressionGames
 
         // AI Service Settings - Use "http://127.0.0.1:18888/" for local aiservice dev testing
         // NOTE: By default this is left as NULL and tracks rgHostAddress value unless overridden
-        [SerializeField] private string aiServiceHostAddress;
+        [SerializeField] private string aiServiceHostAddress = "http://127.0.0.1:18888/";
 
         /*
          * This is setup to be safely callable on the non-main thread.

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGSettings.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGSettings.cs
@@ -43,7 +43,7 @@ namespace RegressionGames
 
         // AI Service Settings - Use "http://127.0.0.1:18888/" for local aiservice dev testing
         // NOTE: By default this is left as NULL and tracks rgHostAddress value unless overridden
-        [SerializeField] private string aiServiceHostAddress = "http://127.0.0.1:18888/";
+        [SerializeField] private string aiServiceHostAddress;
 
         /*
          * This is setup to be safely callable on the non-main thread.

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVImageCriteriaEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVImageCriteriaEvaluator.cs
@@ -102,12 +102,10 @@ namespace RegressionGames.StateRecorder.BotSegments
                                 case "jpg":
                                     // keeps the original jpg lossless
                                     return Convert.ToBase64String(fileData);
-                                    break;
                                 case "png":
                                     // this may be somewhat lossy in that it converts to JPG, but it should handle all supported image types for Texture2D
                                     var texture = CreateTextureFromJpgOrPngImageFileBytes(fileData);
                                     return Convert.ToBase64String(texture.EncodeToJPG(100));
-                                    break;
                                 default:
                                     throw new Exception("Unsupported image type for file://.  Only JPG and PNG are supported by Unity ImageConversion.LoadImage (https://docs.unity3d.com/ScriptReference/ImageConversion.LoadImage.html).");
                             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVImageCriteriaEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVImageCriteriaEvaluator.cs
@@ -1,11 +1,15 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using RegressionGames.StateRecorder.BotSegments.Models;
 using RegressionGames.StateRecorder.BotSegments.Models.AIService;
 using RegressionGames.StateRecorder.JsonConverters;
+using StateRecorder.BotSegments;
 using UnityEngine;
+
+using File = UnityEngine.Windows.File;
 
 namespace RegressionGames.StateRecorder.BotSegments
 {
@@ -38,7 +42,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                     var pair = keyValuePair.Value;
                     foreach (var pairValue in pair.Values)
                     {
-                        pairValue.Invoke();
+                        pairValue?.Invoke();
                     }
                 }
 
@@ -78,6 +82,91 @@ namespace RegressionGames.StateRecorder.BotSegments
                 _priorResultsTracker.Remove(segmentNumber, out _);
                 RGDebug.LogVerbose($"CVImageCriteriaEvaluator - Cleanup - botSegment: {segmentNumber} - END");
             }
+        }
+
+        public static string GetImageData(string imageData)
+        {
+            if (!string.IsNullOrEmpty(imageData))
+            {
+                if (imageData.StartsWith("file://"))
+                {
+                    try
+                    {
+                        var filePath = imageData.Substring(7);
+                        var fileData = File.ReadAllBytes(filePath);
+                        var extension = PictureHelper.TryGetExtension(fileData);
+                        if (extension != null)
+                        {
+                            switch (extension)
+                            {
+                                case "jpg":
+                                    // keeps the original jpg lossless
+                                    return Convert.ToBase64String(fileData);
+                                    break;
+                                case "png":
+                                    // this may be somewhat lossy in that it converts to JPG, but it should handle all supported image types for Texture2D
+                                    var texture = CreateTextureFromJpgOrPngImageFileBytes(fileData);
+                                    return Convert.ToBase64String(texture.EncodeToJPG(100));
+                                    break;
+                                default:
+                                    throw new Exception("Unsupported image type for file://.  Only JPG and PNG are supported by Unity ImageConversion.LoadImage (https://docs.unity3d.com/ScriptReference/ImageConversion.LoadImage.html).");
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception($"Error Loading CVImage imageData from file:// url - {imageData}", ex);
+                    }
+                }
+
+                if (imageData.StartsWith("resource://"))
+                {
+                    try
+                    {
+                        var filePath = imageData.Substring(11);
+                        var index = filePath.LastIndexOf('.');
+                        if (index >= 0)
+                        {
+                            // remove trailing extension if provided (hint: they shouldn't provide this for resources
+                            filePath = filePath.Substring(0, index);
+                        }
+
+                        Texture2D texture;
+                        // this may be somewhat lossy in that it converts to JPG, even if the existing file was already jpg, but it should handle all supported image types for Texture2D
+                        var textAsset = Resources.Load<TextAsset>(filePath);
+                        if (textAsset != null)
+                        {
+                            var fileData = textAsset.bytes;
+                            texture = CreateTextureFromJpgOrPngImageFileBytes(fileData);
+                        }
+                        else
+                        {
+                            var fileTexture = Resources.Load<Texture2D>(filePath);
+                            // force ARGB32 so that EncodeToJPG works.
+                            texture = new Texture2D(fileTexture.width, fileTexture.height, TextureFormat.ARGB32, false);
+                            texture.SetPixels32(fileTexture.GetPixels32());
+                        }
+
+                        var textureJpgBytes = texture.EncodeToJPG(100);
+                        return Convert.ToBase64String(textureJpgBytes);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception($"Error Loading CVImage imageData from resource:// name - {imageData} - Resource was not a valid Texture2D or a .bytes TextAsset.  Check your path, import your JPG/PNG into your project as a READABLE Texture, or ensure that your raw JPG/PNG image is saved in your project Resource folder with a .bytes extension.", ex);
+                    }
+                }
+            }
+
+            // already an encoded image
+            return imageData;
+        }
+
+        private static Texture2D CreateTextureFromJpgOrPngImageFileBytes(byte[] fileData)
+        {
+            // force ARGB32 so that EncodeToJPG works.
+            Texture2D tex = new Texture2D(2, 2, TextureFormat.ARGB32, false);
+            tex.LoadImage(fileData);
+            return tex;
         }
 
         // Returns a list of non-matched entries
@@ -164,7 +253,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                                     height = height,
                                     data = imageData
                                 },
-                                imageToMatch = criteriaData.imageData,
+                                imageToMatch = GetImageData(criteriaData.imageData),
                                 withinRect = withinRect
                             },
                             abortRegistrationHook:

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
@@ -126,7 +126,7 @@ namespace RegressionGames.StateRecorder.BotSegments
             // If a request is in progress, we'll wait for the results.
             else
             {
-                resultList.Add("Awaiting CV Image evaluation results ...");
+                resultList.Add("Awaiting CV Object Detection evaluation results ...");
             }
 
             lock (_requestTracker)
@@ -210,7 +210,7 @@ namespace RegressionGames.StateRecorder.BotSegments
             }
             else
             {
-                resultList.Add("Awaiting CV Image evaluation results ...");
+                resultList.Add("Awaiting CV Object Detection evaluation results ...");
             }
             return resultList;
         }
@@ -330,6 +330,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                             textQuery: textQuery,
                             imageQuery: imageQuery,
                             withinRect: withinRect,
+                            threshold: criteriaData.threshold,
                             index: index
                         ),
                         // Cancel ongoing request in a thread safe manner.
@@ -342,7 +343,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                         onFailure: () => OnFailure(segmentNumber, index)
                     );
                     RGDebug.LogVerbose($"CVObjectDetectionEvaluator - Matched - botSegment: {segmentNumber}, index: {index} - Request - SENT");
-                    resultList.Add("Awaiting CV Image evaluation results ...");
+                    resultList.Add("Awaiting CV Object Detection evaluation results ...");
                 }
             }
             else

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/CVObjectDetectionEvaluator.cs
@@ -317,7 +317,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                     }
 
                     var textQuery = criteriaData.textQuery;
-                    var imageQuery = criteriaData.imageQuery;
+                    var imageQuery = CVImageCriteriaEvaluator.GetImageData(criteriaData.imageQuery);
                     // do NOT await this, let it run async
                     _ = AIServiceManager.GetInstance().PostCriteriaObjectDetection(
                         new CVObjectDetectionRequest(

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/CVObjectDetectionMouseActionDataJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/CVObjectDetectionMouseActionDataJsonConverter.cs
@@ -24,6 +24,7 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
                 actionModel.imageQuery = jObject.GetValue("imageQuery")?.ToObject<string>(serializer);
                 actionModel.textQuery = jObject.GetValue("textQuery")?.ToObject<string>(serializer);
                 actionModel.withinRect = jObject.GetValue("withinRect")?.ToObject<CVWithinRect>(serializer);
+                actionModel.threshold = jObject.GetValue("threshold")?.ToObject<float?>(serializer);
                 actionModel.actions = jObject.GetValue("actions").ToObject<List<CVMouseActionDetails>>(serializer);
                 return actionModel;
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/AIService/CVObjectDetectionRequest.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/AIService/CVObjectDetectionRequest.cs
@@ -35,7 +35,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models.AIService
         public int index;
 
         /// <summary>
-        /// Optional threshold to accept a returned value from the owl model.
+        /// Optional threshold to accept a returned match from the object detection model. Returned matches with a confidence score less than this threshold are ignored.
         /// </summary>
         public float? threshold;
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/AIService/CVObjectDetectionRequest.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/AIService/CVObjectDetectionRequest.cs
@@ -34,16 +34,23 @@ namespace RegressionGames.StateRecorder.BotSegments.Models.AIService
         /// </summary>
         public int index;
 
+        /// <summary>
+        /// Optional threshold to accept a returned value from the owl model.
+        /// </summary>
+        public float? threshold;
+
         public CVObjectDetectionRequest(CVImageBinaryData screenshot,
                                         [CanBeNull] string textQuery,
                                         [CanBeNull] string imageQuery,
                                         RectInt? withinRect,
+                                        float? threshold = null,
                                         int index = 0)
         {
             this.screenshot = screenshot;
             this.textQuery = textQuery;
             this.imageQuery = imageQuery;
             this.withinRect = withinRect;
+            this.threshold = threshold;
             this.index = index;
 
             if (textQuery != null && imageQuery != null)
@@ -77,6 +84,8 @@ namespace RegressionGames.StateRecorder.BotSegments.Models.AIService
             StringJsonConverter.WriteToStringBuilder(stringBuilder, imageQuery);
             stringBuilder.Append(",\"withinRect\":");
             RectIntJsonConverter.WriteToStringBuilderNullable(stringBuilder, withinRect);
+            stringBuilder.Append(",\"threshold\":");
+            FloatJsonConverter.WriteToStringBuilderNullable(stringBuilder, threshold);
             stringBuilder.Append(",\"index\":");
             IntJsonConverter.WriteToStringBuilder(stringBuilder, index);
             stringBuilder.Append("}");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSequence.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSequence.cs
@@ -45,7 +45,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         /**
          * <summary>Loads a Json sequence file from a json path.  This API expects a relative path</summary>
          */
-        public static BotSequence LoadSequenceJsonFromPath(string path)
+        public static (string, BotSequence) LoadSequenceJsonFromPath(string path)
         {
             if (path.StartsWith('/') || path.StartsWith('\\'))
             {
@@ -70,7 +70,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                 sequenceJson = LoadJsonResource("Assets/RegressionGames/Resources/" + path);
             }
 
-            return JsonConvert.DeserializeObject<BotSequence>(sequenceJson.Item2);
+            return (sequenceJson.Item1, JsonConvert.DeserializeObject<BotSequence>(sequenceJson.Item2));
         }
 
         public string ToJsonString()
@@ -129,6 +129,29 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             catch (Exception e)
             {
                 throw new Exception($"Exception trying to persist BotSequence name: {name}", e);
+            }
+        }
+
+        /**
+         * <summary>
+         * Checks if there exists a file at the path param, and deletes the file if so.
+         * </summary>
+         * <para name="path">The Sequence path to delete</para>
+         */
+        public static void DeleteSequence(string path)
+        {
+            if (!File.Exists(path))
+            {
+                Debug.LogError($"Bot Sequence at: {path} cannot be deleted, as it does not exist");
+            }
+
+            try
+            {
+                File.Delete(path);
+            }
+            catch (Exception e)
+            {
+                throw new Exception($"Exception trying to delete bot sequences at: {path}");
             }
         }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVImageKeyFrameCriteriaData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVImageKeyFrameCriteriaData.cs
@@ -11,10 +11,11 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
     public class CVImageKeyFrameCriteriaData : IKeyFrameCriteriaData
     {
         // update this if this schema changes
-        public int apiVersion = SdkApiVersion.VERSION_9;
+        public int apiVersion = SdkApiVersion.VERSION_18;
 
         /**
          * base64 encoded byte[] of jpg image data , NOT the raw pixel data, the full jpg file bytes
+         * OR a file:// path
          */
         public string imageData;
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVImageMouseActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVImageMouseActionData.cs
@@ -131,7 +131,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                                     height = height,
                                     data = screenshot
                                 },
-                                imageToMatch = imageData,
+                                imageToMatch = CVImageCriteriaEvaluator.GetImageData(imageData),
                                 withinRect = queryWithinRect
                             },
                             abortRegistrationHook:

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionKeyFrameCriteriaData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionKeyFrameCriteriaData.cs
@@ -11,7 +11,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
     public class CVObjectDetectionKeyFrameCriteriaData : IKeyFrameCriteriaData
     {
         // update this if this schema changes
-        public int apiVersion = SdkApiVersion.VERSION_16;
+        public int apiVersion = SdkApiVersion.VERSION_18;
 
         /// <summary>
         /// The text query used for object detection.
@@ -31,12 +31,18 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public CVWithinRect withinRect;
 
         /// <summary>
+        /// The threshold to accept a returned value from the owl model.
+        /// </summary>
+        public float? threshold;
+
+        /// <summary>
         /// Constructor for CVObjectDetectionKeyFrameCriteriaData.
         /// </summary>
         /// <param name="textQuery">The text query used for object detection.</param>
         /// <param name="imageQuery">Currently not supported. The image query used for object detection.</param>
         /// <param name="withinRect">Optional rectangle defining the region of interest within the image.</param>
-        public CVObjectDetectionKeyFrameCriteriaData(string textQuery = null, string imageQuery = null, CVWithinRect withinRect = null)
+        /// <param name="threshold">Optional threshold to accept a returned value from the owl model.</param>
+        public CVObjectDetectionKeyFrameCriteriaData(string textQuery = null, string imageQuery = null, CVWithinRect withinRect = null, float? threshold = null)
         {
             
             if (textQuery != null && imageQuery != null)
@@ -53,6 +59,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             this.textQuery = textQuery;
             this.imageQuery = imageQuery;
             this.withinRect = withinRect;
+            this.threshold = threshold;
         }
 
         public void WriteToStringBuilder(StringBuilder stringBuilder)
@@ -63,6 +70,8 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             IntJsonConverter.WriteToStringBuilder(stringBuilder, apiVersion);
             stringBuilder.Append(",\"withinRect\":");
             CVWithinRectJsonConverter.WriteToStringBuilderNullable(stringBuilder, withinRect);
+            stringBuilder.Append(",\"threshold\":");
+            FloatJsonConverter.WriteToStringBuilderNullable(stringBuilder, threshold);
             stringBuilder.Append("}");
         }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionKeyFrameCriteriaData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionKeyFrameCriteriaData.cs
@@ -31,7 +31,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public CVWithinRect withinRect;
 
         /// <summary>
-        /// The threshold to accept a returned value from the owl model.
+        /// The threshold to accept a returned match from the object detection model. Returned matches with a confidence score less than this threshold are ignored.
         /// </summary>
         public float? threshold;
 
@@ -41,7 +41,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         /// <param name="textQuery">The text query used for object detection.</param>
         /// <param name="imageQuery">Currently not supported. The image query used for object detection.</param>
         /// <param name="withinRect">Optional rectangle defining the region of interest within the image.</param>
-        /// <param name="threshold">Optional threshold to accept a returned value from the owl model.</param>
+        /// <param name="threshold">Optional threshold to accept a returned match from the object detection model. Returned matches with a confidence score less than this threshold are ignored.</param>
         public CVObjectDetectionKeyFrameCriteriaData(string textQuery = null, string imageQuery = null, CVWithinRect withinRect = null, float? threshold = null)
         {
             

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionKeyFrameCriteriaData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionKeyFrameCriteriaData.cs
@@ -11,7 +11,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
     public class CVObjectDetectionKeyFrameCriteriaData : IKeyFrameCriteriaData
     {
         // update this if this schema changes
-        public int apiVersion = SdkApiVersion.VERSION_18;
+        public int apiVersion = SdkApiVersion.VERSION_19;
 
         /// <summary>
         /// The text query used for object detection.

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionMouseActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionMouseActionData.cs
@@ -21,7 +21,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
     public class CVObjectDetectionMouseActionData : IBotActionData
     {
         // api version for this object, update if object format changes
-        public int apiVersion = SdkApiVersion.VERSION_17;
+        public int apiVersion = SdkApiVersion.VERSION_18;
 
         [NonSerialized]
         public static readonly BotActionType Type = BotActionType.Mouse_ObjectDetection;
@@ -54,6 +54,11 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
          * Mouse down in one bot segment, then mouse up as a separate bot segment.
          */
         public List<CVMouseActionDetails> actions;
+
+        /**
+         * Optional threshold to accept a returned value from the owl model.
+         */
+        public float? threshold;
 
         private bool _isStopped;
 
@@ -139,7 +144,8 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                                 },
                                 textQuery: textQuery,
                                 imageQuery: CVImageCriteriaEvaluator.GetImageData(imageQuery),
-                                withinRect: queryWithinRect
+                                withinRect: queryWithinRect,
+                                threshold: threshold
                             ),
                             // Register the abort action.
                             abortRegistrationHook: action => OnAbort(segmentNumber, action),
@@ -343,6 +349,8 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             StringJsonConverter.WriteToStringBuilder(stringBuilder, textQuery);
             stringBuilder.Append(",\"withinRect\":");
             CVWithinRectJsonConverter.WriteToStringBuilderNullable(stringBuilder, withinRect);
+            stringBuilder.Append(",\"threshold\":");
+            FloatJsonConverter.WriteToStringBuilderNullable(stringBuilder, threshold);
             stringBuilder.Append(",\"actions\":[");
             var actionsCount = actions.Count;
             for (var i = 0; i < actionsCount; i++)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionMouseActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionMouseActionData.cs
@@ -138,7 +138,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                                     data = screenshot
                                 },
                                 textQuery: textQuery,
-                                imageQuery: imageQuery,
+                                imageQuery: CVImageCriteriaEvaluator.GetImageData(imageQuery),
                                 withinRect: queryWithinRect
                             ),
                             // Register the abort action.

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionMouseActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionMouseActionData.cs
@@ -56,7 +56,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public List<CVMouseActionDetails> actions;
 
         /**
-         * Optional threshold to accept a returned value from the owl model.
+         * Optional threshold to accept a returned match from the object detection model. Returned matches with a confidence score less than this threshold are ignored.
          */
         public float? threshold;
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionMouseActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/CVObjectDetectionMouseActionData.cs
@@ -21,7 +21,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
     public class CVObjectDetectionMouseActionData : IBotActionData
     {
         // api version for this object, update if object format changes
-        public int apiVersion = SdkApiVersion.VERSION_18;
+        public int apiVersion = SdkApiVersion.VERSION_19;
 
         [NonSerialized]
         public static readonly BotActionType Type = BotActionType.Mouse_ObjectDetection;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/PictureHelper.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/PictureHelper.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+
+namespace StateRecorder.BotSegments
+{
+    // borrowed from https://www.c-sharpcorner.com/blogs/auto-detecting-image-type-and-extension-from-byte-in-c-sharp
+    public static class PictureHelper
+    {
+        // some magic bytes for the most important image formats, see Wikipedia for more
+        static readonly List<byte> jpg = new List<byte> { 0xFF, 0xD8 };
+        static readonly List<byte> bmp = new List<byte> { 0x42, 0x4D };
+        static readonly List<byte> gif = new List<byte> { 0x47, 0x49, 0x46 };
+        static readonly List<byte> png = new List<byte> { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+        static readonly List<byte> svg_xml_small = new List<byte> { 0x3C, 0x3F, 0x78, 0x6D, 0x6C }; // "<?xml"
+        static readonly List<byte> svg_xml_capital = new List<byte> { 0x3C, 0x3F, 0x58, 0x4D, 0x4C }; // "<?XML"
+        static readonly List<byte> svg_small = new List<byte> { 0x3C, 0x73, 0x76, 0x67}; // "<svg"
+        static readonly List<byte> svg_capital = new List<byte> { 0x3C, 0x53, 0x56, 0x47 }; // "<SVG"
+        static readonly List<byte> intel_tiff = new List<byte> { 0x49, 0x49, 0x2A, 0x00};
+        static readonly List<byte> motorola_tiff = new List<byte> { 0x4D, 0x4D, 0x00, 0x2A};
+
+        static readonly List< (List<byte> magic, string extension)> imageFormats = new List<(List<byte> magic, string extension)>()
+        {
+            (jpg, "jpg"),
+            (bmp, "bmp"),
+            (gif, "gif"),
+            (png, "png"),
+            (svg_small, "svg"),
+            (svg_capital, "svg"),
+            (intel_tiff,"tif"),
+            (motorola_tiff, "tif"),
+            (svg_xml_small, "svg"),
+            (svg_xml_capital, "svg")
+        };
+
+        public static string TryGetExtension(byte[] array)
+        {
+            // check for simple formats first
+            foreach (var imageFormat in imageFormats)
+            {
+                if (array.IsImage(imageFormat.magic))
+                {
+                    if (imageFormat.magic != svg_xml_small && imageFormat.magic != svg_xml_capital)
+                        return imageFormat.extension;
+
+                    // special handling for SVGs starting with XML tag
+                    int readCount = imageFormat.magic.Count; // skip XML tag
+                    int maxReadCount = 1024;
+
+                    do
+                    {
+                        if (array.IsImage(svg_small, readCount) || array.IsImage(svg_capital, readCount))
+                        {
+                            return imageFormat.extension;
+                        }
+                        readCount++;
+                    }
+                    while (readCount < maxReadCount && readCount < array.Length - 1);
+
+                    return null;
+                }
+            }
+            return null;
+        }
+
+        private static bool IsImage(this byte[] array, List<byte> comparer, int offset = 0)
+        {
+            int arrayIndex = offset;
+            foreach (byte c in comparer)
+            {
+                if (arrayIndex > array.Length -1 || array[arrayIndex] != c)
+                    return false;
+                ++arrayIndex;
+            }
+            return true;
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/PictureHelper.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/PictureHelper.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5d091d53d6f04c18ab1dd867d5aff032
+timeCreated: 1726163750

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
@@ -28,10 +28,10 @@ namespace RegressionGames.StateRecorder
         public RGTextPulse uploadingIndicator;
         public RGTextPulse fileOpenIndicator;
 
+        public string selectedReplayFilePath;
         public BotSegmentsPlaybackController replayDataController;
 
         private bool _recording;
-        private string _selectedReplayFilePath;
 
         // Start is called before the first frame update
         void Start()
@@ -92,7 +92,7 @@ namespace RegressionGames.StateRecorder
             {
                 // FileBrowser.Result is null, if FileBrowser.Success is false
                 // Get the file path of the first selected file
-                _selectedReplayFilePath = FileBrowser.Result[0];
+                selectedReplayFilePath = FileBrowser.Result[0];
                 RefreshSelectedFile();
             }
         }
@@ -107,7 +107,7 @@ namespace RegressionGames.StateRecorder
             fileOpenIndicator.Normal();
 
             // do this on background thread then return to the main thread for continuation
-            Task.Run(() => ProcessDataContainerZipAndSetup(_selectedReplayFilePath)).ContinueWith(_ =>
+            Task.Run(() => ProcessDataContainerZipAndSetup(selectedReplayFilePath)).ContinueWith(_ =>
             {
                 if (_playbackContainer != null)
                 {
@@ -156,11 +156,21 @@ namespace RegressionGames.StateRecorder
 
         public void PlayReplay()
         {
-            RefreshSelectedFile(() =>
+            if (selectedReplayFilePath == null)
             {
+                // this happens when the user plays a bot sequence from the overlay
+                // (no zip file to load)
                 SetInUseButtonStates();
                 replayDataController.Play();
-            });
+            }
+            else
+            {
+                RefreshSelectedFile(() =>
+                {
+                    SetInUseButtonStates();
+                    replayDataController.Play();
+                });
+            }
         }
 
         public void LoopReplay()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/SdkApiVersion.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/SdkApiVersion.cs
@@ -69,18 +69,20 @@
          * </summary>
          */
         public const int VERSION_15 = 15;
-
         /*
          * <summary> Added CV Object Detection Key Frame Criteria. </summary>
          */
         public const int VERSION_16 = 16;
-
         /*
          * <summary> Added CV Object Detection text mouse action. </summary>
          */
         public const int VERSION_17 = 17;
+        /*
+         * <summary> Added file:// and resource:// support to CVImage data. </summary>
+         */
+        public const int VERSION_18 = 18;
 
         // Update this when new features are used in the SDK
-        public const int CURRENT_VERSION = VERSION_17;
+        public const int CURRENT_VERSION = VERSION_18;
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/SdkApiVersion.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/SdkApiVersion.cs
@@ -82,7 +82,12 @@
          */
         public const int VERSION_18 = 18;
 
+        /*
+         * <summary> Added CV Object Detection threshold. </summary>
+         */
+        public const int VERSION_19 = 19;
+
         // Update this when new features are used in the SDK
-        public const int CURRENT_VERSION = VERSION_18;
+        public const int CURRENT_VERSION = VERSION_19;
     }
 }

--- a/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/ObjectDetection.meta
+++ b/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/ObjectDetection.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 528144fc72ec43f4d8948a4e3f31152f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/ObjectDetection/CVObjectDetectionQueryTests.cs
+++ b/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/ObjectDetection/CVObjectDetectionQueryTests.cs
@@ -1,0 +1,111 @@
+using NUnit.Framework;
+using RegressionGames.StateRecorder.BotSegments.Models.AIService;
+using UnityEngine;
+using UnityEngine.TestTools;
+using System;
+
+public class CVObjectDetectionQueryTests
+{
+    /// <summary>
+    /// Tests the creation of a CVObjectDetectionRequest with a text query.
+    /// </summary>
+    [Test]
+    public void TestCreateCVObjectDetectionTextQueryRequest()
+    {
+        // Arrange
+        var screenshot = new CVImageBinaryData
+        {
+            width = 1920,
+            height = 1080,
+            data = new byte[] { 0, 1, 2, 3, 4 } // Dummy data
+        };
+        var textQuery = "button";
+        var withinRect = new RectInt(100, 100, 200, 200);
+        var threshold = 0.8f;
+
+        // Act
+        var request = new CVObjectDetectionRequest(
+            screenshot: screenshot,
+            textQuery: textQuery,
+            imageQuery: null,
+            withinRect: withinRect,
+            threshold: threshold,
+            index: 0
+        );
+
+        // Assert
+        Assert.IsNotNull(request);
+        Assert.AreEqual(screenshot, request.screenshot);
+        Assert.AreEqual(textQuery, request.textQuery);
+        Assert.IsNull(request.imageQuery);
+        Assert.AreEqual(withinRect, request.withinRect);
+        Assert.AreEqual(threshold, request.threshold);
+        Assert.AreEqual(0, request.index);
+    }
+
+    /// <summary>
+    /// Tests the creation of a CVObjectDetectionRequest with an image query.
+    /// </summary>
+    [Test]
+    public void TestCreateCVObjectDetectionImageQueryRequest()
+    {
+        var screenshot = new CVImageBinaryData
+        {
+            width = 1920,
+            height = 1080,
+            data = new byte[] { 0, 1, 2, 3, 4 } // Dummy data
+        };
+        var imageQuery = Convert.ToBase64String(new byte[] { 5, 6, 7, 8, 9 }); // Base64 encoded dummy data
+        var withinRect = new RectInt(100, 100, 200, 200);
+        var threshold = 0.8f;
+
+        var request = new CVObjectDetectionRequest(
+            screenshot: screenshot,
+            textQuery: null,
+            imageQuery: imageQuery,
+            withinRect: withinRect,
+            threshold: threshold,
+            index: 0
+        );
+
+        Assert.IsNotNull(request);
+        Assert.AreEqual(screenshot, request.screenshot);
+        Assert.IsNull(request.textQuery);
+        Assert.AreEqual(imageQuery, request.imageQuery);
+        Assert.AreEqual(withinRect, request.withinRect);
+        Assert.AreEqual(threshold, request.threshold);
+        Assert.AreEqual(0, request.index);
+    }
+
+    /// <summary>
+    /// Tests the behavior of CVObjectDetectionRequest when both text and image queries are provided.
+    /// </summary>
+    [Test]
+    public void TestCreateCVObjectDetectionRequestWithBothQueries()
+    {
+        var screenshot = new CVImageBinaryData
+        {
+            width = 1920,
+            height = 1080,
+            data = new byte[] { 0, 1, 2, 3, 4 } // Dummy data
+        };
+        var textQuery = "button";
+        var imageQuery = Convert.ToBase64String(new byte[] { 5, 6, 7, 8, 9 }); // Base64 encoded dummy data
+        var withinRect = new RectInt(100, 100, 200, 200);
+        var threshold = 0.8f;
+
+        // Check whether we are getting the error message.
+        LogAssert.Expect(LogType.Error, new System.Text.RegularExpressions.Regex(@".*Both textQuery and imageQuery are provided\. Only one should be used\..*"));
+
+        var request = new CVObjectDetectionRequest(
+            screenshot: screenshot,
+            textQuery: textQuery,
+            imageQuery: imageQuery,
+            withinRect: withinRect,
+            threshold: threshold,
+            index: 0
+        );
+
+        Assert.IsNotNull(request);
+    }
+}

--- a/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/ObjectDetection/CVObjectDetectionQueryTests.cs.meta
+++ b/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/ObjectDetection/CVObjectDetectionQueryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: afe8cb34b1926244c86e5c52d53a5c82
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/RGOverlay/RGDeleteSequence.test.cs
+++ b/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/RGOverlay/RGDeleteSequence.test.cs
@@ -1,0 +1,83 @@
+using System;
+using NUnit.Framework;
+using RegressionGames;
+using UnityEngine;
+using UnityEngine.UI;
+using Object = UnityEngine.Object;
+
+[TestFixture]
+public class RGDeleteSequenceTests
+{
+    private GameObject _uat;
+
+    private RGDeleteSequence deleter;
+
+    [SetUp]
+    public void SetUp()
+    {
+        // create the delete script we want to test
+        _uat = new GameObject();
+        deleter = _uat.AddComponent<RGDeleteSequence>();
+        deleter.sequenceNamePrefab = RGTestUtils.CreateTMProPlaceholder();
+        deleter.confirmButton = new GameObject().AddComponent<Button>();
+        deleter.cancelButton = new GameObject().AddComponent<Button>();
+        deleter.Start();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Object.Destroy(_uat);
+    }
+
+    [Test]
+    public void Start()
+    {
+        Assert.NotNull(deleter.confirmButton);
+        Assert.NotNull(deleter.cancelButton);
+    }
+    
+    [Test]
+    public void Initialize()
+    {
+        var entry = new GameObject().AddComponent<RGSequenceEntry>();
+        entry.sequenceName = "Great Sequence";
+        entry.sequencePath = "/sequence/path";
+        
+        deleter.Initialize(entry);
+        
+        // ensure that we transfer the sequence entry's name and path to the script's display fields 
+        Assert.AreEqual(entry.sequenceName, deleter.sequenceNamePrefab.text);
+        Assert.AreEqual(entry.sequencePath, deleter.sequencePath);
+    }
+    
+    [Test]
+    public void OnDelete_HasSequencePath()
+    {
+        deleter.sequencePath = "/sequence/path";
+        
+        deleter.OnDelete();
+        
+        // ensure that we reset the script's display fields after deleting
+        Assert.IsEmpty(deleter.sequencePath);
+        Assert.IsEmpty(deleter.sequenceNamePrefab.text);
+    }
+    
+    [Test]
+    public void OnDelete_NoSequencePath()
+    {
+        deleter.sequencePath = null;
+        
+        // ensure that a missing sequence path throws an exception
+        Assert.Throws<Exception>(() => deleter.OnDelete());
+    }
+    
+    [Test]
+    public void OnCancel()
+    {
+        // ensure that we can cancel the deletion and reset the scripts display fields 
+        Assert.DoesNotThrow(() => deleter.OnCancel());
+        Assert.IsEmpty(deleter.sequencePath);
+        Assert.IsEmpty(deleter.sequenceNamePrefab.text);
+    }
+}

--- a/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/RGOverlay/RGDeleteSequence.test.cs.meta
+++ b/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/RGOverlay/RGDeleteSequence.test.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5a94140aa11949599a0807d6ce7908a7
+timeCreated: 1726175493

--- a/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/RGOverlay/RGSequenceManager.test.cs
+++ b/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/RGOverlay/RGSequenceManager.test.cs
@@ -51,10 +51,10 @@ public class RGSequenceManagerTests
     {
         // add a list of bot sequences to the manager for instantiation
         const int numSequences = 5;
-        var sequences = new List<BotSequence>();
+        var sequences = new Dictionary<string, BotSequence>();
         for (var i = 0; i < numSequences; ++i)
         {
-            sequences.Add(new BotSequence());
+            sequences.Add($"/placeholder/path/{i}", new BotSequence());
         }
 
         manager.InstantiateSequences(sequences);

--- a/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/RGTestUtils.cs
+++ b/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/RGTestUtils.cs
@@ -125,7 +125,7 @@ namespace RegressionGames
         {
             RGDebug.LogInfo("Loading and starting bot sequence from " + sequencePath);
 
-            var botSequence = BotSequence.LoadSequenceJsonFromPath(sequencePath);
+            var botSequence = BotSequence.LoadSequenceJsonFromPath(sequencePath).Item2;
 
             botSequence.Play();
 

--- a/user-tools/README-CVImage.md
+++ b/user-tools/README-CVImage.md
@@ -15,7 +15,11 @@ Disclaimer: The `CVImage` type is still in an experimental phase and may provide
 - `type` - `CVImage` - tells the SDK to evaluate this type of criteria using the supplied data
 - `transient` - `transient`=`true` means that this image can match at any time during the evaluation of this bot segment and that passing result will persist even if it takes multiple more frames before other criteria in this segment are matched.  `transient`=`false` means that this criteria and other non-transient criteria must all be true at the same time (any transient criteria must also have matched already).  **Transient should almost always be `true` for `CVImage`**.  `CVImage` evaluation is a largely asynchronous process that can take multiple frames to complete, thus setting `trasient`=`false` for the criteria to match within a single frame can lead to situations where the criteria matched on the frame when the request was made, but are no longer matching by the time the result comes back.  Setting `transient`=`true` allows the needed flexibility for this asynchronous operation to pass more easily, especially when used  combination with other `endCriteria`.
 - `data` - The data json object that defines how to evaluate this `CVImage` criteria.
-  - `imageData` - The base64 encoded string of the JPG image data.  This is the entire JPG image file, not just the visible bytes.
+  - `imageData` - The image data in one of the following formats...
+    - The base64 encoded string of the JPG image data - This must be the entire JPG image file, not just the visible bytes.
+    - A file:// path to a JPG or PNG image - Be careful when using relative paths as these will be interpreted differently in the Editor vs Runtime builds.
+    - A resource:// path to a READABLE Texture2D in one of your project's Resources folders.
+    - A resource:// path to a .bytes TextAsset in one of your project's Resources folders that is a JPG or PNG saved with a .bytes file extension.  This can be used if you do not want Unity to import your image as a Texture.
   - `withinRect` - An optional (can be null/undefined) field to limit the search area to a specific pixel region of the current frame.  The SDK will linearly transform the supplied `rect` to fit the current resolution using the `screenSize` as the initial reference resolution.
     - `screenSize` - The reference resolution in pixels which defines the screen space that `rect` is defined within.
     - `rect` - The position (x=0, y=0 is bottom left) and size (width, height) of the rectangle that must contain the supplied image data.  The values are defined in pixels.
@@ -23,7 +27,11 @@ Disclaimer: The `CVImage` type is still in an experimental phase and may provide
 #### `botAction`
 - `type` - `Mouse_CVImage` - tells the SDK to evaluate this type of criteria using the supplied data and perform the specified mouse actions at the center of the found `rect`
 - `data` - The data json object that defines how to evaluate this `CVImage` criteria.
-  - `imageData` - The base64 encoded string of the JPG image data.  This is the entire JPG image file, not just the visible bytes.
+  - `imageData` - The image data in one of the following formats...
+    - The base64 encoded string of the JPG image data - This must be the entire JPG image file, not just the visible bytes.
+    - A file:// path to a JPG or PNG image - Be careful when using relative paths as these will be interpreted differently in the Editor vs Runtime builds.
+    - A resource:// path to a READABLE Texture2D in one of your project's Resources folders.
+    - A resource:// path to a .bytes TextAsset in one of your project's Resources folders that is a JPG or PNG file saved with a .bytes file extension.  This can be used if you do not want Unity to import your image as a Texture.
   - `withinRect` - An optional (can be null/undefined) field to limit the search area to a specific pixel region of the current frame.  The SDK will linearly tranform the supplied `rect` to fit the current resolution using the `screenSize` as the initial reference resolution.
     - `screenSize` - The reference resolution in pixels which defines the screen space that `rect` is defined within.
     - `rect` - The position (x=0, y=0 is bottom left) and size (width, height) of the rectangle that must contain the supplied image data.  The values are defined in pixels.
@@ -47,6 +55,7 @@ Disclaimer: The `CVImage` type is still in an experimental phase and may provide
 
 ### `endCriteria`
 
+- Using base64 byte[]
 ```json
 {
     "name":"CV Image Criteria: Menu Change Profile Button",
@@ -67,8 +76,30 @@ Disclaimer: The `CVImage` type is still in an experimental phase and may provide
 }
 ```
 
+- Using file:// path (??? represents the path to this folder on your system)
+```json
+{
+    "name":"CV Image Criteria: Menu Change Profile Button",
+    "endCriteria":[
+        {
+            "type":"CVImage",
+            "transient":true,
+            "data":{
+                "imageData":"file://???/sample_images/change_profile_button.jpg",
+                "withinRect": {
+                    "screenSize":{"x":1653,"y":714},
+                    "rect":{"x":1250,"y":210,"width":250,"height":275}
+                } 
+            }
+        }
+    ],
+    "botAction":{}
+}
+```
+
 ### `botAction`
 
+- Using base64 byte[]
 ```json
 {
     "name": "CV Image Action: Click Menu Change Profile Button",
@@ -80,6 +111,29 @@ Disclaimer: The `CVImage` type is still in an experimental phase and may provide
         "type":"Mouse_CVImage",
         "data": {
             "imageData":"/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wAARCABFAEgDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDE+C37Pc37QzeIZdF+Ki+H73R7iOC60X+wo7p4VaNWSQOZlJVjv5xwVYdq6L/hkWx/6OY0H/wUWf8A8lV85fCn48T/ALM/7U3/AAkrSyDw1e+VZa5bxpv32zxod4X+8jYcEc8MP4iD9OfthfCuHwx4ug8XaNHv8P8AiIfaPOjIMa3DDcwGOgYYcfVsdOPzHLMnq4rM6OAr4lUoVqcZ0n7GjK7UVzwblC7kviWrbW7ud+bZriML7WrT5pcs2mueatq7Ws9uhQ/4ZFsf+jmNB/8ABTZ//JVcV8dP2afF/wALPhe/jjwx8Sbf4g6ZbThL37DpUEQt4uQZdyySBgrbQQORuz0Bx57Xun7LvxIs9H1m/wDBPiJUu/C/iZDayQXJzEsrKV5B4w4Ow+vyelfX5twbjcmwksxoVo4j2VpSpuhRXNBfEk4xTTtdr0seBg+JKmLrKhUlKHNon7Sbs+m77nxJ/wALU8U/9BT/AMl4v/ia+kf2afgP40+PvhHV/FOqeO4/BXh+zlEEN9daVDOlww/1hBLxhVXKjdk5JI7GvO/iJ+yrrvh79pKL4ZaWvmx6rcLNpl02dosnJPmMTz+7VXDepjOOor7I+Ml5pvgPwloHwm8LK1tpWkwxm7KN/rGxlVY9SSSZGz3ZfwylhcLn2JweWZFTpqeIXO5+zhL2dJbyaaau37qTW99jrxGZYrLaFXFYyrO0NEuaS5pdFv8AN+RyC/sZpJ939o7R2+miWp/9uqVv2M1T737R2jr9dEtf/kquZVUs4fQ16p+zL8PV8c+Nm1vUIs6HomJ3dsbHmByiH1AwWPb5cHrz9Pn3h5Q4ey2tmWNzO0aau/8AZ8Pr2S9zduyXmz5TAcaY/McTHD0aTvJ2/iVPv36Hl/xi/Ztn/Z+07R9T1z4r/wBuy6ndG1s9IGgR2zXJ2MzN5gmYqqgZzg8lR/FRXjfxy+PjftLftWRapazySeEtHMun6LExwjRorl58A4zIw3Z67QgPTAK/AsdhcThaeH+vte1nDmaUYxtduytFRV0t3a9/Kx+85HWliKNRptpStq2+i6ts8a+LkIuPHGrIwyCIv/RSV9w/sLfEO1/aI+A+vfA/xNOX8QeH4PP0i8um3sbUufLYc7v3LsEPbY6KPSviL4qf8j7qn/bL/wBFJVL4a/EnVvgr8SdA8daGA9/pM/mNAzFUuIiCskTY7MpI9sg9q/XsVllXMsiw0sLLlr0ownTl2nGKa+T2fSzPzPE1IxzDEQqK8ZSkn6Ns+gtc0W78O6xe6XfwmC8s5mgmjbqrKSCPzFVIVZpBtyCDwRX0r+1DouifEjw14c+MHhC4hvNI1u3jW5MAzhsEK7Y6EEGNgeQyAdeng2j6WZGBK1+wcK5tDifLqWOpx5W9Jx6xmtJRfo/ws+p+Z5pQeWVpUp9Nn3XRn0Z4X/aPt5NJ0671XQft3i6wtJLSDUsLgq23JJ+8N2xCwHXb2zXmt1dTXl3cX95IZrq4kaWSRurMTk1SsLNbWPcRiqOsaoI1Kg19dkHCWTcKSrYnL6PJOrvq31bsrv3Y3bdlZfgfNZnnWOzvko153jDb/N935skka51rUrbTrKNp7u6lWGKNeSzMcAD8TXoH7bPxLt/2aP2e9L+Efh27j/4S3xREx1GaBikkdq2RNKcc/OR5S56qr/3cVu/sw6JpPhnTPEHxa8WXEdloOgQStDLMONyrl5B3OB8ox1ZsDkV+d/xe+K2q/Hj4qa/461jKPqE220tj0trZeIohyei4z6kse9finFeZPiviCOU03fDYRqdTtKr9iHnyL3pebs9j9DyDL1luDeLmvfqaR8o9X8/yG/CCBbfxxpCKMAeZ/wCinoqX4U/8j9pX1l/9FPRX5Tx1/wAjCn/gX/pUj9r4S/3Kf+N/lET4qf8AI+6p/wBsv/RSVyZj875Nu4twABkmus+Kn/I+6p/2y/8ARSV6L+yv8OU8S+MD4k1FMaTobCVd6/JLPglRk/3fvH32+tfpNHHU8tyOjiqivy04WXVvlSSXm3ofA4jDyxWaVaUes5a9ld3fyPoHwT4dufg/+zjp/gy9uHur/UpGuZbZnJS3LuJGVVPQLgDj+Ik1n6Zp6wRgkVqa1qD+JNalvZP9WPkiU9kHT+p/Gs/UL5beMgHFfs/AvD0+H8q9pjP49aTqVOynK2i/wpJfK5+P8UZus2x/Jhv4cFyR80uvzd2Q6pqSwoQDXE6pqRlcgGtPWIdRkszefY7n7H0+0eU3l/8AfWMVyzMWbJr3MbjvbScYPY5MHg/ZJSktz1W4s5/jJ+zZrPgOyvJrTUbM+fHBHKUS4IcyKrAdVY5Ug8ZANfC7Wz2btBIhikjJRkYYKkcEH3r6v8E+KJfCPiK21CPLRj5JUB+8h6j+v1Arhv2qvh7Bo/iSHxbpKodI1s75PKHypORkn6OPm+oavwCphv7BzyrQf8HFt1IvtU+3F+vxL5o/XcPW/tLLozXx0Uotf3fsv5bM81+FP/I/aV9Zf/RT0UfCn/kftK+sv/op6K/M+Ov+RhT/AMC/9KkfpfCX+4z/AMb/ACiWvH+l3WufFC60+yiM13cyQxRRjuxjQD6D3r608O+HrfwL4K0/w1Yk4RN1xL/z0Y8u34n9BiuZ+CfwP1jxp8T9X8QWun/aCDHDZySDCR/ulEkhY9P7oxz96vo6b9mHxjIXcXGlbmOf+Ph/y+5X13DedcP1swwsc5x1KlSwkIS5ZzjFzquKto3tDf8AxWPgeJ6OPwmHrxwVGUquIlJXSb5YX1+ctvQ8WurhbWHANN8DeG5viB4ut9PG5bRT5lzIv8MY6/ieg+tem6n+yb49us+XNpH43T//ABFcR8ZtXuv2Q/g/eiSSM+NNcdrSyktzvCyEH5xkfdjXLcjliB3r9O4p8SsrqYJ4bh7F06+KqNQpxhOMrN/aaTdoxV23tol1PgOGuE61TFqpmVNwpQXNJtWul0Xm3odz/wANpeENY+Ml18EP7NtJPDf9njTI9QQ4U6gpIeA9tu0BARzvBHORjwH4i+DZvA/im706T5oQ2+CT+/GT8p+vr7g18bi3njVbpZ5P7QWT7QLksS/mZ3bs+uec1+hHwtmuP2wPhRp11aPaxeL9KP2W+WVio8wAZJ4JCuMOOvOR2NflOT06Xh9jKdSpUf1SvaNWUnpGr0qtvZT1jLZLRvY/RMdQp5/hKipRtWpNyil1h1j6rdfceM12mjLa+PPBWpeDtUc7ZIy1tJjlCOQR7q2D9M16R/wxT8Qv+euj/wDgW/8A8RU9j+xt8R9PvIrmGbR1kjbcMXb/AJfcr6/iDiLhXOsDLDrNKEaitKEvaw92cdYvf5PybPl8pw+Y5bio1Xh5OD0krPWL3/zXmfEfgXR7rw98VbbTb2MxXVrLNFIp9RG/I9j1B7g0V9K/Gz4Ga34P+IWieJL3Tvszruhu5IzujcGNgjhh3ydvryKK/Cs9zalncsPi6Uk7wSdndKSlK+q6dV5NH7pkWDeBo1KT25rrzTUbf13Pljxl8YviN4b8VahZaL8QvFGi2MTgR2unavcW8SDaDgIjgD8qx/8AhoL4u/8ARWfG/wD4UN5/8door9jwOWYGphKM50INuMfsrsvI/NcZWq/WanvP4n18w/4aC+Lv/RWfG/8A4UN5/wDHazNQ8XeJfHt/DeeKvE2seJrm2UpDLrF9LdNGpOSFMjEgZ7CiivWw+X4OhUVSlRjGXdRSf4I86rVqSg05MfTdN8aeKfAN5cTeFfFOteGJLoL57aPfy2pl2527vLYbsZOM+poorvxFGnXpunVipRfRq6OSjKUJ3i7Gl/w0F8Xf+is+N/8Awobz/wCO0f8ADQXxd/6Kz43/APChvP8A47RRXkf2Tl//AEDw/wDAY/5Hoe2q/wAz+81/CHxm+JPiLxNYWOr/ABF8U6xYyuVktdQ1i5nicbTwUdyD+Iooor814nw1DD4qEaNNRXL0SXVn3WQ1Jyw8uaTev6I//9k=",
+            "withinRect": null,
+            "actions": [
+                {"leftButton":false,"middleButton":false,"rightButton":false,"forwardButton":false,"backButton":false,"scroll":{"x":0.0,"y":0.0},"duration":2.0 },
+                {"leftButton":true,"middleButton":false,"rightButton":false,"forwardButton":false,"backButton":false,"scroll":{"x":0.0,"y":0.0} },
+                {"leftButton":false,"middleButton":false,"rightButton":false,"forwardButton":false,"backButton":false,"scroll":{"x":0.0,"y":0.0} }
+            ]
+        }
+    }
+}
+```
+
+- Using resoure:// path (note that the `sample_images` folder must be under a Resources folder in your project)
+```json
+{
+    "name": "CV Image Action: Click Menu Change Profile Button",
+    "description":"Moves the mouse over the change profile button, then clicks and releases on the button. Criteria waits for the action to complete.",
+    "endCriteria": [
+        {"type":"ActionComplete" }
+    ],
+    "botAction":{    
+        "type":"Mouse_CVImage",
+        "data": {
+            "imageData":"resource://sample_images/change_profile_button",
             "withinRect": null,
             "actions": [
                 {"leftButton":false,"middleButton":false,"rightButton":false,"forwardButton":false,"backButton":false,"scroll":{"x":0.0,"y":0.0},"duration":2.0 },


### PR DESCRIPTION
[Loom video](https://www.loom.com/share/9775948da78742b5b444b8b2551d4a69?sid=105fafc7-1a8d-4256-a1b7-0b27553c738b).

This PR adds the threshold parameter to the sdk. This is an optional threshold to accept a returned match from the object detection model. Returned matches with a confidence score less than this threshold are ignored.

The added tests are as simple as they get. Currently only checking for errors at query construction, and that an error is logged when both text and image queries are added. I think we should add more comprehensive tests that check the actual result of sending a query. However, decided that this is out of scope for this PR and created a [ticket](https://linear.app/regression-games/issue/REG-1982/add-more-end-to-end-sdk-tests-for-computer-vision) for future work.

The a future PR will update the docs.


---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
