### PR TITLE
[REG-2059] Refresh assets after copy of recording if in unityeditor

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -13,7 +13,9 @@ using Newtonsoft.Json;
 using RegressionGames.CodeCoverage;
 using RegressionGames.StateRecorder.BotSegments.Models;
 using RegressionGames.StateRecorder.Models;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.Experimental.Rendering;
@@ -96,6 +98,10 @@ namespace RegressionGames.StateRecorder
         private MouseInputActionObserver _mouseObserver;
         private ProfilerObserver _profilerObserver;
         private LoggingObserver _loggingObserver;
+
+#if UNITY_EDITOR
+        private bool _needToRefreshAssets;
+#endif
 
         public static ScreenRecorder GetInstance()
         {
@@ -243,6 +249,10 @@ namespace RegressionGames.StateRecorder
             // Copy the most recent recording into the user's project if running in the editor , or their persistent data path if running in production runtime
             await MoveSegmentsToProject(botSegmentsDirectoryPrefix);
 
+#if UNITY_EDITOR
+            _needToRefreshAssets = true;
+#endif
+
             if (Directory.Exists(dataDirectoryPrefix))
             {
                 Directory.Delete(dataDirectoryPrefix, true);
@@ -297,7 +307,7 @@ namespace RegressionGames.StateRecorder
                 {
                     Directory.Delete(segmentResourceDirectory, true);
                 }
-                
+
                 // Path.GetDirectoryName returns the parent directory (e.g. "Assets/RegressionGames/Resources/BotSegments")
                 // This is because our current path does not end with a trailing /
                 // So we can safely create this without interfering with the .Move command right below.
@@ -421,6 +431,17 @@ namespace RegressionGames.StateRecorder
                     // only do this when the game object is still alive :D
                     StartCoroutine(ShowUploadingIndicator(false));
                 }
+            }
+        }
+
+        private void Update()
+        {
+#if UNITY_EDITOR
+            if (_needToRefreshAssets)
+            {
+                _needToRefreshAssets = false;
+                AssetDatabase.Refresh();
+#endif
             }
         }
 


### PR DESCRIPTION
- Handle refreshing assets after copying segments into project when running in the editor

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
