### PR TITLE
[REG-1983] Don't update comparison status until all segments for this Update evaluated

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
@@ -374,6 +374,8 @@ namespace RegressionGames.StateRecorder.BotSegments
                     }
                 }
 
+                var matchedThisUpdate = false;
+
                 // check count each loop because we remove from it during the loop
                 for (var i = 0; i < _nextBotSegments.Count; /* do not increment here*/)
                 {
@@ -399,8 +401,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                             {
                                 _lastTimeLoggedKeyFrameConditions = now;
                                 FindObjectOfType<ReplayToolbarManager>()?.SetKeyFrameWarningText(null);
-                                // only do this when it is the zero index segment that passes
-                                KeyFrameEvaluator.Evaluator.PersistPriorFrameStatus();
+                                matchedThisUpdate = true;
                             }
                         }
 
@@ -444,6 +445,12 @@ namespace RegressionGames.StateRecorder.BotSegments
 
                         ++i;
                     }
+                }
+
+                if (matchedThisUpdate)
+                {
+                    // only do this when a segment passed this update after all segments have been considered for this update
+                    KeyFrameEvaluator.Evaluator.PersistPriorFrameStatus();
                 }
 
                 if (_nextBotSegments.Count > 0)


### PR DESCRIPTION
- Fixes a bug where we were updating the 'previous' objectStatus for delta comparison too soon during each update when multiple bot segments were being considered.  This caused addedCount and removedCount to be 0 in some evaluation cases where they should have had real counts

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
