### PR TITLE
[REG-2013] Record an END segment with any remaining inputs, logs, etc

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentZipParser.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentZipParser.cs
@@ -81,7 +81,7 @@ namespace RegressionGames.StateRecorder.BotSegments
             string badSegmentName = null;
             try
             {
-                var replayNumber = 1;
+                var replayNumber = 1; // 1 to align with the actual numbers in the recording
                 foreach (var entry in entries)
                 {
                     using var sr = new StreamReader(entry.Open());

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackContainer.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackContainer.cs
@@ -15,7 +15,7 @@ namespace RegressionGames.StateRecorder.BotSegments
 
         public BotSegmentsPlaybackContainer(IEnumerable<BotSegment> segments, string sessionId = null)
         {
-            var replayNumber = 0;
+            var replayNumber = 1; // 1 to align with the actual numbers in the recording
             _botSegments = new(segments);
             _botSegments.ForEach(a => a.Replay_SegmentNumber = replayNumber++);
             this.SessionId = sessionId ?? Guid.NewGuid().ToString("n");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyFrameType.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyFrameType.cs
@@ -11,6 +11,7 @@
         // No longer used, transform-ui, transform-worldspace, entity all map to GAME_ELEMENT now
         UI_ELEMENT,
         UI_PIXELHASH,
-        TIMER
+        TIMER,
+        END_RECORDING // the trailing logs/inputs/etc leftover when a recording is stopped or the game is exited
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseEventSender.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseEventSender.cs
@@ -168,7 +168,18 @@ namespace RegressionGames.StateRecorder
         public static Vector2 MoveMouseOffScreen(int replaySegment = 0)
         {
             var mousePosition = new Vector2(Screen.width + 20, -20);
-            SendRawPositionMouseEvent(replaySegment, mousePosition);
+            if (_virtualMouse != null)
+            {
+                SendRawPositionMouseEvent(replaySegment, mousePosition);
+            }
+            else
+            {
+                // if the virtual mouse is destroyed, just get the cursor off the screen
+                // need to use the static accessor here as this anonymous function's parent gameObject instance could get destroyed
+                var virtualMouseCursors = Object.FindObjectsOfType<VirtualMouseCursor>();
+                virtualMouseCursors.FirstOrDefault()?.SetPosition(mousePosition);
+            }
+
             return mousePosition;
         }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseInputActionObserver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseInputActionObserver.cs
@@ -144,7 +144,7 @@ namespace RegressionGames.StateRecorder
             _mouseInputActions.Clear();
         }
 
-        public List<MouseInputActionData> FlushInputDataBuffer(bool ensureOne = false)
+        public List<MouseInputActionData> FlushInputDataBuffer(bool ignoreLastClick)
         {
             List<MouseInputActionData> result = new();
             while (_mouseInputActions.TryPeek(out var action))
@@ -153,10 +153,20 @@ namespace RegressionGames.StateRecorder
                 result.Add(action);
             }
 
-            if (ensureOne && result.Count == 0 && _priorMouseState != null)
+            if (result.Count == 0 && _priorMouseState != null)
             {
                 // or.. we asked for at least 1 mouse observation per tick
                 result.Add(_priorMouseState);
+            }
+
+            // get all mouse inputs up to the last click... this is used when we stop the recording from the toolbar to avoid capturing the click on our record button on end recording
+            if (ignoreLastClick)
+            {
+                var lastIndex = result.FindLastIndex(a => a.IsButtonClicked);
+                if (lastIndex > -1)
+                {
+                    result = result.GetRange(0, lastIndex);
+                }
             }
 
             return result;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
@@ -96,7 +96,7 @@ namespace RegressionGames.StateRecorder
                 RefreshSelectedFile();
             }
         }
-        
+
         private volatile bool _parsingZipFile;
 
         void RefreshSelectedFile(Action onFileLoadComplete = null)
@@ -121,7 +121,7 @@ namespace RegressionGames.StateRecorder
                     loopButton.SetActive(true);
                     stopButton.SetActive(true);
                     recordButton.SetActive(false);
-                    
+
                     // if we have something to do after loading then do that here
                     onFileLoadComplete?.Invoke();
                 }
@@ -199,7 +199,7 @@ namespace RegressionGames.StateRecorder
             if (!_recording)
             {
                 recordingPulse.Stop();
-                ScreenRecorder.GetInstance()?.StopRecording();
+                ScreenRecorder.GetInstance()?.StopRecording(true);
                 SetDefaultButtonStates();
             }
             else


### PR DESCRIPTION
- Captures any outstanding logs/inputs/etc in a final state capture on end recording
  - Only works on STOP recording from overlay button... if the application exits, we get notified too late by unity to be able to run a coroutine or wait for another frame :/ .  We still work in the case of application exit, we just don't get this extra data.
- Excludes any mouse events since the last button down IF this was a stop from our overlay button... this avoids replaying this sequence causing it to start recording again by clicking that button at the end
```json
{
"sessionId":"907c0645f3724b0b9454badd067b0fc2",
"referenceSessionId":null,
"apiVersion":13,
"tickNumber":2,
**"keyFrame":["END_RECORDING"],**
"time":7.7670521,
"timeScale":1,
"screenSize":{"x":1502,"y":796},
"performance":{
"previousTickTime":5.5324536,
"apiVersion":4,
"framesSincePreviousTick":260,
"fps":116,
```


---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
