### PR TITLE
[FIX] prevent null exception when opening Overlay for the first time

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGBotManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGBotManager.cs
@@ -62,6 +62,14 @@ public class RGBotManager : MonoBehaviour
                 recordingToolbar.SetActive(false);
             }
         }
+
+        // if the Sequence Manager is present, we do not need to initialize the bot/behavior
+        // dropdowns. They are only kept in this script for backwards compatibility
+        var sequenceManager = GetComponentInChildren<RGSequenceManager>();
+        if (sequenceManager != null)
+        {
+            _initialized = true;
+        }
     }
 
     private void InitializeDropdown()


### PR DESCRIPTION
## What is your problem
- When I click the Williward face to open our overlay, the first click doesn't work and displays an error. Subsequent clicks produce no such error until the game/editor is restarted

## What is the solution
- The `RGBotManager` script is shared by both the new and previous RGOverlay prefabs. The previous overlay initializes its Bot and Behaviour dropdowns when you first open the overlay; however, the new overlay does not need to populate these dropdowns. They don't even exist in the new overlay!
- In the future, when the new overlay becomes the standard, we can revise the RGBotManager script to contain no logic relating to Bot and Behaviour dropdowns

## Found footage
https://github.com/user-attachments/assets/121f3ee4-c9c2-456b-ae43-1a10f5e8cc58
