### PR TITLE
[REG-2038] Allow pausing bot sequence playback

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlayCanvas.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlayCanvas.prefab
@@ -528,7 +528,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -814,7 +814,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 9
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -969,7 +969,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1508,7 +1508,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1919,7 +1919,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2203,7 +2203,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3162,7 +3162,7 @@ RectTransform:
   m_Children:
   - {fileID: 985415874430226196}
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3239,7 +3239,7 @@ RectTransform:
   - {fileID: 5061430410649258493}
   - {fileID: 5716806768315515097}
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 11
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3373,6 +3373,140 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &8052215285220177439
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9070620812819065330}
+  - component: {fileID: 2794561587726870589}
+  - component: {fileID: 4932499338121651334}
+  - component: {fileID: 6020225762271723939}
+  m_Layer: 5
+  m_Name: Pause Replay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9070620812819065330
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8052215285220177439}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1090041802443136416}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -40, y: 0}
+  m_SizeDelta: {x: 80, y: 80}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2794561587726870589
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8052215285220177439}
+  m_CullTransparentMesh: 1
+--- !u!114 &4932499338121651334
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8052215285220177439}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 07f1d589ce5d6c44785568588ea0d3d0, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6020225762271723939
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8052215285220177439}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4932499338121651334}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1784025199367272708}
+        m_TargetAssemblyTypeName: RegressionGames.StateRecorder.ReplayToolbarManager,
+          RegressionGames
+        m_MethodName: PauseReplay
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &8603231290118914297
 GameObject:
   m_ObjectHideFlags: 0
@@ -3543,6 +3677,7 @@ RectTransform:
   - {fileID: 7012070649302215336}
   - {fileID: 5586944382632803572}
   - {fileID: 4564151345767979582}
+  - {fileID: 9070620812819065330}
   - {fileID: 265634225495791308}
   - {fileID: 5959241570588781038}
   - {fileID: 3543544153959450623}
@@ -3573,6 +3708,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   chooseReplayButton: {fileID: 4760620846668409867}
   playButton: {fileID: 2022806533036299947}
+  pauseButton: {fileID: 8052215285220177439}
   loopButton: {fileID: 2564316877153735817}
   loopCount: {fileID: 6730458779980616978}
   stopButton: {fileID: 4192813288835746039}

--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlayCanvasV2.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlayCanvasV2.prefab
@@ -1575,7 +1575,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1988,7 +1988,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 9
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2143,7 +2143,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3049,7 +3049,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3627,7 +3627,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3912,7 +3912,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4053,6 +4053,140 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 28}
   m_Pivot: {x: 0.5, y: 1}
+--- !u!1 &4504299472509601499
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6328614165029387609}
+  - component: {fileID: 6259969186231482384}
+  - component: {fileID: 3109057088039901434}
+  - component: {fileID: 6842954945748900850}
+  m_Layer: 5
+  m_Name: Pause Replay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6328614165029387609
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4504299472509601499}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1090041802443136416}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -39.99939, y: -0.00006866455}
+  m_SizeDelta: {x: 80, y: 80}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6259969186231482384
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4504299472509601499}
+  m_CullTransparentMesh: 1
+--- !u!114 &3109057088039901434
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4504299472509601499}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 07f1d589ce5d6c44785568588ea0d3d0, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6842954945748900850
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4504299472509601499}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 3109057088039901434}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1784025199367272708}
+        m_TargetAssemblyTypeName: RegressionGames.StateRecorder.ReplayToolbarManager,
+          RegressionGames
+        m_MethodName: PauseReplay
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &4592676549654162190
 GameObject:
   m_ObjectHideFlags: 0
@@ -5649,7 +5783,7 @@ RectTransform:
   m_Children:
   - {fileID: 985415874430226196}
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -5726,7 +5860,7 @@ RectTransform:
   - {fileID: 5061430410649258493}
   - {fileID: 5716806768315515097}
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 11
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -6973,6 +7107,7 @@ RectTransform:
   - {fileID: 7012070649302215336}
   - {fileID: 5586944382632803572}
   - {fileID: 4564151345767979582}
+  - {fileID: 6328614165029387609}
   - {fileID: 265634225495791308}
   - {fileID: 5959241570588781038}
   - {fileID: 3543544153959450623}
@@ -7003,6 +7138,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   chooseReplayButton: {fileID: 4760620846668409867}
   playButton: {fileID: 2022806533036299947}
+  pauseButton: {fileID: 4504299472509601499}
   loopButton: {fileID: 2564316877153735817}
   loopCount: {fileID: 6730458779980616978}
   stopButton: {fileID: 4192813288835746039}
@@ -7012,6 +7148,7 @@ MonoBehaviour:
   recordingPulse: {fileID: 2788856397230457161}
   uploadingIndicator: {fileID: 4082924595279891428}
   fileOpenIndicator: {fileID: 6646297724481399087}
+  selectedReplayFilePath: 
   replayDataController: {fileID: 5893801167117800152}
 --- !u!114 &5893801167117800152
 MonoBehaviour:

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
@@ -16,8 +16,9 @@ using Object = UnityEngine.Object;
 
 namespace RegressionGames.StateRecorder.BotSegments
 {
-    enum PlayState
+    public enum PlayState
     {
+        NotLoaded,
         Starting,
         Playing,
         Paused,
@@ -31,7 +32,7 @@ namespace RegressionGames.StateRecorder.BotSegments
         private BotSegmentsPlaybackContainer _dataPlaybackContainer;
 
         //tracks in playback is in progress or paused or starting or stopped
-        private PlayState _isPlaying = PlayState.Stopped;
+        private PlayState _isPlaying = PlayState.NotLoaded;
 
         // 0 or greater == isLooping true
         private int _loopCount = -1;
@@ -72,7 +73,7 @@ namespace RegressionGames.StateRecorder.BotSegments
 
         void OnSceneLoad(Scene s, LoadSceneMode m)
         {
-            if (_isPlaying != PlayState.Stopped)
+            if (_isPlaying != PlayState.NotLoaded)
             {
                 // since this is a don't destroy on load, we need to 'fix' the event systems in each new scene that loads
                 RGUtils.SetupOverrideEventSystem(s);
@@ -81,7 +82,7 @@ namespace RegressionGames.StateRecorder.BotSegments
 
         void OnSceneUnload(Scene s)
         {
-            if (_isPlaying != PlayState.Stopped)
+            if (_isPlaying != PlayState.NotLoaded)
             {
                 RGUtils.TeardownOverrideEventSystem(s);
             }
@@ -121,6 +122,20 @@ namespace RegressionGames.StateRecorder.BotSegments
             MouseEventSender.Reset();
 
             _dataPlaybackContainer = dataPlaybackContainer;
+            if (_dataPlaybackContainer != null)
+            {
+                _isPlaying = PlayState.Stopped;
+            }
+            else
+            {
+                _isPlaying = PlayState.NotLoaded;
+            }
+            LogHotkeyInformation();
+        }
+
+        public void LogHotkeyInformation()
+        {
+            RGDebug.LogInfo("BotSegments loaded.  Use the on screen overlay buttons or keyboard hotkeys to control playback.  CTRL+SHIFT_F9 = Play/Pause  , CTRL+SHIFT_F10 = Stop");
         }
 
         /**
@@ -206,7 +221,7 @@ namespace RegressionGames.StateRecorder.BotSegments
             }
 
             _nextBotSegments.Clear();
-            _isPlaying = PlayState.Stopped;
+            _isPlaying = PlayState.NotLoaded;
             _loopCount = -1;
             _replaySuccessful = null;
             WaitingForKeyFrameConditions = null;
@@ -291,14 +306,9 @@ namespace RegressionGames.StateRecorder.BotSegments
             }
         }
 
-        public bool IsPlaying()
+        public PlayState GetState()
         {
-            return _isPlaying == PlayState.Playing;
-        }
-
-        public bool IsPaused()
-        {
-            return _isPlaying == PlayState.Paused;
+            return _isPlaying;
         }
 
         public void Update()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BehaviourActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BehaviourActionData.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json;
 using RegressionGames.StateRecorder.BotSegments.JsonConverters;
 using RegressionGames.StateRecorder.JsonConverters;
 using RegressionGames.StateRecorder.Models;
+using RegressionGames.StateRecorder.Types;
 using UnityEngine;
 
 namespace RegressionGames.StateRecorder.BotSegments.Models
@@ -83,6 +84,34 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             }).Start();
         }
 
+        public void PauseAction(int segmentNumber)
+        {
+            if (_myGameObject != null)
+            {
+                if (_myGameObject.TryGetComponent(_typeToCreate, out var createdType))
+                {
+                    if (createdType is IRGBotSegmentActionBehaviour bsab)
+                    {
+                        bsab.PauseAction();
+                    }
+                }
+            }
+        }
+
+        public void UnPauseAction(int segmentNumber)
+        {
+            if (_myGameObject != null)
+            {
+                if (_myGameObject.TryGetComponent(_typeToCreate, out var createdType))
+                {
+                    if (createdType is IRGBotSegmentActionBehaviour bsab)
+                    {
+                        bsab.UnPauseAction();
+                    }
+                }
+            }
+        }
+
         public bool ProcessAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities, out string error)
         {
             var time = Time.unscaledTime;
@@ -118,7 +147,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
                 if (_myGameObject != null)
                 {
-                    if (!_myGameObject.GetComponent(_typeToCreate))
+                    if (!_myGameObject.TryGetComponent(_typeToCreate, out _))
                     {
                         // StopAction really calls AbortAction by default, but this is a code sample of how to call StopAction in case it is overridden
                         // This represents the 'clean end' case where the behaviour destroyed itself after completing

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotAction.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotAction.cs
@@ -49,6 +49,22 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             data.StopAction(segmentNumber, currentTransforms, currentEntities);
         }
 
+        /**
+         * Handles resuming the paused action if un-paused from the UI; this is most useful for input playback
+         */
+        public void UnPauseAction(int segmentNumber)
+        {
+            data.UnPauseAction(segmentNumber);
+        }
+
+        /**
+          * Handle pausing the action if paused from the UI; this is most useful for input playback
+          */
+        public void PauseAction(int segmentNumber)
+        {
+            data.PauseAction(segmentNumber);
+        }
+
         public void ReplayReset()
         {
             data.ReplayReset();

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
@@ -114,6 +114,28 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             }
         }
 
+        /**
+         * Handles resuming the paused action if un-paused from the UI; this is most useful for input playback
+         */
+        public void UnPauseAction()
+        {
+            if (botAction != null)
+            {
+                botAction.UnPauseAction(Replay_SegmentNumber);
+            }
+        }
+
+        /**
+          * Handle pausing the action if paused from the UI; this is most useful for input playback
+          */
+        public void PauseAction()
+        {
+            if (botAction != null)
+            {
+                botAction.PauseAction(Replay_SegmentNumber);
+            }
+        }
+
         // Replay only
         public void ReplayReset()
         {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IBotActionData.cs
@@ -13,6 +13,22 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public void StartAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities);
 
         /**
+         * Handles resuming the paused action if un-paused from the UI; this is most useful for input playback
+         */
+        public void UnPauseAction(int segmentNumber)
+        {
+            // no-op default
+        }
+
+        /**
+          * Handle pausing the action if paused from the UI; this is most useful for input playback
+          */
+        public void PauseAction(int segmentNumber)
+        {
+            // no-op default
+        }
+
+        /**
          * Called at least once per frame
          * returns true if an action was performed
          * Returns null or an error message string

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
@@ -24,6 +24,8 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         private bool _isStopped;
 
+        private float pauseTime = -1f;
+
         public void StartAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities)
         {
             RGDebug.LogInfo($"({segmentNumber}) - Bot Segment - Processing InputPlaybackActionData");
@@ -40,6 +42,39 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             {
                 mouseInputActionData.Replay_OffsetTime = currentInputTimePoint;
             }
+        }
+
+        public void PauseAction(int segmentNumber)
+        {
+            pauseTime = Time.unscaledTime;
+        }
+
+        public void UnPauseAction(int segmentNumber)
+        {
+            // reset the times to get the right spacing of inputs for any that haven't finished yet
+            if (pauseTime > 0)
+            {
+                var now = Time.unscaledTime;
+                var delta = now - pauseTime;
+
+                foreach (var keyboardInputActionData in inputData.keyboard)
+                {
+                    if (!keyboardInputActionData.Replay_IsDone)
+                    {
+                        keyboardInputActionData.Replay_OffsetTime += delta;
+                    }
+                }
+
+                foreach (var mouseInputActionData in inputData.mouse)
+                {
+                    if (!mouseInputActionData.Replay_IsDone)
+                    {
+                        mouseInputActionData.Replay_OffsetTime += delta;
+                    }
+                }
+            }
+
+            pauseTime = -1f;
         }
 
         public bool ProcessAction(int segmentNumber, Dictionary<long, ObjectStatus> currentTransforms, Dictionary<long, ObjectStatus> currentEntities, out string error)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseEventSender.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseEventSender.cs
@@ -168,17 +168,14 @@ namespace RegressionGames.StateRecorder
         public static Vector2 MoveMouseOffScreen(int replaySegment = 0)
         {
             var mousePosition = new Vector2(Screen.width + 20, -20);
-            if (_virtualMouse != null)
-            {
-                SendRawPositionMouseEvent(replaySegment, mousePosition);
-            }
-            else
-            {
-                // if the virtual mouse is destroyed, just get the cursor off the screen
-                // need to use the static accessor here as this anonymous function's parent gameObject instance could get destroyed
-                var virtualMouseCursors = Object.FindObjectsOfType<VirtualMouseCursor>();
-                virtualMouseCursors.FirstOrDefault()?.SetPosition(mousePosition);
-            }
+
+            // just get the cursor off the screen
+            // need to use the static accessor here as this anonymous function's parent gameObject instance could get destroyed
+            var virtualMouseCursors = Object.FindObjectsOfType<VirtualMouseCursor>();
+            virtualMouseCursors.FirstOrDefault()?.SetPosition(mousePosition);
+
+            // also send the event to move it off screen in the tracking if it hasn't been destroyed
+            SendRawPositionMouseEvent(replaySegment, mousePosition);
 
             return mousePosition;
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
@@ -14,6 +14,8 @@ namespace RegressionGames.StateRecorder
 
         public GameObject playButton;
 
+        public GameObject pauseButton;
+
         public GameObject loopButton;
         public TextMeshProUGUI loopCount;
 
@@ -48,6 +50,7 @@ namespace RegressionGames.StateRecorder
             successIcon.SetActive(false);
 
             playButton.SetActive(false);
+            pauseButton.SetActive(false);
             loopButton.SetActive(false);
             stopButton.SetActive(false);
             loopCount.gameObject.SetActive(false);
@@ -58,6 +61,7 @@ namespace RegressionGames.StateRecorder
             chooseReplayButton.SetActive(false);
             successIcon.SetActive(false);
             playButton.SetActive(false);
+            pauseButton.SetActive(true);
             loopButton.SetActive(false);
             stopButton.SetActive(true);
             recordButton.SetActive(false);
@@ -118,6 +122,7 @@ namespace RegressionGames.StateRecorder
                     // set button states
                     chooseReplayButton.SetActive(false);
                     playButton.SetActive(true);
+                    pauseButton.SetActive(false);
                     loopButton.SetActive(true);
                     stopButton.SetActive(true);
                     recordButton.SetActive(false);
@@ -165,12 +170,33 @@ namespace RegressionGames.StateRecorder
             }
             else
             {
-                RefreshSelectedFile(() =>
+                if (replayDataController.IsPaused())
                 {
+                    // don't refresh from a pause
                     SetInUseButtonStates();
                     replayDataController.Play();
-                });
+                }
+                else
+                {
+                    // refresh on a new play after stop
+                    RefreshSelectedFile(() =>
+                    {
+                        SetInUseButtonStates();
+                        replayDataController.Play();
+                    });
+                }
             }
+        }
+
+        public void PauseReplay()
+        {
+            // reset the button states just in case
+            SetInUseButtonStates();
+            replayDataController.Pause();
+
+            // make it so they can hit play again
+            pauseButton.SetActive(false);
+            playButton.SetActive(true);
         }
 
         public void LoopReplay()
@@ -223,6 +249,7 @@ namespace RegressionGames.StateRecorder
                     chooseReplayButton.SetActive(false);
                     successIcon.SetActive(true);
                     playButton.SetActive(true);
+                    pauseButton.SetActive(false);
                     loopButton.SetActive(true);
                     stopButton.SetActive(true);
                     recordButton.SetActive(false);

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Types/IRGBotSegmentActionBehaviour.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Types/IRGBotSegmentActionBehaviour.cs
@@ -1,0 +1,21 @@
+﻿namespace RegressionGames.StateRecorder.Types
+{
+    /**
+     * <summary>An interface that MonoBehaviours used as actions in RG BotSegments MAY implement to provide pause / un-pause functionality during Bot Segment evaluation.
+     * Implementing this interface is not required for the behaviour action to run, only for it to support pause / un-pause.</summary>
+     */
+    public interface IRGBotSegmentActionBehaviour
+    {
+        /**
+         * <summary>Called by Regression Games Bot Segment processing to indicate that the user has paused the playback of the bot segments.
+         * This should normally be implemented by setting a boolean to true and checking that boolean at the start of your Update loop to block execution when paused.</summary>
+         */
+        public void PauseAction();
+
+        /**
+         * <summary>Called by Regression Games Bot Segment processing to indicate that the user has un-paused the playback of the bot segments.
+         * This should normally be implemented by setting a boolean to false and checking that boolean at the start of your Update loop to allow execution when un-paused.</summary>
+         */
+        public void UnPauseAction();
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Types/IRGBotSegmentActionBehaviour.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Types/IRGBotSegmentActionBehaviour.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 834a6feafa9140a285a79c7ea92c3db7
+timeCreated: 1727273012

--- a/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/RGTestUtils.cs
+++ b/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/RGTestUtils.cs
@@ -76,7 +76,7 @@ namespace RegressionGames.TestFramework
             playbackController.SetDataContainer(replayData);
             playbackController.Play();
             yield return null; // Allow the recording to start playing
-            while (playbackController.IsPlaying())
+            while (playbackController.GetState() == PlayState.Playing || playbackController.GetState() == PlayState.Paused)
             {
                 yield return null;
             }
@@ -103,7 +103,7 @@ namespace RegressionGames.TestFramework
             playbackController.SetDataContainer(replayData);
             playbackController.Play();
             yield return null; // Allow the recording to start playing
-            while (playbackController.IsPlaying())
+            while (playbackController.GetState() == PlayState.Playing || playbackController.GetState() == PlayState.Paused)
             {
                 yield return null;
             }
@@ -132,7 +132,7 @@ namespace RegressionGames.TestFramework
             var playbackController = Object.FindObjectOfType<BotSegmentsPlaybackController>();
 
             yield return null; // Allow the recording to start playing
-            while (playbackController.IsPlaying())
+            while (playbackController.GetState() == PlayState.Playing || playbackController.GetState() == PlayState.Paused)
             {
                 yield return null;
             }


### PR DESCRIPTION
- Allows the user to pause and resume bot sequence playback
  - Handles updating the input playback time offsets appropriately when un-pausing
  - Handles pausing any actions that implement the correct methods.
    - Adds an interface that can be implemented by MonoBehaviours used in BotSegment actions to make them pausable
  - Also works with replay looping
- Toggles between a new pause button and the play button to pause/un-pause
![image](https://github.com/user-attachments/assets/aac44672-ddf4-4c39-923b-a2f6551564d8)
- Adds CTRL+SHIFT+F9 & CTRL+SHIFT+F10 shortcuts for play/pause & stop
---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
