### PR TITLE
[REG-1995] Fix the hitch/hang when starting a game with our SDK installed

### DIFF
--- a/src/gg.regression.unity.bots/Editor/Scripts/RGEditorUtils.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGEditorUtils.cs
@@ -67,25 +67,5 @@ namespace RegressionGames.Editor
             }
 #endif
         }
-
-
-        #if UNITY_EDITOR
-        /// <summary>
-        /// Finds the Runtime assembly for the Regression Games SDK.
-        /// </summary>
-        public static Assembly FindRGAssembly()
-        {
-            var rgAsmName = Path.GetFileName(typeof(BotSegmentsPlaybackController).Assembly.Location);
-            Assembly[] assemblies = CompilationPipeline.GetAssemblies(AssembliesType.Player);
-            foreach (Assembly assembly in assemblies)
-            {
-                if (Path.GetFileName(assembly.outputPath) == rgAsmName)
-                {
-                    return assembly;
-                }
-            }
-            return null;
-        }
-        #endif
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
@@ -42,7 +42,6 @@ public class RGSequenceManager : MonoBehaviour
      */
     public void LoadSequences()
     {
-        return;
         if (_loadingSequences == false)
         {
             // not perfectly thread safe.. but close enough for this case

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
@@ -182,31 +182,34 @@ public class RGSequenceManager : MonoBehaviour
     public void InstantiateSequences(IDictionary<string, (string,BotSequence)> sequences)
 
     {
-        // ensure we aren't appending new sequences on to the previous ones
-        ClearExistingSequences();
-
-        // instantiate a prefab for each sequence file that has been loaded
-        foreach (var sequenceKVPair in sequences)
+        if (sequencesPanel != null && sequenceCardPrefab != null)
         {
-            var resourcePath = sequenceKVPair.Key;
-            var sequenceInfo = sequenceKVPair.Value;
-            var instance = Instantiate(sequenceCardPrefab, Vector3.zero, Quaternion.identity);
+            // ensure we aren't appending new sequences on to the previous ones
+            ClearExistingSequences();
 
-            // map sequence data fields to new prefab
-            instance.transform.SetParent(sequencesPanel.transform, false);
-            var prefabComponent = instance.GetComponent<RGSequenceEntry>();
-            if (prefabComponent != null)
+            // instantiate a prefab for each sequence file that has been loaded
+            foreach (var sequenceKVPair in sequences)
             {
-                prefabComponent.sequenceName = sequenceInfo.Item2.name;
-                prefabComponent.filePath = sequenceInfo.Item1;
-                prefabComponent.resourcePath = resourcePath;
-                prefabComponent.description = sequenceInfo.Item2.description;
-                prefabComponent.playAction = () =>
-                {
-                    _replayToolbarManager.selectedReplayFilePath = null;
-                    sequenceInfo.Item2.Play();
-                };
+                var resourcePath = sequenceKVPair.Key;
+                var sequenceInfo = sequenceKVPair.Value;
+                var instance = Instantiate(sequenceCardPrefab, Vector3.zero, Quaternion.identity);
 
+                // map sequence data fields to new prefab
+                instance.transform.SetParent(sequencesPanel.transform, false);
+                var prefabComponent = instance.GetComponent<RGSequenceEntry>();
+                if (prefabComponent != null)
+                {
+                    prefabComponent.sequenceName = sequenceInfo.Item2.name;
+                    prefabComponent.filePath = sequenceInfo.Item1;
+                    prefabComponent.resourcePath = resourcePath;
+                    prefabComponent.description = sequenceInfo.Item2.description;
+                    prefabComponent.playAction = () =>
+                    {
+                        _replayToolbarManager.selectedReplayFilePath = null;
+                        sequenceInfo.Item2.Play();
+                    };
+
+                }
             }
         }
     }
@@ -216,15 +219,18 @@ public class RGSequenceManager : MonoBehaviour
      */
     private void ClearExistingSequences()
     {
-        for(int i = 0; i < sequencesPanel.transform.childCount; i++)
+        if (sequencesPanel != null)
         {
-            if (i == 0)
+            for (int i = 0; i < sequencesPanel.transform.childCount; i++)
             {
-                // don't destroy the 'create new sequence' button child. It is always the first one
-                continue;
-            }
+                if (i == 0)
+                {
+                    // don't destroy the 'create new sequence' button child. It is always the first one
+                    continue;
+                }
 
-            Destroy(sequencesPanel.transform.GetChild(i).gameObject);
+                Destroy(sequencesPanel.transform.GetChild(i).gameObject);
+            }
         }
     }
 


### PR DESCRIPTION
- Resolves the hitch/hang experienced when entering play mode for a game with our SDK installed
  - Botsequence resolution is now async
  - Instrumentation code is back to being more performant

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
