### PR TITLE
[REG-2006] Transient segments were completing too early

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
@@ -35,9 +35,6 @@ public class RGSequenceManager : MonoBehaviour
 
     private ReplayToolbarManager _replayToolbarManager;
 
-    private bool _loadingSequences = false;
-    private IDictionary<string, (string, BotSequence)> _loadedSequences = null;
-
     public static RGSequenceManager GetInstance()
     {
         return _this;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
@@ -389,24 +389,26 @@ namespace RegressionGames.StateRecorder.BotSegments
 
                     if (matched)
                     {
-                        if (!nextBotSegment.Replay_Matched)
+                        // only update the time when the first index matches, but keeps us from logging this while waiting for actions to complete
+                        if (i == 0)
                         {
-                            nextBotSegment.Replay_Matched = true;
-                            // log this the first time
-                            RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment - Criteria Matched - {nextBotSegment.name} - {nextBotSegment.description}");
-                            // tell the action that our segment completed and it should stop when it finishes its current actions
-                            nextBotSegment.StopAction(transformStatuses, entityStatuses);
-                            if (i == 0)
+                            if (!nextBotSegment.Replay_Matched)
                             {
+                                // only mark this fully matched (as opposed to transient if it is the current segment)
+                                nextBotSegment.Replay_Matched = true;
+                                RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment - Criteria Matched - {nextBotSegment.name} - {nextBotSegment.description}");
+
+                                if (nextBotSegment.Replay_ActionStarted && !nextBotSegment.Replay_ActionCompleted)
+                                {
+                                    // tell the action that our segment completed and it should stop when it finishes its current actions.. only do this the first time we pass through as matched
+                                    nextBotSegment.StopAction(transformStatuses, entityStatuses);
+                                }
+
                                 _lastTimeLoggedKeyFrameConditions = now;
                                 FindObjectOfType<ReplayToolbarManager>()?.SetKeyFrameWarningText(null);
                                 matchedThisUpdate = true;
                             }
-                        }
 
-                        // only update the time when the first index matches, but keeps us from logging this while waiting for actions to complete
-                        if (i == 0)
-                        {
                             // wait 10 seconds between logging this as some actions take quite a while
                             if (nextBotSegment.Replay_ActionStarted && !nextBotSegment.Replay_ActionCompleted && _lastTimeLoggedKeyFrameConditions < now - LOG_ERROR_INTERVAL)
                             {
@@ -417,10 +419,10 @@ namespace RegressionGames.StateRecorder.BotSegments
                             }
                         }
 
-                        if (nextBotSegment.Replay_ActionStarted && nextBotSegment.Replay_ActionCompleted)
+                        if (nextBotSegment.Replay_Matched && nextBotSegment.Replay_ActionStarted && nextBotSegment.Replay_ActionCompleted)
                         {
                             _lastTimeLoggedKeyFrameConditions = now;
-                            RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment - Completed - {nextBotSegment.name} - {nextBotSegment.description}");
+                            RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment - DONE - Criteria Matched && Action Completed - {nextBotSegment.name} - {nextBotSegment.description}");
                             //Process the inputs from that bot segment if necessary
                             _nextBotSegments.RemoveAt(i);
                         }
@@ -454,17 +456,21 @@ namespace RegressionGames.StateRecorder.BotSegments
 
                 if (_nextBotSegments.Count > 0)
                 {
-                    // see if the last entry has transient matches.. if so.. dequeue another
+                    // see if the last entry has transient matches.. if so.. dequeue another up to a limit of 2 total segments being evaluated... we may need to come back to this.. but without this look ahead, loading screens like bossroom fail due to background loading
+                    // but if you go too far.. you can match segments in the replay that you won't see for another 50 segments when you go back to the menu again.. which is obviously wrong
                     var lastSegment = _nextBotSegments[^1];
                     if (lastSegment.Replay_TransientMatched)
                     {
-                        var next = _dataPlaybackContainer.DequeueBotSegment();
-                        if (next != null)
+                        if (_nextBotSegments.Count < 2)
                         {
-                            _lastTimeLoggedKeyFrameConditions = now;
-                            FindObjectOfType<ReplayToolbarManager>()?.SetKeyFrameWarningText(null);
-                            RGDebug.LogInfo($"({next.Replay_SegmentNumber}) - Bot Segment - Added {(next.HasTransientCriteria ? "" : "Non-")}Transient BotSegment for Evaluation after Transient BotSegment - {next.name} - {next.description}");
-                            _nextBotSegments.Add(next);
+                            var next = _dataPlaybackContainer.DequeueBotSegment();
+                            if (next != null)
+                            {
+                                _lastTimeLoggedKeyFrameConditions = now;
+                                FindObjectOfType<ReplayToolbarManager>()?.SetKeyFrameWarningText(null);
+                                RGDebug.LogInfo($"({next.Replay_SegmentNumber}) - Bot Segment - Added {(next.HasTransientCriteria ? "" : "Non-")}Transient BotSegment for Evaluation after Transient BotSegment - {next.name} - {next.description}");
+                                _nextBotSegments.Add(next);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
- Transient bot segments were completing too early in some cases (like Menu, play game, back to menu)... sometimes that second menu would be marked as complete too soon... see in code comments for more explanation

- Tested on boss room, menu -> select character -> load into game -> clear prompts -> exit to menu... for 105+ loops without failure.. so i believe this still covers the loading screen cases that transient criteria overlapping evaluations were originally put in for
---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
