### PR TITLE
[REG-2021] Add metadata file to recordings and add some info to state

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGServiceManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGServiceManager.cs
@@ -573,6 +573,34 @@ namespace RegressionGames
             }
         }
 
+        public async Task UploadGameplaySessionMetadata(long gameplaySessionId, string metadataPath, Action onSuccess, Action onFailure)
+        {
+            if (LoadAuth(out _))
+            {
+                await SendWebFileUploadRequest(
+                    uri: $"{GetRgServiceBaseUri()}/gameplay-session/{gameplaySessionId}/metadata",
+                    method: "POST",
+                    filePath: metadataPath,
+                    contentType: "application/json",
+                    onSuccess: (s) =>
+                    {
+                        RGDebug.LogDebug(
+                            $"RGService GameplaySessionMetadata response received");
+                        onSuccess.Invoke();
+                    },
+                    onFailure: (f) =>
+                    {
+                        RGDebug.LogWarning($"Failed to upload metadata for gameplay session {gameplaySessionId}: {f}");
+                        onFailure.Invoke();
+                    }
+                );
+            }
+            else
+            {
+                onFailure.Invoke();
+            }
+        }
+
         public async Task UploadGameplaySessionLogs(long gameplaySessionId, string zipPath, Action onSuccess, Action onFailure)
         {
             if (LoadAuth(out _))

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/IStringBuilderWriteable.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/IStringBuilderWriteable.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text;
 using JetBrains.Annotations;
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverterContractResolver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverterContractResolver.cs
@@ -57,6 +57,7 @@ namespace RegressionGames.StateRecorder
             { typeof(MeshRenderer), new MeshRendererJsonConverter() },
             { typeof(SkinnedMeshRenderer), new SkinnedMeshRendererJsonConverter() },
             { typeof(NavMeshAgent), new NavMeshAgentJsonConverter() },
+            { typeof(RGGameMetadataJsonConverter), new RGGameMetadataJsonConverter() }
 
         };
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/RGGameMetadataJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/RGGameMetadataJsonConverter.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using RegressionGames.StateRecorder.BotSegments.Models.AIService;
+using RegressionGames.StateRecorder.Models;
+using UnityEngine;
+
+namespace RegressionGames.StateRecorder.JsonConverters
+{
+    public class RGGameMetadataJsonConverter : JsonConverter, ITypedStringBuilderWriteable<RGGameMetadata>
+    {
+
+        // re-usable and large enough to fit all sizes
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(1000));
+
+        void ITypedStringBuilderWriteable<RGGameMetadata>.WriteToStringBuilder(StringBuilder stringBuilder, RGGameMetadata val)
+        {
+            WriteToStringBuilder(stringBuilder, val);
+        }
+
+        string ITypedStringBuilderWriteable<RGGameMetadata>.ToJsonString(RGGameMetadata val)
+        {
+            return ToJsonString(val);
+        }
+
+        public static void WriteToStringBuilder(StringBuilder stringBuilder, RGGameMetadata val)
+        {
+            val.WriteToStringBuilder(stringBuilder);
+        }
+
+        private static string ToJsonString(RGGameMetadata val)
+        {
+            _stringBuilder.Value.Clear();
+            WriteToStringBuilder(_stringBuilder.Value, val);
+            return _stringBuilder.Value.ToString();
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+            }
+            else
+            {
+                // raw is way faster than using the libraries
+                writer.WriteRawValue(ToJsonString((RGGameMetadata)value));
+            }
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JObject jObject = JObject.Load(reader);
+            // ReSharper disable once UseObjectOrCollectionInitializer - easier to debug when on separate lines
+            RGGameMetadata gameMetadata = new();
+            gameMetadata.apiVersion = jObject.GetValue("apiVersion").ToObject<int>(serializer);
+            gameMetadata.unityVersion = jObject.GetValue("unityVersion")?.ToObject<string>(serializer);
+            gameMetadata.runtimePlatform = jObject.GetValue("runtimePlatform")?.ToObject<RuntimePlatform>(serializer) ?? RuntimePlatform.WindowsEditor;
+            gameMetadata.isEditor = jObject.GetValue("isEditor")?.ToObject<bool>(serializer) ?? false;
+            gameMetadata.productName = jObject.GetValue("productName")?.ToObject<string>(serializer);
+            gameMetadata.companyName = jObject.GetValue("companyName")?.ToObject<string>(serializer);
+            gameMetadata.gameVersion = jObject.GetValue("gameVersion")?.ToObject<string>(serializer);
+            gameMetadata.gameBuildGUID = jObject.GetValue("gameBuildGUID")?.ToObject<string>(serializer);
+            gameMetadata.systemLanguage = jObject.GetValue("systemLanguage")?.ToObject<SystemLanguage>(serializer) ?? SystemLanguage.English;
+            gameMetadata.allConfiguredRenderPipelines = jObject.GetValue("allConfiguredRenderPipelines")?.ToObject<List<string>>(serializer);
+            gameMetadata.usingLegacyInputManager = jObject.GetValue("usingLegacyInputManager")?.ToObject<bool>(serializer) ?? false;
+            return gameMetadata;
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(RGGameMetadata);
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/RGGameMetadataJsonConverter.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/RGGameMetadataJsonConverter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6d7544539ced43d68e257abaebdb3463
+timeCreated: 1727192060

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/ObjectStatus.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/ObjectStatus.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 namespace RegressionGames.StateRecorder.Models
 {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/RGGameMetadata.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/RGGameMetadata.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Newtonsoft.Json;
+using RegressionGames.StateRecorder.JsonConverters;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.InputSystem;
+using UnityEngine.Rendering;
+
+
+namespace RegressionGames.StateRecorder.Models
+{
+    [Serializable]
+    [JsonConverter(typeof(RGGameMetadataJsonConverter))]
+    public class RGGameMetadata
+    {
+        public int apiVersion = SdkApiVersion.VERSION_21;
+
+        public int ApiVersion()
+        {
+            return apiVersion;
+        }
+
+        public string unityVersion;
+        public RuntimePlatform runtimePlatform;
+        public bool isEditor;
+        public string productName;
+        public string companyName;
+        public string gameVersion;
+        public string gameBuildGUID;
+        public SystemLanguage systemLanguage;
+        public List<string> allConfiguredRenderPipelines;
+        public bool usingLegacyInputManager;
+
+        public static RGGameMetadata GetMetadata()
+        {
+            return new RGGameMetadata()
+            {
+                unityVersion = Application.unityVersion,
+                runtimePlatform = Application.platform,
+                isEditor = Application.isEditor,
+                productName = Application.productName,
+                companyName = Application.companyName,
+                gameVersion = Application.version,
+                gameBuildGUID = Application.buildGUID,
+                systemLanguage = Application.systemLanguage,
+                allConfiguredRenderPipelines = GraphicsSettings.allConfiguredRenderPipelines.Select(a=> a.GetType().FullName).Distinct().ToList(),
+#if ENABLE_LEGACY_INPUT_MANAGER
+                usingLegacyInputManager = true
+#else
+                usingLegacyInputManager = false
+#endif
+            };
+
+        }
+
+        public void WriteToStringBuilder(StringBuilder stringBuilder)
+        {
+            stringBuilder.Append("{\n\"apiVersion\":");
+            IntJsonConverter.WriteToStringBuilder(stringBuilder, apiVersion);
+            stringBuilder.Append(",\n\"unityVersion\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, unityVersion);
+            stringBuilder.Append(",\n\"runtimePlatform\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, Enum.GetName(typeof(RuntimePlatform),runtimePlatform));
+            stringBuilder.Append(",\n\"isEditor\":");
+            BooleanJsonConverter.WriteToStringBuilder(stringBuilder, isEditor);
+            stringBuilder.Append(",\n\"productName\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, productName);
+            stringBuilder.Append(",\n\"companyName\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, companyName);
+            stringBuilder.Append(",\n\"gameVersion\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, gameVersion);
+            stringBuilder.Append(",\n\"gameBuildGUID\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, gameBuildGUID);
+            stringBuilder.Append(",\n\"systemLanguage\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, Enum.GetName(typeof(SystemLanguage),systemLanguage));
+
+            stringBuilder.Append(",\n\"allConfiguredRenderPipelines\":[");
+            var allConfiguredRenderPipelinesCount = allConfiguredRenderPipelines.Count;
+            for (var i = 0; i < allConfiguredRenderPipelinesCount; i++)
+            {
+                StringJsonConverter.WriteToStringBuilder(stringBuilder, allConfiguredRenderPipelines[i]);
+                if (i + 1 < allConfiguredRenderPipelinesCount)
+                {
+                    stringBuilder.Append(",");
+                }
+            }
+            stringBuilder.Append("]");
+
+            stringBuilder.Append(",\n\"usingLegacyInputManager\":");
+            BooleanJsonConverter.WriteToStringBuilder(stringBuilder, usingLegacyInputManager);
+
+            stringBuilder.Append("\n}");
+        }
+
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/RGGameMetadata.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/RGGameMetadata.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f451d5f36a904dfdaca769ea912f25da
+timeCreated: 1727189163

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/RecordingFrameStateData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/RecordingFrameStateData.cs
@@ -14,7 +14,7 @@ namespace RegressionGames.StateRecorder.Models
     public class RecordingFrameStateData
     {
         //Update me if fields/types change
-        public int apiVersion = SdkApiVersion.VERSION_13;
+        public int apiVersion = SdkApiVersion.VERSION_21;
 
         /// <summary>
         /// Effective API version for this state recording considering all sub elements
@@ -35,6 +35,9 @@ namespace RegressionGames.StateRecorder.Models
         public float timeScale;
         public Vector2Int screenSize;
         public string pixelHash;
+        public string currentRenderPipeline;
+        public List<string> activeEventSystemInputModules;
+        public List<string> activeInputDevices;
         public IEnumerable<RecordedGameObjectState> state;
         public RecordingCodeCoverageState codeCoverage;
         public InputData inputs;
@@ -72,9 +75,31 @@ namespace RegressionGames.StateRecorder.Models
             Vector2IntJsonConverter.WriteToStringBuilder(stringBuilder, screenSize);
             stringBuilder.Append(",\n\"performance\":");
             performance.WriteToStringBuilder(stringBuilder);
-            stringBuilder.Append(",\n\"pixelHash\":\"");
-            stringBuilder.Append(pixelHash);
-            stringBuilder.Append("\",\n\"state\":[\n");
+            stringBuilder.Append(",\n\"pixelHash\"");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, pixelHash);
+            stringBuilder.Append(",\n\"currentRenderPipeline\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, currentRenderPipeline);
+            stringBuilder.Append(",\n\"activeEventSystemInputModules\":[");
+            var activeEventSystemInputModulesCount = activeEventSystemInputModules.Count;
+            for (var i = 0; i < activeEventSystemInputModulesCount; i++)
+            {
+                StringJsonConverter.WriteToStringBuilder(stringBuilder, activeEventSystemInputModules[i]);
+                if (i + 1 < activeEventSystemInputModulesCount)
+                {
+                    stringBuilder.Append(",");
+                }
+            }
+            stringBuilder.Append("],\n\"activeInputDevices\":[");
+            var activeInputDevicesCount = activeInputDevices.Count;
+            for (var i = 0; i < activeInputDevicesCount; i++)
+            {
+                StringJsonConverter.WriteToStringBuilder(stringBuilder, activeInputDevices[i]);
+                if (i + 1 < activeInputDevicesCount)
+                {
+                    stringBuilder.Append(",");
+                }
+            }
+            stringBuilder.Append("],\n\"state\":[\n");
             var counter = 0;
             var stateCount = state.Count();
             foreach( var stateEntry in state)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/RecordingFrameStateData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/RecordingFrameStateData.cs
@@ -75,7 +75,7 @@ namespace RegressionGames.StateRecorder.Models
             Vector2IntJsonConverter.WriteToStringBuilder(stringBuilder, screenSize);
             stringBuilder.Append(",\n\"performance\":");
             performance.WriteToStringBuilder(stringBuilder);
-            stringBuilder.Append(",\n\"pixelHash\"");
+            stringBuilder.Append(",\n\"pixelHash\":");
             StringJsonConverter.WriteToStringBuilder(stringBuilder, pixelHash);
             stringBuilder.Append(",\n\"currentRenderPipeline\":");
             StringJsonConverter.WriteToStringBuilder(stringBuilder, currentRenderPipeline);

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -14,7 +14,9 @@ using RegressionGames.CodeCoverage;
 using RegressionGames.StateRecorder.BotSegments.Models;
 using RegressionGames.StateRecorder.Models;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.Experimental.Rendering;
+using UnityEngine.InputSystem;
 using UnityEngine.Rendering;
 
 // ReSharper disable once ForCanBeConvertedToForeach - Better performance using indexing vs enumerators
@@ -67,6 +69,7 @@ namespace RegressionGames.StateRecorder
         private string _currentGameplaySessionBotSegmentsDirectoryPrefix;
         private string _currentGameplaySessionDataDirectoryPrefix;
         private string _currentGameplaySessionCodeCoverageMetadataPath;
+        private string _currentGameplaySessionGameMetadataPath;
         private string _currentGameplaySessionThumbnailPath;
         private string _currentGameplaySessionLogsDirectoryPrefix;
 
@@ -143,11 +146,52 @@ namespace RegressionGames.StateRecorder
             RGDebug.LogInfo( "Supported Formats for Readback\n" + string.Join( "\n", read_formats ) );
         }
 
-        private async Task HandleEndRecording(long tickCount, DateTime startTime, DateTime endTime, long loggedWarnings, long loggedErrors, string dataDirectoryPrefix, string botSegmentsDirectoryPrefix, string screenshotsDirectoryPrefix, string codeCovMetadataPath, string thumbnailPath, string logsDirectoryPrefix, bool onDestroy = false)
+        private async Task HandleEndRecording(
+            long tickCount,
+            DateTime startTime,
+            DateTime endTime,
+            long loggedWarnings,
+            long loggedErrors,
+            string dataDirectoryPrefix,
+            string botSegmentsDirectoryPrefix,
+            string screenshotsDirectoryPrefix,
+            string codeCovMetadataPath,
+            string thumbnailPath,
+            string logsDirectoryPrefix,
+            string gameMetadataPath,
+            bool onDestroy = false)
         {
             if (!onDestroy)
             {
                 StartCoroutine(ShowUploadingIndicator(true));
+            }
+
+            Task codeCovMetadataTask = null;
+            Task gameMetadataTask = null;
+
+            // Save code coverage metadata if code coverage is enabled
+            RGSettings rgSettings = RGSettings.GetOrCreateSettings();
+            if (rgSettings.GetFeatureCodeCoverage())
+            {
+                var metadata = RGCodeCoverage.GetMetadata();
+                if (metadata != null)
+                {
+                    RGDebug.LogInfo($"Saving code coverage metadata to file: {codeCovMetadataPath}");
+                    using (StreamWriter sw = new StreamWriter(codeCovMetadataPath))
+                    {
+                        string metadataJson = JsonConvert.SerializeObject(metadata, Formatting.Indented);
+                        codeCovMetadataTask = sw.WriteAsync(metadataJson);
+                    }
+                }
+            }
+
+            // Save game metadata
+            var gameMetadata = RGGameMetadata.GetMetadata();
+            RGDebug.LogInfo($"Saving game metadata to file: {gameMetadataPath}");
+            using (StreamWriter sw = new StreamWriter(gameMetadataPath))
+            {
+                string metadataJson = JsonConvert.SerializeObject(gameMetadata, Formatting.Indented);
+                gameMetadataTask = sw.WriteAsync(metadataJson);
             }
 
             var zipTask1 = Task.Run(() =>
@@ -182,26 +226,17 @@ namespace RegressionGames.StateRecorder
                 RGDebug.LogInfo($"Finished zipping replay to file: {logsDirectoryPrefix}.zip");
             });
 
-            // Save code coverage metadata if code coverage is enabled
-            RGSettings rgSettings = RGSettings.GetOrCreateSettings();
-            if (rgSettings.GetFeatureCodeCoverage())
-            {
-                var metadata = RGCodeCoverage.GetMetadata();
-                if (metadata != null)
-                {
-                    RGDebug.LogInfo($"Saving code coverage metadata to file: {codeCovMetadataPath}");
-                    using (StreamWriter sw = new StreamWriter(codeCovMetadataPath))
-                    {
-                        string metadataJson = JsonConvert.SerializeObject(metadata, Formatting.Indented);
-                        sw.Write(metadataJson);
-                    }
-                }
-            }
-
             // Finally, we also save a thumbnail, by choosing the middle file in the screenshots
             var screenshotFiles = Directory.GetFiles(screenshotsDirectoryPrefix);
             var middleFile = screenshotFiles[screenshotFiles.Length / 2]; // this gets floored automatically
             File.Copy(middleFile, thumbnailPath);
+
+            // wait for the metadata tasks to finish
+            if (codeCovMetadataTask != null)
+            {
+                Task.WaitAll(codeCovMetadataTask);
+            }
+            Task.WaitAll(gameMetadataTask);
 
             // wait for the zip tasks to finish
             Task.WaitAll(zipTask1, zipTask2, zipTask3, zipTask4);
@@ -222,11 +257,25 @@ namespace RegressionGames.StateRecorder
                 screenshotsDirectoryPrefix,
                 thumbnailPath,
                 logsDirectoryPrefix,
+                gameMetadataPath,
                 onDestroy
             );
         }
 
-        private async Task CreateAndUploadGameplaySession(long tickCount, DateTime startTime, DateTime endTime, long loggedWarnings, long loggedErrors, string dataDirectoryPrefix, string botSegmentsDirectoryPrefix, string screenshotsDirectoryPrefix, string thumbnailPath, string logsPathPrefix, bool onDestroy = false)
+        private async Task CreateAndUploadGameplaySession(
+            long tickCount,
+            DateTime startTime,
+            DateTime endTime,
+            long loggedWarnings,
+            long loggedErrors,
+            string dataDirectoryPrefix,
+            string botSegmentsDirectoryPrefix,
+            string screenshotsDirectoryPrefix,
+            string thumbnailPath,
+            string logsPathPrefix,
+            string gameMetadataPath,
+            bool onDestroy = false
+            )
         {
 
             try
@@ -272,6 +321,12 @@ namespace RegressionGames.StateRecorder
                 await RGServiceManager.GetInstance().UploadGameplaySessionThumbnail(gameplaySessionId,
                     thumbnailPath,
                     () => { RGDebug.LogInfo($"Uploaded gameplay session thumbnail from {thumbnailPath}"); },
+                    () => { });
+
+                // Upload the metadata
+                await RGServiceManager.GetInstance().UploadGameplaySessionMetadata(gameplaySessionId,
+                    gameMetadataPath,
+                    () => { RGDebug.LogInfo($"Uploaded gameplay session metadata from {gameMetadataPath}"); },
                     () => { });
 
                 // Upload the logs
@@ -358,6 +413,7 @@ namespace RegressionGames.StateRecorder
                 _currentGameplaySessionScreenshotsDirectoryPrefix = _currentGameplaySessionDirectoryPrefix + "/screenshots";
                 _currentGameplaySessionBotSegmentsDirectoryPrefix = _currentGameplaySessionDirectoryPrefix + "/bot_segments";
                 _currentGameplaySessionCodeCoverageMetadataPath = _currentGameplaySessionDirectoryPrefix + "/code_coverage_metadata.json";
+                _currentGameplaySessionGameMetadataPath = _currentGameplaySessionDirectoryPrefix + "/game_metadata.json";
                 _currentGameplaySessionThumbnailPath = _currentGameplaySessionDirectoryPrefix + "/thumbnail.jpg";
                 _currentGameplaySessionLogsDirectoryPrefix = _currentGameplaySessionDirectoryPrefix + "/logs";
                 Directory.CreateDirectory(_currentGameplaySessionDataDirectoryPrefix);
@@ -479,6 +535,7 @@ namespace RegressionGames.StateRecorder
                     _currentGameplaySessionCodeCoverageMetadataPath,
                     _currentGameplaySessionThumbnailPath,
                     _currentGameplaySessionLogsDirectoryPrefix,
+                    _currentGameplaySessionGameMetadataPath,
                     true);
             }
 
@@ -704,6 +761,12 @@ namespace RegressionGames.StateRecorder
                                 };
                             }
                         }
+                        GameObject esGameObject = (EventSystem.current != null? EventSystem.current.gameObject:null);
+                        List<string> eventSystemInputModules = new();
+                        if (esGameObject != null)
+                        {
+                            eventSystemInputModules = esGameObject.gameObject.GetComponents<BaseInputModule>().Where(a => a.isActiveAndEnabled).Select(a => a.GetType().FullName).ToList();
+                        }
 
                         var frameState = new RecordingFrameStateData()
                         {
@@ -716,6 +779,9 @@ namespace RegressionGames.StateRecorder
                             screenSize = new Vector2Int() { x = screenWidth, y = screenHeight },
                             performance = performanceMetrics,
                             pixelHash = pixelHash,
+                            currentRenderPipeline = GraphicsSettings.currentRenderPipeline.GetType().FullName,
+                            activeEventSystemInputModules = eventSystemInputModules,
+                            activeInputDevices = InputSystem.devices.Select(a=>$"{a.name} - {a.path}").ToList(),
                             state = currentStates.Values,
                             codeCoverage = codeCoverageState,
                             inputs = inputData

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/SdkApiVersion.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/SdkApiVersion.cs
@@ -89,8 +89,12 @@
          * <summary> Removed 'type' field from bot sequence entry</summary>
          */
         public const int VERSION_20 = 20;
+        /**
+         * <summary> Define first version of RGGameMetadata. Add fields to FrameStateData</summary>
+         */
+        public const int VERSION_21 = 21;
 
         // Update this when new features are used in the SDK
-        public const int CURRENT_VERSION = VERSION_20;
+        public const int CURRENT_VERSION = VERSION_21;
     }
 }


### PR DESCRIPTION
- Creates a metadata file with each recording
  - (note: follow up task exists for adding endpoint to accept this upload on the backend)
  - https://linear.app/regression-games/issue/REG-2033/add-endpoint-to-rgservice-to-capture-game-metadata
```json
{
"apiVersion":21,
"unityVersion":"2021.3.24f1",
"runtimePlatform":"WindowsEditor",
"isEditor":true,
"productName":"com.unity.multiplayer.samples.coop",
"companyName":"Unity",
"gameVersion":"2.0.4",
"gameBuildGUID":"",
"systemLanguage":"English",
"allConfiguredRenderPipelines":["UnityEngine.Rendering.Universal.UniversalRenderPipelineAsset"],
"usingLegacyInputManager":true
}
```
- Adds some of the more dynamic metadata information to tick state payloads
```json
{
"sessionId":"67c5c4acc0c24a1fbd63a99bd0434e02",
"referenceSessionId":null,
"apiVersion":21,
"tickNumber":1,
"keyFrame":["FIRST_FRAME"],
"time":5.5027099,
"timeScale":1,
"screenSize":{"x":1502,"y":796},
"performance":{
"previousTickTime":0,
"apiVersion":4,
"framesSincePreviousTick":1,
"fps":0,
"perFrameStatistics":[
{
"frameTime":0,
"apiVersion":4,
"cpuTimeNs":null,
"memoryBytes":null,
"gcMemoryBytes":null,
"engineStats":{"frameTime":0.0059621,"apiVersion":4,"renderTime":0.0048094,"triangles":14118,"vertices":19508,"setPassCalls":20,"drawCalls":110,"dynamicBatchedDrawCalls":2,"staticBatchedDrawCalls":2,"instancedBatchedDrawCalls":0,"batches":110,"dynamicBatches":2,"staticBatches":1,"instancedBatches":0}
}
]
},
"pixelHash":null,
**"currentRenderPipeline":"UnityEngine.Rendering.Universal.UniversalRenderPipelineAsset",**
**"activeEventSystemInputModules":["UnityEngine.InputSystem.UI.InputSystemUIInputModule"],**
**"activeInputDevices":["Keyboard - /Keyboard","Mouse - /Mouse","Simulated Touchscreen - /Simulated Touchscreen"],**
"state":[
```

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
