### PR TITLE
[REG-1984] Cleans up virtual mouse device... doesn't solve UI real mouse interference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ artifacts/
 .idea
 
 src/RGUnityBots/Assets/RegressionGames/Resources/RGBots.asset*
+src/RGUnityBots/Assets/RegressionGames/Resources/RGBotSequences.asset*
 
 # Unity specific ignores appear in '.gitignore' files within the Unity projects themselves
 # This is because the default Unity gitignore (https://github.com/github/gitignore/blob/main/Unity.gitignore) only works when at the root of the Unity project

--- a/src/RGUnityBots/Assets/Tests/Runtime/RGActionManagerTests.cs
+++ b/src/RGUnityBots/Assets/Tests/Runtime/RGActionManagerTests.cs
@@ -29,7 +29,7 @@ namespace Tests.Runtime
             Assert.IsTrue(parsedRange.RangeEquals(rng));
             Assert.IsTrue(rng.RangeEquals(parsedRange));
         }
-        
+
         [Test]
         public void TestValueRanges()
         {
@@ -182,7 +182,8 @@ namespace Tests.Runtime
         private void ResetInputSystem()
         {
             InputSystem.ResetDevice(Keyboard.current, true);
-            InputSystem.ResetDevice(MouseEventSender.GetMouse(), true);
+            MouseEventSender.Reset();
+            InputSystem.ResetDevice(Mouse.current, true);
         }
 
         private bool _inputUpdateCompleted = false;
@@ -197,7 +198,7 @@ namespace Tests.Runtime
         {
             _inputUpdateCompleted = true;
         }
-        
+
         /// <summary>
         /// Wait for both legacy and new Input System event processing updates to complete, then
         /// immediately invoke the given callback.
@@ -208,19 +209,19 @@ namespace Tests.Runtime
             _inputUpdateCompleted = false;
             yield return new WaitUntil(() => _inputUpdateCompleted); // wait for new Input System update to complete
         }
-        
+
         [UnityTest]
         public IEnumerator TestActionManager()
         {
             RGLegacyInputWrapper.UpdateMode = RGLegacyInputUpdateMode.MANUAL;
-            
+
             if (Keyboard.current == null)
             {
                 InputSystem.AddDevice<Keyboard>();
             }
             SceneManager.LoadSceneAsync("ActionManagerTestScene", LoadSceneMode.Single);
             yield return RGTestUtils.WaitForScene("ActionManagerTestScene");
-            
+
             GameObject eventSystem = GameObject.Find("EventSystem");
             var eventSys = eventSystem.GetComponent<EventSystem>();
 
@@ -234,11 +235,11 @@ namespace Tests.Runtime
                 FindAndPerformAction("Any Key", true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Keyboard.current.anyKey.wasPressedThisFrame");
-                
+
                 FindAndPerformAction("Key fireKey", true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "keyboard[key].isPressed");
-                
+
                 FindAndPerformAction("Key Key.Backslash", true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Keyboard.current.backslashKey.isPressed");
@@ -246,7 +247,7 @@ namespace Tests.Runtime
                 FindAndPerformAction("Key Key.LeftAlt", true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "keyboard.altKey.wasPressedThisFrame");
-                
+
                 FindAndPerformAction("Key Key.F2", true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Keyboard.current[Key.F2].isPressed");
@@ -256,7 +257,7 @@ namespace Tests.Runtime
                 inputSysKeyListener.SetActive(false);
                 RGActionManager.StopSession();
             }
-            
+
             #if ENABLE_LEGACY_INPUT_MANAGER
             // Test Legacy Input Manager Axis
             ResetInputSystem();
@@ -268,11 +269,11 @@ namespace Tests.Runtime
                 FindAndPerformAction("Axis \"Mouse X\"", 1);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetAxisRaw(\"Mouse X\")");
-                
+
                 FindAndPerformAction("Axis \"Mouse ScrollWheel\"", 1);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetAxis(\"Mouse ScrollWheel\")");
-                
+
                 FindAndPerformAction("Axis axisName", 1);
                 FindAndPerformAction("Axis axisName2", 1);
                 yield return WaitForInputUpdate();
@@ -283,8 +284,8 @@ namespace Tests.Runtime
                 legacyAxisListener.SetActive(false);
                 RGActionManager.StopSession();
             }
-            
-            // Test Legacy Input Manager Button 
+
+            // Test Legacy Input Manager Button
             ResetInputSystem();
             RGActionManager.StartSession(eventSys);
             GameObject legacyButtonListener = FindGameObject("LegacyButtonListener");
@@ -294,11 +295,11 @@ namespace Tests.Runtime
                 FindAndPerformAction("Button ButtonName", true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetButton(ButtonName)");
-                
+
                 FindAndPerformAction("Button \"Fire1\"", true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetButtonDown(btn)");
-                
+
                 FindAndPerformAction("Button \"Fire2\"", true);
                 yield return WaitForInputUpdate();
                 FindAndPerformAction("Button \"Fire2\"", false);
@@ -310,7 +311,7 @@ namespace Tests.Runtime
                 legacyButtonListener.SetActive(false);
                 RGActionManager.StopSession();
             }
-            
+
             // Test Legacy Input Manager Key
             ResetInputSystem();
             RGActionManager.StartSession(eventSys);
@@ -322,25 +323,25 @@ namespace Tests.Runtime
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.anyKey");
                 LogAssert.Expect(LogType.Log, "Input.anyKeyDown");
-                
+
                 FindAndPerformAction("Key _gameSettings.bindings.CrouchKey", true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetKey(crouchKey)");
-                
+
                 FindAndPerformAction("Key _gameSettings.bindings.fireKey", true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetKeyDown(_gameSettings.bindings.fireKey)");
-                
+
                 FindAndPerformAction("Key _gameSettings.bindings.jumpKey", true);
                 yield return WaitForInputUpdate();
                 FindAndPerformAction("Key _gameSettings.bindings.jumpKey", false);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetKeyUp(_gameSettings.bindings.jumpKey)");
-                
+
                 FindAndPerformAction("Key KeyCode.LeftShift", true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetKey(aimKey)");
-                
+
                 FindAndPerformAction("Key MOVE_RIGHT_KEY", true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetKey(MOVE_RIGHT_KEY)");
@@ -351,7 +352,7 @@ namespace Tests.Runtime
                 RGActionManager.StopSession();
             }
             #endif
-            
+
             // Test Mouse Button
             ResetInputSystem();
             RGActionManager.StartSession(eventSys);
@@ -363,22 +364,22 @@ namespace Tests.Runtime
                 FindAndPerformAction("Mouse Button 0", true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetMouseButton(0)");
-                
+
                 FindAndPerformAction("Mouse Button mouseBtn", true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetMouseButtonDown(mouseBtn)");
-                
+
                 FindAndPerformAction("Mouse Button otherMouseBtn", true);
                 yield return WaitForInputUpdate();
                 FindAndPerformAction("Mouse Button otherMouseBtn", false);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Input.GetMouseButtonUp(btn)");
                 #endif
-                
+
                 FindAndPerformAction("Mouse Button 3", true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Mouse.current.forwardButton.isPressed");
-                
+
                 FindAndPerformAction("Mouse Button 4", true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "mouse.backButton.wasPressedThisFrame");
@@ -388,7 +389,7 @@ namespace Tests.Runtime
                 mouseBtnListener.SetActive(false);
                 RGActionManager.StopSession();
             }
-            
+
             // Test Mouse Movement
             ResetInputSystem();
             RGActionManager.StartSession(eventSys);
@@ -417,7 +418,7 @@ namespace Tests.Runtime
                 mouseMovementListener.SetActive(false);
                 RGActionManager.StopSession();
             }
-            
+
             #if ENABLE_LEGACY_INPUT_MANAGER
             // Test Mouse Handlers
             ResetInputSystem();
@@ -433,17 +434,17 @@ namespace Tests.Runtime
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "OnMouseEnter MouseHandlerListener");
                 LogAssert.Expect(LogType.Log, "OnMouseOver MouseHandlerListener");
-                
+
                 FindAndPerformAction(hoverAction, false);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "OnMouseExit MouseHandlerListener");
-                
+
                 FindAndPerformAction(pressAction, true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "OnMouseDown MouseHandlerListener");
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "OnMouseDrag MouseHandlerListener");
-                
+
                 FindAndPerformAction(pressAction, false);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "OnMouseUpAsButton MouseHandlerListener");
@@ -455,7 +456,7 @@ namespace Tests.Runtime
                 RGActionManager.StopSession();
             }
             #endif
-            
+
             // Test Mouse Raycast 2D
             ResetInputSystem();
             RGActionManager.StartSession(eventSys);
@@ -483,7 +484,7 @@ namespace Tests.Runtime
                         }
                     }
                 }
-                
+
                 Debug.Assert(hitCoord.HasValue);
                 foreach (var inp in actionInst.GetInputs(hitCoord.Value))
                 {
@@ -491,7 +492,7 @@ namespace Tests.Runtime
                 }
 
                 yield return WaitForInputUpdate();
-                
+
                 LogAssert.Expect(LogType.Log, "Hit 2D game object The_Square");
             }
             finally
@@ -500,7 +501,7 @@ namespace Tests.Runtime
                 theSquare.SetActive(false);
                 RGActionManager.StopSession();
             }
-            
+
             // Test Mouse Raycast 3D
             ResetInputSystem();
             RGActionManager.StartSession(eventSys);
@@ -513,7 +514,7 @@ namespace Tests.Runtime
                 var actionInst = RGActionManager.GetValidActions().FirstOrDefault(actionInst =>
                     actionInst.BaseAction is MousePositionAction && actionInst.TargetObject.GetType().Name == "MouseRaycast3DObject");
                 Debug.Assert(actionInst != null);
-                
+
                 Vector2? hitCoord = null;
                 int gridLength = 16;
                 for (int x = 0; x < gridLength; ++x)
@@ -528,7 +529,7 @@ namespace Tests.Runtime
                         }
                     }
                 }
-                
+
                 Debug.Assert(hitCoord.HasValue);
                 foreach (var inp in actionInst.GetInputs(hitCoord.Value))
                 {
@@ -536,7 +537,7 @@ namespace Tests.Runtime
                 }
 
                 yield return WaitForInputUpdate();
-                
+
                 LogAssert.Expect(LogType.Log, "Hit 3D game object The_Cube");
             }
             finally
@@ -545,12 +546,12 @@ namespace Tests.Runtime
                 theCube.SetActive(false);
                 RGActionManager.StopSession();
             }
-            
+
             // Test Unity UI interaction
             string[] uiObjects =
             {
-                "The_Button", "The_Toggle", 
-                "Slider_Horizontal", "Slider_Vertical", 
+                "The_Button", "The_Toggle",
+                "Slider_Horizontal", "Slider_Vertical",
                 "Scrollbar_Horizontal", "Scrollbar_Vertical",
                 "Dropdown", "TMP_Dropdown", "InputField", "TMP_InputField"
             };
@@ -570,7 +571,7 @@ namespace Tests.Runtime
                 FindAndPerformAction("ActionManagerTests.UIHandler.OnBtnClick", false);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Clicked button The_Button");
-                
+
                 // Toggle Click
                 FindAndPerformAction("Press The_Toggle", true);
                 yield return WaitForInputUpdate();
@@ -582,7 +583,7 @@ namespace Tests.Runtime
                 FindAndPerformAction("Press The_Toggle", false);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "The_Toggle changed to False");
-                
+
                 // Dropdown Press
                 FindAndPerformAction("Press Dropdown", true);
                 yield return WaitForInputUpdate();
@@ -595,7 +596,7 @@ namespace Tests.Runtime
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Dropdown value changed");
                 yield return RGTestUtils.WaitUntil(() => GameObject.Find("Dropdown List") == null, 5, "Dropdown item did not disappear");
-                
+
                 // TextMeshPro Dropdown Press
                 FindAndPerformAction("Press TMP_Dropdown", true);
                 yield return WaitForInputUpdate();
@@ -608,7 +609,7 @@ namespace Tests.Runtime
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "TMP_Dropdown value changed");
                 yield return RGTestUtils.WaitUntil(() => GameObject.Find("Dropdown List") == null, 5, "TMP_Dropdown item did not disappear");
-                
+
                 // InputField text entry
                 FindAndPerformAction("Press InputField", true);
                 yield return WaitForInputUpdate();
@@ -628,7 +629,7 @@ namespace Tests.Runtime
                 FindAndPerformAction("Text Submit InputField", true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "InputField submitted with text Hello");
-                
+
                 // TextMeshPro InputField text entry
                 FindAndPerformAction("Press TMP_InputField", true);
                 yield return WaitForInputUpdate();
@@ -648,7 +649,7 @@ namespace Tests.Runtime
                 FindAndPerformAction("Text Submit TMP_InputField", true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "TMP_InputField submitted with text World");
-                
+
                 // Horizontal Slider Movement
                 FindAndPerformAction("Press Slider_Horizontal", 0.25f);
                 yield return WaitForInputUpdate();
@@ -660,7 +661,7 @@ namespace Tests.Runtime
                 FindAndPerformAction("Release Slider_Horizontal", 0.75f);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Slider_Horizontal changed to second half");
-                
+
                 // Vertical Slider Movement
                 FindAndPerformAction("Press Slider_Vertical", 0.25f);
                 yield return WaitForInputUpdate();
@@ -689,7 +690,7 @@ namespace Tests.Runtime
                     FindAndPerformAction("Release Scrollbar_Horizontal", 0.75f);
                     yield return WaitForInputUpdate();
                     LogAssert.Expect(LogType.Log, "Scrollbar_Horizontal changed to second half");
-                    
+
                     // Vertical Scrollbar Movement
                     FindAndPerformAction("Press Scrollbar_Vertical", 0.25f);
                     yield return WaitForInputUpdate();
@@ -714,7 +715,7 @@ namespace Tests.Runtime
                 }
                 RGActionManager.StopSession();
             }
-            
+
             // Test interprocedural analysis
             ResetInputSystem();
             RGActionManager.StartSession(eventSys);
@@ -731,7 +732,7 @@ namespace Tests.Runtime
                 interprocObj.SetActive(false);
                 RGActionManager.StopSession();
             }
-            
+
             // Test triggering inputs handled via InputActionAsset and embedded InputAction
             ResetInputSystem();
             RGActionManager.StartSession(eventSys);
@@ -740,7 +741,7 @@ namespace Tests.Runtime
             try
             {
                 yield return null; // wait one frame for the InputActions to become active
-                
+
                 FindAndPerformAction("InputAction Move", new Vector2Int(1, 1));
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "moveVal.sqrMagnitude");
@@ -765,7 +766,7 @@ namespace Tests.Runtime
                 inputActionListener.SetActive(false);
                 RGActionManager.StopSession();
             }
-            
+
             // Test triggering inputs handled via InputActionAsset C# wrapper
             ResetInputSystem();
             RGActionManager.StartSession(eventSys);
@@ -774,15 +775,15 @@ namespace Tests.Runtime
             try
             {
                 yield return null; // wait one frame for the InputActions to become active
-                
+
                 FindAndPerformAction("InputAction Crouch", true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "Crouch pressed");
-                
+
                 FindAndPerformAction("InputAction Horizontal", 1);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "horizVal > 0");
-                
+
                 FindAndPerformAction("InputAction Horizontal", -1);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "horizVal < 0");
@@ -792,7 +793,7 @@ namespace Tests.Runtime
                 csWrapperListener.SetActive(false);
                 RGActionManager.StopSession();
             }
-            
+
             // Test triggering inputs handled via PlayerInput
             ResetInputSystem();
             RGActionManager.StartSession(eventSys);
@@ -801,15 +802,15 @@ namespace Tests.Runtime
             try
             {
                 yield return null; // wait one frame for the InputActions to become active
-                
+
                 FindAndPerformAction("InputAction Move", new Vector2Int(1, 1));
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "OnMove()");
-                
+
                 FindAndPerformAction("InputAction Jump", true);
                 yield return WaitForInputUpdate();
                 LogAssert.Expect(LogType.Log, "OnJump()");
-                
+
                 FindAndPerformAction("InputAction Aim", new Vector2Int(-1, -1));
                 yield return WaitForInputUpdate();
                 FindAndPerformAction("InputAction Aim", new Vector2Int(1, 1));

--- a/src/RGUnityBots/Assets/Tests/Runtime/RGActionManagerTests.cs
+++ b/src/RGUnityBots/Assets/Tests/Runtime/RGActionManagerTests.cs
@@ -183,7 +183,12 @@ namespace Tests.Runtime
         {
             InputSystem.ResetDevice(Keyboard.current, true);
             MouseEventSender.Reset();
-            InputSystem.ResetDevice(Mouse.current, true);
+            if (Mouse.current != null)
+            {
+                InputSystem.ResetDevice(Mouse.current, true);
+            }
+
+            MouseEventSender.InitializeVirtualMouse();
         }
 
         private bool _inputUpdateCompleted = false;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
@@ -79,7 +79,6 @@ namespace RegressionGames.StateRecorder.BotSegments
         {
             _screenRecorder = GetComponentInParent<ScreenRecorder>();
             SetupEventSystem();
-            MouseEventSender.GetMouse();
         }
 
         private bool unpaused;
@@ -108,7 +107,7 @@ namespace RegressionGames.StateRecorder.BotSegments
             Stop();
             _replaySuccessful = null;
 
-            MouseEventSender.MoveMouseOffScreen();
+            MouseEventSender.Reset();
 
             _dataPlaybackContainer = dataPlaybackContainer;
         }
@@ -185,7 +184,6 @@ namespace RegressionGames.StateRecorder.BotSegments
             _dataPlaybackContainer = null;
             KeyboardEventSender.Reset();
             MouseEventSender.Reset();
-            MouseEventSender.MoveMouseOffScreen();
 
             TransformStatus.Reset();
             KeyFrameEvaluator.Evaluator.Reset();
@@ -215,7 +213,6 @@ namespace RegressionGames.StateRecorder.BotSegments
             _dataPlaybackContainer?.Reset();
             KeyboardEventSender.Reset();
             MouseEventSender.Reset();
-            MouseEventSender.MoveMouseOffScreen();
 
             TransformStatus.Reset();
             KeyFrameEvaluator.Evaluator.Reset();
@@ -244,7 +241,6 @@ namespace RegressionGames.StateRecorder.BotSegments
             _dataPlaybackContainer?.Reset();
             KeyboardEventSender.Reset();
             MouseEventSender.Reset();
-            MouseEventSender.MoveMouseOffScreen();
 
             TransformStatus.Reset();
             KeyFrameEvaluator.Evaluator.Reset();
@@ -267,6 +263,9 @@ namespace RegressionGames.StateRecorder.BotSegments
             {
                 if (_startPlaying)
                 {
+                    // initialize the virtual mouse
+                    MouseEventSender.InitializeVirtualMouse();
+
                     // start the mouse off the screen.. this avoids CV or other things failing because the virtual mouse is in the way at the start
                     MouseEventSender.MoveMouseOffScreen();
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseEventSender.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseEventSender.cs
@@ -62,6 +62,11 @@ namespace RegressionGames.StateRecorder
                     RGDebug.LogDebug("reset - Enabling the real mouse device for mouse event");
                     InputSystem.EnableDevice(_realMouse);
                 }
+
+                if (_realMouse != null)
+                {
+                    _realMouse.MakeCurrent();
+                }
             }
 
             _virtualMouse = null;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseEventSender.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseEventSender.cs
@@ -9,6 +9,7 @@ using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Utilities;
+using Object = UnityEngine.Object;
 
 namespace RegressionGames.StateRecorder
 {
@@ -17,217 +18,298 @@ namespace RegressionGames.StateRecorder
 
         private static Vector2? _lastMousePosition;
 
-        private static IDisposable _mouseEventHandler;
+        private static IDisposable _virtualMouseEventHandler;
+
+        private static IDisposable _realMouseEventHandler;
 
         // ReSharper disable once InconsistentNaming
         private static readonly RecordedGameObjectStatePathEqualityComparer _recordedGameObjectStatePathEqualityComparer = new();
 
+        private static InputDevice _realMouse;
+
+        private static InputDevice _virtualMouse;
+
+
         public static void Reset()
         {
+            MoveMouseOffScreen();
             try
             {
-                _mouseEventHandler?.Dispose();
+                _virtualMouseEventHandler?.Dispose();
             }
             catch (Exception)
             {
                 // do nothing
             }
 
-            _mouseEventHandler = null;
+            try
+            {
+                _realMouseEventHandler?.Dispose();
+            }
+            catch (Exception)
+            {
+                // do nothing
+            }
+
+            _virtualMouseEventHandler = null;
+            _realMouseEventHandler = null;
+
+            if (_virtualMouse != null)
+            {
+                InputSystem.RemoveDevice(_virtualMouse);
+                if (_realMouse is { enabled: false })
+                {
+                    RGDebug.LogDebug("reset - Enabling the real mouse device for mouse event");
+                    InputSystem.EnableDevice(_realMouse);
+                }
+            }
+
+            _virtualMouse = null;
+            _realMouse = null;
         }
 
-        public static InputDevice GetMouse()
+        public static InputDevice InitializeVirtualMouse()
         {
-            var mouse = InputSystem.devices.FirstOrDefault(a => a.name == "RGVirtualMouse");
-            if (mouse == null)
+            _realMouse ??= InputSystem.devices.FirstOrDefault(a => a.name == "Mouse");
+
+            _virtualMouse ??= InputSystem.devices.FirstOrDefault(a => a.name == "RGVirtualMouse");
+
+            if (_virtualMouse == null)
             {
-                mouse = InputSystem.AddDevice<Mouse>("RGVirtualMouse");
+                _virtualMouse = InputSystem.AddDevice<Mouse>("RGVirtualMouse");
             }
 
-            if (!mouse.enabled)
+            if (_virtualMouse != null)
             {
-                InputSystem.EnableDevice(mouse);
-            }
-
-            if (!mouse.canRunInBackground)
-            {
-                // Forcibly allow the virtual mouse to send events while the application is backgrounded
-                // Note that if the user continues creating mouse events while outside the application, this could still interfere
-                // with the game if it is reading mouse input via the Input System.
-                var deviceFlagsField = mouse.GetType().GetField("m_DeviceFlags", BindingFlags.NonPublic | BindingFlags.Instance);
-                if (deviceFlagsField != null)
+                if (!_virtualMouse.enabled)
                 {
-                    int canRunInBackground = 1 << 11;
-                    int canRunInBackgroundHasBeenQueried = 1 << 12;
-                    var deviceFlags = (int)deviceFlagsField.GetValue(mouse);
-                    deviceFlags |= canRunInBackground;
-                    deviceFlags |= canRunInBackgroundHasBeenQueried;
-                    deviceFlagsField.SetValue(mouse, deviceFlags);
+                    InputSystem.EnableDevice(_virtualMouse);
                 }
-                else
-                {
-                    RGDebug.LogWarning("Unable to check device flags for virtual mouse");
-                }
-            }
 
-            if (_mouseEventHandler == null)
-            {
-                _mouseEventHandler = InputSystem.onEvent.ForDevice(mouse).Call(e =>
+                if (!_virtualMouse.canRunInBackground)
                 {
-                    var positionControl = mouse.allControls.First(a => a is Vector2Control && a.name == "position") as Vector2Control;
+                    // Forcibly allow the virtual mouse to send events while the application is backgrounded
+                    // Note that if the user continues creating mouse events while outside the application, this could still interfere
+                    // with the game if it is reading mouse input via the Input System.
+                    var deviceFlagsField = _virtualMouse.GetType().GetField("m_DeviceFlags", BindingFlags.NonPublic | BindingFlags.Instance);
+                    if (deviceFlagsField != null)
+                    {
+                        int canRunInBackground = 1 << 11;
+                        int canRunInBackgroundHasBeenQueried = 1 << 12;
+                        var deviceFlags = (int)deviceFlagsField.GetValue(_virtualMouse);
+                        deviceFlags |= canRunInBackground;
+                        deviceFlags |= canRunInBackgroundHasBeenQueried;
+                        deviceFlagsField.SetValue(_virtualMouse, deviceFlags);
+                    }
+                    else
+                    {
+                        RGDebug.LogWarning("Unable to set device canRunInBackground flags for virtual mouse");
+                    }
+                }
+
+                _virtualMouseEventHandler ??= InputSystem.onEvent.ForDevice(_virtualMouse).Call(e =>
+                {
+                    var positionControl = _virtualMouse.allControls.First(a => a is Vector2Control && a.name == "position") as Vector2Control;
                     var position = positionControl.ReadValueFromEvent(e);
 
-                    var buttonsClicked = mouse.allControls.FirstOrDefault(a =>
+                    var buttonsClicked = _virtualMouse.allControls.FirstOrDefault(a =>
                         a is ButtonControl abc && abc.ReadValueFromEvent(e) > 0.1f
                     ) != null;
-                    RGDebug.LogDebug("Mouse event at: " + position.x + "," + position.y + "  buttonsClicked: " + buttonsClicked);
+                    RGDebug.LogDebug("Virtual mouse event at: " + position.x + "," + position.y + "  buttonsClicked: " + buttonsClicked);
+
                     // need to use the static accessor here as this anonymous function's parent gameObject instance could get destroyed
-                    var virtualMouseCursors = UnityEngine.Object.FindObjectsOfType<VirtualMouseCursor>();
+                    var virtualMouseCursors = Object.FindObjectsOfType<VirtualMouseCursor>();
                     virtualMouseCursors.FirstOrDefault()?.SetPosition(position, buttonsClicked);
+
+                    if (!buttonsClicked && _realMouse is { enabled: false })
+                    {
+                        RGDebug.LogDebug("Enabling the real mouse device after virtual click mouse event");
+                        InputSystem.EnableDevice(_realMouse);
+                    }
                 });
             }
 
-            return mouse;
+            if (_realMouseEventHandler == null)
+            {
+                if (_realMouse != null)
+                {
+                    _realMouseEventHandler = InputSystem.onEvent.ForDevice(_realMouse).Call(e =>
+                    {
+                        if (RGDebug.IsVerboseEnabled || _realMouse is {enabled: false})
+                        {
+                            var positionControl = _realMouse.allControls.First(a => a is Vector2Control && a.name == "position") as Vector2Control;
+                            var position = positionControl.ReadValueFromEvent(e);
+
+                            var buttonsClicked = _realMouse.allControls.FirstOrDefault(a =>
+                                a is ButtonControl abc && abc.ReadValueFromEvent(e) > 0.1f
+                            ) != null;
+                            if (_realMouse is { enabled: false })
+                            {
+                                //shouldn't happen.. we disabled it
+                                RGDebug.LogWarning("Real mouse event at: " + position.x + "," + position.y + "  buttonsClicked: " + buttonsClicked);
+                            }
+                            else
+                            {
+                                RGDebug.LogVerbose("Real mouse event at: " + position.x + "," + position.y + "  buttonsClicked: " + buttonsClicked);
+                            }
+                        }
+                    });
+                }
+            }
+
+            return _virtualMouse;
         }
 
         public static Vector2 MoveMouseOffScreen(int replaySegment = 0)
         {
             var mousePosition = new Vector2(Screen.width + 20, -20);
-            MouseEventSender.SendRawPositionMouseEvent(replaySegment, mousePosition);
+            SendRawPositionMouseEvent(replaySegment, mousePosition);
             return mousePosition;
         }
 
-        public static void SendRawPositionMouseEvent(int replaySegment, Vector2 normalizedPosition, bool leftButton = false, bool middleButton = false, bool rightButton = false, bool forwardButton = false, bool backButton = false)
+        private static void SendRawPositionMouseEvent(int replaySegment, Vector2 normalizedPosition, bool leftButton = false, bool middleButton = false, bool rightButton = false, bool forwardButton = false, bool backButton = false)
         {
             SendRawPositionMouseEvent(replaySegment, normalizedPosition, leftButton, middleButton, rightButton, forwardButton, backButton, Vector2.zero);
         }
 
         public static void SendRawPositionMouseEvent(int replaySegment, Vector2 normalizedPosition, bool leftButton, bool middleButton, bool rightButton, bool forwardButton, bool backButton, Vector2 scroll)
         {
+            if (_virtualMouse != null)
+            {
+                using (StateEvent.From(_virtualMouse, out var eventPtr))
+                {
+                    eventPtr.time = InputState.currentTime;
 
-             var mouse = GetMouse();
+                    var mouseControls = _virtualMouse.allControls;
+                    var mouseEventString = "";
 
-             using (StateEvent.From(mouse, out var eventPtr))
-             {
-                 eventPtr.time = InputState.currentTime;
+                    // 1f == true == clicked state
+                    // 0f == false == un-clicked state
+                    foreach (var mouseControl in mouseControls)
+                    {
+                        switch (mouseControl.name)
+                        {
+                            case "delta":
+                                if (_lastMousePosition != null)
+                                {
+                                    var delta = normalizedPosition - _lastMousePosition.Value;
+                                    if (RGDebug.IsDebugEnabled)
+                                    {
+                                        mouseEventString += $"delta: {delta.x},{delta.y}  ";
+                                    }
 
-                 var mouseControls = mouse.allControls;
-                 var mouseEventString = "";
+                                    ((Vector2Control)mouseControl).WriteValueIntoEvent(delta, eventPtr);
+                                }
 
-                 // 1f == true == clicked state
-                 // 0f == false == un-clicked state
-                 foreach (var mouseControl in mouseControls)
-                 {
-                     switch (mouseControl.name)
-                     {
-                         case "delta":
-                             if (_lastMousePosition != null)
-                             {
-                                 var delta = normalizedPosition - _lastMousePosition.Value;
-                                 if (RGDebug.IsDebugEnabled)
-                                 {
-                                     mouseEventString += $"delta: {delta.x},{delta.y}  ";
-                                 }
+                                break;
+                            case "position":
+                                if (RGDebug.IsDebugEnabled)
+                                {
+                                    mouseEventString += $"position: {normalizedPosition.x},{normalizedPosition.y}  ";
+                                }
 
-                                 ((Vector2Control)mouseControl).WriteValueIntoEvent(delta, eventPtr);
-                             }
+                                ((Vector2Control)mouseControl).WriteValueIntoEvent(normalizedPosition, eventPtr);
+                                break;
+                            case "scroll":
+                                if (RGDebug.IsDebugEnabled)
+                                {
+                                    if (scroll.x < -0.1f || scroll.x > 0.1f || scroll.y < -0.1f || scroll.y > 0.1f)
+                                    {
+                                        mouseEventString += $"scroll: {scroll.x},{scroll.y}  ";
+                                    }
+                                }
 
-                             break;
-                         case "position":
-                             if (RGDebug.IsDebugEnabled)
-                             {
-                                 mouseEventString += $"position: {normalizedPosition.x},{normalizedPosition.y}  ";
-                             }
+                                ((DeltaControl)mouseControl).WriteValueIntoEvent(scroll, eventPtr);
+                                break;
+                            case "leftButton":
+                                if (RGDebug.IsDebugEnabled)
+                                {
+                                    if (leftButton)
+                                    {
+                                        mouseEventString += $"leftButton  ";
+                                    }
+                                }
 
-                             ((Vector2Control)mouseControl).WriteValueIntoEvent(normalizedPosition, eventPtr);
-                             break;
-                         case "scroll":
-                             if (RGDebug.IsDebugEnabled)
-                             {
-                                 if (scroll.x < -0.1f || scroll.x > 0.1f || scroll.y < -0.1f || scroll.y > 0.1f)
-                                 {
-                                     mouseEventString += $"scroll: {scroll.x},{scroll.y}  ";
-                                 }
-                             }
+                                ((ButtonControl)mouseControl).WriteValueIntoEvent(leftButton ? 1f : 0f, eventPtr);
+                                break;
+                            case "middleButton":
+                                if (RGDebug.IsDebugEnabled)
+                                {
+                                    if (middleButton)
+                                    {
+                                        mouseEventString += $"middleButton  ";
+                                    }
+                                }
 
-                             ((DeltaControl)mouseControl).WriteValueIntoEvent(scroll, eventPtr);
-                             break;
-                         case "leftButton":
-                             if (RGDebug.IsDebugEnabled)
-                             {
-                                 if (leftButton)
-                                 {
-                                     mouseEventString += $"leftButton  ";
-                                 }
-                             }
+                                ((ButtonControl)mouseControl).WriteValueIntoEvent(middleButton ? 1f : 0f, eventPtr);
+                                break;
+                            case "rightButton":
+                                if (RGDebug.IsDebugEnabled)
+                                {
+                                    if (rightButton)
+                                    {
+                                        mouseEventString += $"rightButton  ";
+                                    }
+                                }
 
-                             ((ButtonControl)mouseControl).WriteValueIntoEvent(leftButton ? 1f : 0f, eventPtr);
-                             break;
-                         case "middleButton":
-                             if (RGDebug.IsDebugEnabled)
-                             {
-                                 if (middleButton)
-                                 {
-                                     mouseEventString += $"middleButton  ";
-                                 }
-                             }
+                                ((ButtonControl)mouseControl).WriteValueIntoEvent(rightButton ? 1f : 0f, eventPtr);
+                                break;
+                            case "forwardButton":
+                                if (RGDebug.IsDebugEnabled)
+                                {
+                                    if (forwardButton)
+                                    {
+                                        mouseEventString += $"forwardButton  ";
+                                    }
+                                }
 
-                             ((ButtonControl)mouseControl).WriteValueIntoEvent(middleButton ? 1f : 0f, eventPtr);
-                             break;
-                         case "rightButton":
-                             if (RGDebug.IsDebugEnabled)
-                             {
-                                 if (rightButton)
-                                 {
-                                     mouseEventString += $"rightButton  ";
-                                 }
-                             }
+                                ((ButtonControl)mouseControl).WriteValueIntoEvent(forwardButton ? 1f : 0f, eventPtr);
+                                break;
+                            case "backButton":
+                                if (RGDebug.IsDebugEnabled)
+                                {
+                                    if (backButton)
+                                    {
+                                        mouseEventString += $"backButton  ";
+                                    }
+                                }
 
-                             ((ButtonControl)mouseControl).WriteValueIntoEvent(rightButton ? 1f : 0f, eventPtr);
-                             break;
-                         case "forwardButton":
-                             if (RGDebug.IsDebugEnabled)
-                             {
-                                 if (forwardButton)
-                                 {
-                                     mouseEventString += $"forwardButton  ";
-                                 }
-                             }
-
-                             ((ButtonControl)mouseControl).WriteValueIntoEvent(forwardButton ? 1f : 0f, eventPtr);
-                             break;
-                         case "backButton":
-                             if (RGDebug.IsDebugEnabled)
-                             {
-                                 if (backButton)
-                                 {
-                                     mouseEventString += $"backButton  ";
-                                 }
-                             }
-
-                             ((ButtonControl)mouseControl).WriteValueIntoEvent(backButton ? 1f : 0f, eventPtr);
-                             break;
-                     }
-                 }
+                                ((ButtonControl)mouseControl).WriteValueIntoEvent(backButton ? 1f : 0f, eventPtr);
+                                break;
+                        }
+                    }
 
 #if ENABLE_LEGACY_INPUT_MANAGER
-                 {
-                     Vector2 delta = _lastMousePosition.HasValue ? (normalizedPosition - _lastMousePosition.Value) : Vector2.zero;
-                     SendMouseEventLegacy(position: normalizedPosition, delta: delta, scroll: scroll,
-                         leftButton: leftButton, middleButton: middleButton, rightButton: rightButton,
-                         forwardButton: forwardButton, backButton: backButton);
-                 }
+                    {
+                        Vector2 delta = _lastMousePosition.HasValue ? (normalizedPosition - _lastMousePosition.Value) : Vector2.zero;
+                        SendMouseEventLegacy(position: normalizedPosition, delta: delta, scroll: scroll,
+                            leftButton: leftButton, middleButton: middleButton, rightButton: rightButton,
+                            forwardButton: forwardButton, backButton: backButton);
+                    }
 #endif
 
-                 _lastMousePosition = normalizedPosition;
+                    _lastMousePosition = normalizedPosition;
 
-                 if (RGDebug.IsDebugEnabled)
-                 {
-                     RGDebug.LogDebug($"({replaySegment}) [frame: {Time.frameCount}] - Sending Mouse Event - {mouseEventString}");
-                 }
+                    // Disable the Real mouse whenever we have a click about to happen, until we un-click
+                    // This is a bit scary, but it provides stability to avoid any single or partial pixel twitches of the real mouse ruining click events or positions to the UI system
+                    if (leftButton || middleButton || rightButton || forwardButton || backButton)
+                    {
+                        if (_realMouse is { enabled: true })
+                        {
+                            RGDebug.LogDebug("Disabling the real mouse device before virtual click mouse event");
+                            InputSystem.DisableDevice(_realMouse);
+                        }
+                    }
 
-                 InputSystem.QueueEvent(eventPtr);
-             }
+
+                    if (RGDebug.IsDebugEnabled)
+                    {
+                        RGDebug.LogDebug($"({replaySegment}) [frame: {Time.frameCount}] - Sending Virtual Mouse Event - {mouseEventString}");
+                    }
+
+                    InputSystem.QueueEvent(eventPtr);
+                }
+            }
         }
 
         public static void SendMouseEvent(int replaySegment, MouseInputActionData mouseInput, Dictionary<long, ObjectStatus> priorTransforms, Dictionary<long, ObjectStatus> priorEntities, Dictionary<long, ObjectStatus> transforms, Dictionary<long, ObjectStatus> entities)
@@ -238,7 +320,7 @@ namespace RegressionGames.StateRecorder
             var normalizedPosition = clickObjectResult.Item3;
 
             // non-world space object found, make sure we hit the object
-            if (bestObject != null && bestObject.screenSpaceBounds.HasValue && !clickObjectResult.Item2)
+            if (bestObject is { screenSpaceBounds: not null } && !clickObjectResult.Item2)
             {
                 var clickBounds = bestObject.screenSpaceBounds.Value;
 
@@ -415,7 +497,7 @@ namespace RegressionGames.StateRecorder
 
                 if (objectToCheck.worldSpaceBounds != null)
                 {
-                    if (bestObject != null && bestObject.worldSpaceBounds == null)
+                    if (bestObject is { worldSpaceBounds: null })
                     {
                         //do nothing, prefer ui elements
                     }
@@ -479,7 +561,7 @@ namespace RegressionGames.StateRecorder
                 }
                 else // objectToCheck.worldSpaceBounds == null
                 {
-                    if (bestObject != null && bestObject.worldSpaceBounds == null)
+                    if (bestObject is { worldSpaceBounds: null })
                     {
                         // compare ui elements for best match
                         // give some threshold variance here for floating point math on sizes


### PR DESCRIPTION
- Disables the 'real' mouse device before we click and re-enables it after we next unclick
  - This may solve the issue where moving the real mouse during a click causes the click not to fire, but ONLY for behaviours listening for clicks.
  - This DOES NOT solve the issue for UI elements as the UI system is processing the raw input system mouse movement events irrespective of whether that device is enabled or not.  It also assumes a single mouse pointer device and thus the movements of the real mouse effectively update the position of the virtual mouse as the UI input system sees things. Poor design on unity's part imho

- Cleans up when our VirtualMouse exists to only be while a replay is playing.  Before this was active all the time and might have interfered with their actual game logic for devices.
---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
