### PR TITLE
[REG-1988] Address Mac Metal async gpu format issues

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenshotCapture.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenshotCapture.cs
@@ -285,8 +285,17 @@ namespace RegressionGames.StateRecorder
                     {
                         Object.Destroy(_screenShotTexture);
                     }
-
-                    _screenShotTexture = new RenderTexture(screenWidth, screenHeight, 0);
+                    
+                    if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Metal)
+                    {
+                        // why Metal defaults to B8G8R8A8_SRGB and thus flips the colors.. who knows..
+                        //  this setting stops it from spam errors
+                        _screenShotTexture = new RenderTexture(screenWidth, screenHeight, 0, GraphicsFormat.R8G8B8A8_SRGB);
+                    }
+                    else
+                    {
+                        _screenShotTexture = new RenderTexture(screenWidth, screenHeight, 0);    
+                    }
                 }
 
                 var theGraphicsFormat = _screenShotTexture.graphicsFormat;
@@ -317,12 +326,6 @@ namespace RegressionGames.StateRecorder
                                     Array.Copy(copyBuffer, 0, pixels, (screenHeight - i - 1) * screenWidth, screenWidth);
                                 }
                             } //else.. we're fine
-
-                            if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Metal)
-                            {
-                                // why Metal defaults to B8G8R8A8_SRGB and thus flips the colors.. who knows.. it also spams errors before this point ... so this is likely to change if Unity fixes that
-                                theGraphicsFormat = GraphicsFormat.R8G8B8A8_SRGB;
-                            }
 
                             var imageOutput = ImageConversion.EncodeArrayToJPG(pixels, theGraphicsFormat, (uint)screenWidth, (uint)screenHeight);
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenshotCapture.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenshotCapture.cs
@@ -289,7 +289,7 @@ namespace RegressionGames.StateRecorder
                     if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Metal)
                     {
                         // why Metal defaults to B8G8R8A8_SRGB and thus flips the colors.. who knows..
-                        //  this setting stops it from spam errors
+                        //  this setting stops it from spamming log errors
                         _screenShotTexture = new RenderTexture(screenWidth, screenHeight, 0, GraphicsFormat.R8G8B8A8_SRGB);
                     }
                     else


### PR DESCRIPTION
- Sets a correctly supported Graphics format on the screenshot texture for AsyncGPU readback on Mac Metal

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
