### PR TITLE
[REG-2056] Ensure BotSegment/Sequence directories are created while saving replays.

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -298,6 +298,7 @@ namespace RegressionGames.StateRecorder
                     Directory.Delete(segmentResourceDirectory, true);
                 }
 
+                Directory.CreateDirectory(Path.GetDirectoryName(segmentResourceDirectory));
                 // move the directory (this also deletes the source directory)
                 Directory.Move(botSegmentsDirectoryPrefix, segmentResourceDirectory);
             }
@@ -325,6 +326,7 @@ namespace RegressionGames.StateRecorder
                 segments = sequenceEntries
             };
 
+            Directory.CreateDirectory(Path.GetDirectoryName(sequenceJsonPath));
             await File.WriteAllBytesAsync(sequenceJsonPath, Encoding.UTF8.GetBytes(botSequence.ToJsonString()));
 
             // refresh the sequences list

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -297,8 +297,12 @@ namespace RegressionGames.StateRecorder
                 {
                     Directory.Delete(segmentResourceDirectory, true);
                 }
-
+                
+                // Path.GetDirectoryName returns the parent directory (e.g. "Assets/RegressionGames/Resources/BotSegments")
+                // This is because our current path does not end with a trailing /
+                // So we can safely create this without interfering with the .Move command right below.
                 Directory.CreateDirectory(Path.GetDirectoryName(segmentResourceDirectory));
+
                 // move the directory (this also deletes the source directory)
                 Directory.Move(botSegmentsDirectoryPrefix, segmentResourceDirectory);
             }


### PR DESCRIPTION
Our current automatic replay copying fails if the BotSegment/Sequences folder is not present. This PR ensures those folders are created, and present.

Tested in Editor and Build.

[Loom video](https://www.loom.com/share/f9e70481e2f842a0b6e298508a66d2ed)

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
