### PR TITLE
[REG-2060] Fix recording copy of underlying segments

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceEditor.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceEditor.cs
@@ -48,7 +48,7 @@ namespace RegressionGames
         private string _existingSequencePath;
 
         private string _originalName = "";
-        private bool _isOriginalRecordingPath;
+        private bool _isOriginalTheRecordingPath;
 
         private bool _makingACopy;
 
@@ -187,8 +187,8 @@ namespace RegressionGames
             {
                 NameInput.text = sequenceToEdit.name;
                 _originalName = sequenceToEdit.name.Trim();
-                _isOriginalRecordingPath = IsRecordingSequencePath(sequencePath);
-                if (!_isOriginalRecordingPath)
+                _isOriginalTheRecordingPath = IsRecordingSequencePath(sequencePath);
+                if (!_isOriginalTheRecordingPath)
                 {
                     // copy the description
                     DescriptionInput.text = sequenceToEdit.description;
@@ -278,7 +278,7 @@ namespace RegressionGames
             CurrentSequence.description = DescriptionInput.text;
 
             // special case for recordings... where we need to copy the underlying segments as well, not just the sequence file
-            if (_makingACopy && _isOriginalRecordingPath)
+            if (_makingACopy && _isOriginalTheRecordingPath)
             {
                 CurrentSequence.CopySequenceSegmentsToNewPath();
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceEditor.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceEditor.cs
@@ -48,6 +48,7 @@ namespace RegressionGames
         private string _existingSequencePath;
 
         private string _originalName = "";
+        private bool _isOriginalRecordingPath;
 
         private bool _makingACopy;
 
@@ -186,7 +187,8 @@ namespace RegressionGames
             {
                 NameInput.text = sequenceToEdit.name;
                 _originalName = sequenceToEdit.name.Trim();
-                if (!IsRecordingSequencePath(sequencePath))
+                _isOriginalRecordingPath = IsRecordingSequencePath(sequencePath);
+                if (!_isOriginalRecordingPath)
                 {
                     // copy the description
                     DescriptionInput.text = sequenceToEdit.description;
@@ -276,7 +278,7 @@ namespace RegressionGames
             CurrentSequence.description = DescriptionInput.text;
 
             // special case for recordings... where we need to copy the underlying segments as well, not just the sequence file
-            if (_makingACopy && string.CompareOrdinal(_originalName, ScreenRecorder.RecordingPathName) == 0)
+            if (_makingACopy && _isOriginalRecordingPath)
             {
                 CurrentSequence.CopySequenceSegmentsToNewPath();
             }


### PR DESCRIPTION
- Fix recording copy of underlying segments

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
