### PR TITLE
[REG-2061] When creating a bot sequence from the Latest Recording sort the segments numerically. 

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -295,7 +295,7 @@ namespace RegressionGames.StateRecorder
                 .Select(a=>a.Substring(a.LastIndexOf('/')+1));
 
             // Order numerically instead of alphanumerically to ensure 2.json is before 10.json.
-            segmentFiles = BotSegmentDirectoryParser.OrderJsonFiles(segmentFiles);
+            segmentFiles = BotSegmentDirectoryParser.OrderJsonFiles(segmentFiles).ToList();
             
             string segmentResourceDirectory = null;
             string sequenceJsonPath = null;
@@ -339,6 +339,7 @@ namespace RegressionGames.StateRecorder
             {
                 path = segmentResourceDirectory + "/" + a
             }).ToList();
+
 
             var botSequence = new BotSequence()
             {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -289,13 +289,13 @@ namespace RegressionGames.StateRecorder
         private async Task MoveSegmentsToProject(string botSegmentsDirectoryPrefix)
         {
             // get all the file paths normalized to /
-            var segmentFiles = Directory.EnumerateFiles(botSegmentsDirectoryPrefix)
+            var segmentFiles = Directory.GetFiles(botSegmentsDirectoryPrefix)
                 .Where(a=>a.EndsWith(".json"))
                 .Select(a=>a.Replace('\\','/'))
                 .Select(a=>a.Substring(a.LastIndexOf('/')+1));
 
             // Order numerically instead of alphanumerically to ensure 2.json is before 10.json.
-            segmentFiles = BotSegmentDirectoryParser.OrderJsonFiles(segmentFiles).ToList();
+            segmentFiles = BotSegmentDirectoryParser.OrderJsonFiles(segmentFiles);
             
             string segmentResourceDirectory = null;
             string sequenceJsonPath = null;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -278,7 +278,12 @@ namespace RegressionGames.StateRecorder
         private async Task MoveSegmentsToProject(string botSegmentsDirectoryPrefix)
         {
             // get all the file paths normalized to /
-            var segmentFiles = Directory.EnumerateFiles(botSegmentsDirectoryPrefix).Where(a=>a.EndsWith(".json")).Select(a=>a.Replace('\\','/')).Select(a=>a.Substring(a.LastIndexOf('/')+1));
+            var segmentFiles = Directory.EnumerateFiles(botSegmentsDirectoryPrefix)
+                .Where(a=>a.EndsWith(".json"))
+                .Select(a=>a.Replace('\\','/'))
+                .Select(a=>a.Substring(a.LastIndexOf('/')+1))
+                .OrderBy(a => int.Parse(Path.GetFileNameWithoutExtension(a))); // Order numerically instead of alphanumerically
+                                                                               // to ensure 2.json is before 10.json.
 
             string segmentResourceDirectory = null;
             string sequenceJsonPath = null;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -13,6 +13,7 @@ using Newtonsoft.Json;
 using RegressionGames.CodeCoverage;
 using RegressionGames.StateRecorder.BotSegments.Models;
 using RegressionGames.StateRecorder.Models;
+using StateRecorder.BotSegments;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -281,10 +282,11 @@ namespace RegressionGames.StateRecorder
             var segmentFiles = Directory.EnumerateFiles(botSegmentsDirectoryPrefix)
                 .Where(a=>a.EndsWith(".json"))
                 .Select(a=>a.Replace('\\','/'))
-                .Select(a=>a.Substring(a.LastIndexOf('/')+1))
-                .OrderBy(a => int.Parse(Path.GetFileNameWithoutExtension(a))); // Order numerically instead of alphanumerically
-                                                                               // to ensure 2.json is before 10.json.
+                .Select(a=>a.Substring(a.LastIndexOf('/')+1));
 
+            // Order numerically instead of alphanumerically to ensure 2.json is before 10.json.
+            segmentFiles = BotSegmentDirectoryParser.OrderJsonFiles(segmentFiles);
+            
             string segmentResourceDirectory = null;
             string sequenceJsonPath = null;
 #if UNITY_EDITOR

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -288,7 +288,9 @@ namespace RegressionGames.StateRecorder
 
         private async Task MoveSegmentsToProject(string botSegmentsDirectoryPrefix)
         {
-            // get all the file paths normalized to /
+            // Get all the file paths normalized to /
+            // Note: Ensure that these files aren't loaded lazily (don't use Directory.EnumerateFiles)
+            // as the folder gets moved later down this function and lazy loading will not find the files.
             var segmentFiles = Directory.GetFiles(botSegmentsDirectoryPrefix)
                 .Where(a=>a.EndsWith(".json"))
                 .Select(a=>a.Replace('\\','/'))


### PR DESCRIPTION
[Loom Video](https://www.loom.com/share/1fe8e487f74e4a78abf47a8cc374563f?sid=dd98d33b-a5b0-4f45-b952-76110476a312)

Currently when we are creating a BotSequence from the copied bot segments the segments are sorted alphanumerically. This means that 2.json will come after 19.json, breaking the sequence.

This PR hotfixes it by ordering it numerically. 

We should do the same sorting order wherever we are showing segments.
