### PR TITLE
[REG-2043] Ignore control characters in text strings

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/StringJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/StringJsonConverter.cs
@@ -18,15 +18,17 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         static StringJsonConverter()
         {
-            // skip these
-            EscapeCharReplacements[0] = char.MaxValue;
-            EscapeCharReplacements[1] = char.MaxValue;
-            EscapeCharReplacements[2] = char.MaxValue;
-            EscapeCharReplacements[3] = char.MaxValue;
-            EscapeCharReplacements[4] = char.MaxValue;
-            EscapeCharReplacements[5] = char.MaxValue;
-            EscapeCharReplacements[6] = char.MaxValue;
-            EscapeCharReplacements[7] = char.MaxValue;
+            // skip these - control characters in ascii table
+            for (int i = 0; i <= 7; i++)
+            {
+                EscapeCharReplacements[i] = char.MaxValue;
+            }
+
+            // skip these - control characters in ascii table
+            for (int i = 14; i <= 27; i++)
+            {
+                EscapeCharReplacements[i] = char.MaxValue;
+            }
 
             // replace these
             EscapeCharReplacements['\n'] = 'n';

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/StringJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/StringJsonConverter.cs
@@ -18,6 +18,17 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         static StringJsonConverter()
         {
+            // skip these
+            EscapeCharReplacements[0] = char.MaxValue;
+            EscapeCharReplacements[1] = char.MaxValue;
+            EscapeCharReplacements[2] = char.MaxValue;
+            EscapeCharReplacements[3] = char.MaxValue;
+            EscapeCharReplacements[4] = char.MaxValue;
+            EscapeCharReplacements[5] = char.MaxValue;
+            EscapeCharReplacements[6] = char.MaxValue;
+            EscapeCharReplacements[7] = char.MaxValue;
+
+            // replace these
             EscapeCharReplacements['\n'] = 'n';
             EscapeCharReplacements['\r'] = 'r';
             EscapeCharReplacements['\t'] = 't';
@@ -68,19 +79,29 @@ namespace RegressionGames.StateRecorder.JsonConverters
                 }
                 else
                 {
-                    // need to escape.. copy existing range to result
+                    // need to escape or skip.. copy existing range to result
                     if (startIndex != endIndex)
                     {
                         var length = endIndex - startIndex;
                         input.CopyTo(startIndex, bufferArray, currentNextIndex, length);
                         currentNextIndex += length;
                     }
+
                     // update indexes
                     endIndex = i + 1;
                     startIndex = i + 1;
-                    // write the escaped value to the buffer
-                    bufferArray[currentNextIndex++] = '\\';
-                    bufferArray[currentNextIndex++] = escapeReplacement;
+
+                    if (escapeReplacement == char.MaxValue)
+                    {
+                        // need to skip
+                    }
+                    else
+                    {
+                        // need to escape
+                        // write the escaped value to the buffer
+                        bufferArray[currentNextIndex++] = '\\';
+                        bufferArray[currentNextIndex++] = escapeReplacement;
+                    }
                 }
             }
 


### PR DESCRIPTION
- ignores ASCII characters 0->7 and 14->27 when escaping json strings
  - 0 - null
  - 1 - start of heading
  - 2 - start of text
  - 3 - end of text (<- this was in traces from some games)
  - 4 - end of transmission
  - 5 - inquiry
  - 6 - acknowledge
  - 7 - bell
  - 14 -> 27 (see online ascii table)

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
