### PR TITLE
[REG-2068] Handle ambiguous available segments in SequenceEditor UI by showing path

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Fonts/Regression.asset
+++ b/src/gg.regression.unity.bots/Runtime/Fonts/Regression.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6b1db76e101060aa98c6c6d0eaa0b0190f830a94c558a914a25cd9cb03e7e2d9
-size 1081928
+oid sha256:fac3f5b1478c0e1f4a6cad4a1670e1cdb0d4e029e150ad382b063de6314582f5
+size 2185363

--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/SegmentCard.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/SegmentCard.prefab
@@ -35,8 +35,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 121, y: -53}
-  m_SizeDelta: {x: 230, y: 50}
+  m_AnchoredPosition: {x: 123.5, y: -58}
+  m_SizeDelta: {x: 235, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5150408973223486109
 CanvasRenderer:
@@ -68,7 +68,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: Description for this segment card. It can add more context to the usage
     of this card. It will be visible up to 3 lines of text. After that we will use
-    an ellipsis
+    an ellipsis to show the overflow
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
   m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
@@ -103,7 +103,7 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
+  m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0
@@ -131,7 +131,7 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: 0.3931656, y: 10.89, z: -3.9032898, w: 4.288208}
+  m_margin: {x: 2, y: 0, z: 0, w: 3}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0
@@ -167,7 +167,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 5343200718293458929}
+  m_Father: {fileID: 5284319017647726404}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -223,7 +223,6 @@ GameObject:
   m_Component:
   - component: {fileID: 5343200718293458929}
   - component: {fileID: 7169126889340263300}
-  - component: {fileID: 2630609904753711820}
   m_Layer: 0
   m_Name: Header Panel
   m_TagString: Untagged
@@ -243,15 +242,15 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 675365589378818316}
-  - {fileID: 1883248460156222526}
+  - {fileID: 5284319017647726404}
+  - {fileID: 9026204256683291253}
   m_Father: {fileID: 8731460653990799894}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 235, y: 20}
+  m_SizeDelta: {x: 235, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7169126889340263300
 CanvasRenderer:
@@ -261,32 +260,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3081616303996226771}
   m_CullTransparentMesh: 1
---- !u!114 &2630609904753711820
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3081616303996226771}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Padding:
-    m_Left: 0
-    m_Right: 0
-    m_Top: 0
-    m_Bottom: 0
-  m_ChildAlignment: 4
-  m_Spacing: 2
-  m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 1
-  m_ChildControlWidth: 0
-  m_ChildControlHeight: 0
-  m_ChildScaleWidth: 0
-  m_ChildScaleHeight: 0
-  m_ReverseArrangement: 0
 --- !u!1 &4056252669799423772
 GameObject:
   m_ObjectHideFlags: 0
@@ -459,7 +432,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 250, y: 30}
+  m_SizeDelta: {x: 250, y: 40}
   m_Pivot: {x: 0, y: 0}
 --- !u!222 &616262484203133319
 CanvasRenderer:
@@ -513,13 +486,223 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   IsReordering: 0
   draggableCardName: Placeholder draggable segment name
+  draggableCardResourcePath: 
   draggableCardDescription: 
   icon: {fileID: 21300000, guid: ac32a463b941b41fab54ea9dd8a1745f, type: 3}
   iconPrefab: {fileID: 2566918779166699024}
   namePrefab: {fileID: 714608286913792316}
+  resourcePathPrefab: {fileID: 6873454172087124566}
   descriptionPrefab: {fileID: 3206347888572036134}
   restingStatePrefab: {fileID: 4199513441948227604}
   draggingStatePrefab: {fileID: 5443515706651796386, guid: a4a3e76dff5a04b31948a43874f94e1c, type: 3}
+--- !u!1 &4300616467306281122
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9026204256683291253}
+  - component: {fileID: 5939748112762973417}
+  - component: {fileID: 5602994148948136486}
+  m_Layer: 0
+  m_Name: SubHeader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9026204256683291253
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4300616467306281122}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2325180774862949103}
+  m_Father: {fileID: 5343200718293458929}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -9}
+  m_SizeDelta: {x: 235, y: 12}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!114 &5939748112762973417
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4300616467306281122}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 2
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!222 &5602994148948136486
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4300616467306281122}
+  m_CullTransparentMesh: 1
+--- !u!1 &5036699724756965507
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2325180774862949103}
+  - component: {fileID: 492084860714670731}
+  - component: {fileID: 6873454172087124566}
+  m_Layer: 0
+  m_Name: ResourcePath
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2325180774862949103
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5036699724756965507}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9026204256683291253}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 235, y: 13}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &492084860714670731
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5036699724756965507}
+  m_CullTransparentMesh: 1
+--- !u!114 &6873454172087124566
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5036699724756965507}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Resource path of the card to disambiguate names
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967210
+  m_fontColor: {r: 0.6666667, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 11
+  m_fontSizeBase: 11
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 2
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 1
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 1
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 20, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &6974525428543936087
 GameObject:
   m_ObjectHideFlags: 0
@@ -655,13 +838,13 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 5343200718293458929}
+  m_Father: {fileID: 5284319017647726404}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 220, y: 20}
+  m_SizeDelta: {x: 220, y: 14}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6824467722930520476
 CanvasRenderer:
@@ -734,7 +917,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_enableWordWrapping: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 1
   m_linkedTextComponent: {fileID: 0}
@@ -760,3 +943,77 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &8490480848055148955
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5284319017647726404}
+  - component: {fileID: 4608976571766641822}
+  - component: {fileID: 74594202798094609}
+  m_Layer: 0
+  m_Name: Header
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5284319017647726404
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8490480848055148955}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 675365589378818316}
+  - {fileID: 1883248460156222526}
+  m_Father: {fileID: 5343200718293458929}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 5}
+  m_SizeDelta: {x: 235, y: 30}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &4608976571766641822
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8490480848055148955}
+  m_CullTransparentMesh: 1
+--- !u!114 &74594202798094609
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8490480848055148955}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0

--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/SegmentCard.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/SegmentCard.prefab
@@ -643,8 +643,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4294967210
-  m_fontColor: {r: 0.6666667, g: 1, b: 1, a: 1}
+    rgba: 4291480266
+  m_fontColor: {r: 0.7924528, g: 0.7924528, b: 0.7924528, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:

--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/SegmentCard.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/SegmentCard.prefab
@@ -667,7 +667,7 @@ MonoBehaviour:
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
-  m_fontStyle: 2
+  m_fontStyle: 0
   m_HorizontalAlignment: 1
   m_VerticalAlignment: 256
   m_textAlignment: 65535

--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/Sequence Editor.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/Sequence Editor.prefab
@@ -254,7 +254,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 422.5, y: 0}
+  m_AnchoredPosition: {x: 16, y: 0}
   m_SizeDelta: {x: 0, y: 480}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7883105480856744201

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGDraggableCard.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGDraggableCard.cs
@@ -20,6 +20,8 @@ namespace RegressionGames
 
         public string draggableCardName;
 
+        public string draggableCardResourcePath;
+
         public string draggableCardDescription;
 
         public Sprite icon;
@@ -27,6 +29,8 @@ namespace RegressionGames
         public GameObject iconPrefab;
 
         public TMP_Text namePrefab;
+
+        public TMP_Text resourcePathPrefab;
 
         public TMP_Text descriptionPrefab;
 
@@ -47,7 +51,8 @@ namespace RegressionGames
         private const float MUTED_ALPHA = 0.2f;
 
         private const int EXPANDED_HEIGHT = 80;
-        private const int SHRUNKEN_HEIGHT = 30;
+
+        private float originalHeight = 40;
 
         public void Start()
         {
@@ -55,9 +60,29 @@ namespace RegressionGames
 
             _isHighlighted = false;
 
-            if (namePrefab != null)
+            // if we have a name set
+            if (!string.IsNullOrEmpty(draggableCardName))
             {
-                namePrefab.text = draggableCardName;
+                if (namePrefab != null)
+                {
+                    namePrefab.text = draggableCardName;
+                }
+
+                if (resourcePathPrefab != null)
+                {
+                    resourcePathPrefab.text = draggableCardResourcePath;
+                    resourcePathPrefab.gameObject.SetActive(true);
+                }
+            }
+            else
+            {
+                // use the resource path as the name and hide the hint path
+                namePrefab.text = draggableCardResourcePath;
+                if (resourcePathPrefab != null)
+                {
+                    resourcePathPrefab.text = "";
+                    resourcePathPrefab.gameObject.SetActive(false);
+                }
             }
 
             if (descriptionPrefab != null)
@@ -69,6 +94,10 @@ namespace RegressionGames
             {
                 iconPrefab.GetComponent<Image>().overrideSprite = icon;
             }
+
+            var rect = GetComponent<RectTransform>();
+            var size = rect.sizeDelta;
+            originalHeight = size.y;
         }
 
         /**
@@ -245,18 +274,21 @@ namespace RegressionGames
          */
         private void ToggleExpand(bool forceShrink = false)
         {
-            if (string.IsNullOrEmpty(descriptionPrefab.text) && !namePrefab.isTextOverflowing)
+            if (string.IsNullOrEmpty(descriptionPrefab.text) && !namePrefab.isTextOverflowing && !resourcePathPrefab.isTextOverflowing)
             {
                 // don't expand cards without a description or overtly long name
                 return;
             }
 
             var isActive = descriptionPrefab.gameObject.activeSelf || forceShrink;
-            var newHeight = isActive ? SHRUNKEN_HEIGHT : EXPANDED_HEIGHT;
+            var newHeight = isActive ? originalHeight : EXPANDED_HEIGHT;
 
             // show full card name when expanded
             var newOverflow = isActive ? TextOverflowModes.Ellipsis : TextOverflowModes.Overflow;
             namePrefab.overflowMode = newOverflow;
+
+            // show full path with expanded
+            resourcePathPrefab.overflowMode = newOverflow;
 
             descriptionPrefab.gameObject.SetActive(!isActive);
 
@@ -290,6 +322,7 @@ namespace RegressionGames
                 if (child != null && i != selfIndex)
                 {
                     child.namePrefab.CrossFadeAlpha(newAlpha, 0.1f, false);
+                    child.resourcePathPrefab.CrossFadeAlpha(newAlpha, 0.1f, false);
                     child.descriptionPrefab.CrossFadeAlpha(newAlpha, 0.1f, false);
                     child.iconPrefab.GetComponent<Image>().color = new Color(1.0f, 1.0f, 1.0f, newAlpha);
                 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceEditor.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceEditor.cs
@@ -492,11 +492,11 @@ namespace RegressionGames
                 // load the card's payload
                 segmentCard.payload = new Dictionary<string, string>
                 {
-                    { "path", entry.path },
-                    { "type", entry.type.ToString() }
+                    { "path", entry.resourcePath }
                 };
                 segmentCard.draggableCardName = entry.name;
                 segmentCard.draggableCardDescription = entry.description;
+                segmentCard.draggableCardResourcePath = entry.resourcePath;
                 segmentCard.icon = entry.type == BotSequenceEntryType.Segment ? SegmentIcon : SegmentListIcon;
             }
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
@@ -450,7 +450,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                             {
                                 // only mark this fully matched (as opposed to transient if it is the current segment)
                                 nextBotSegment.Replay_Matched = true;
-                                RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment - Criteria Matched - {nextBotSegment.name} - {nextBotSegment.description}");
+                                RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment - Criteria Matched - {nextBotSegment.name ?? nextBotSegment.resourcePath} - {nextBotSegment.description}");
 
                                 if (nextBotSegment.Replay_ActionStarted && !nextBotSegment.Replay_ActionCompleted)
                                 {
@@ -476,7 +476,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                         if (nextBotSegment.Replay_Matched && nextBotSegment.Replay_ActionStarted && nextBotSegment.Replay_ActionCompleted)
                         {
                             _lastTimeLoggedKeyFrameConditions = now;
-                            RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment - DONE - Criteria Matched && Action Completed - {nextBotSegment.name} - {nextBotSegment.description}");
+                            RGDebug.LogInfo($"({nextBotSegment.Replay_SegmentNumber}) - Bot Segment - DONE - Criteria Matched && Action Completed - {nextBotSegment.name ?? nextBotSegment.resourcePath} - {nextBotSegment.description}");
                             //Process the inputs from that bot segment if necessary
                             _nextBotSegments.RemoveAt(i);
                         }
@@ -522,7 +522,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                             {
                                 _lastTimeLoggedKeyFrameConditions = now;
                                 FindObjectOfType<ReplayToolbarManager>()?.SetKeyFrameWarningText(null);
-                                RGDebug.LogInfo($"({next.Replay_SegmentNumber}) - Bot Segment - Added {(next.HasTransientCriteria ? "" : "Non-")}Transient BotSegment for Evaluation after Transient BotSegment - {next.name} - {next.description}");
+                                RGDebug.LogInfo($"({next.Replay_SegmentNumber}) - Bot Segment - Added {(next.HasTransientCriteria ? "" : "Non-")}Transient BotSegment for Evaluation after Transient BotSegment - {next.name ?? next.resourcePath} - {next.description}");
                                 _nextBotSegments.Add(next);
                             }
                         }
@@ -536,7 +536,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                     {
                         _lastTimeLoggedKeyFrameConditions = now;
                         FindObjectOfType<ReplayToolbarManager>()?.SetKeyFrameWarningText(null);
-                        RGDebug.LogInfo($"({next.Replay_SegmentNumber}) - Bot Segment - Added {(next.HasTransientCriteria ? "" : "Non-")}Transient BotSegment for Evaluation - {next.name} - {next.description}");
+                        RGDebug.LogInfo($"({next.Replay_SegmentNumber}) - Bot Segment - Added {(next.HasTransientCriteria ? "" : "Non-")}Transient BotSegment for Evaluation - {next.name ?? next.resourcePath} - {next.description}");
                         _nextBotSegments.Add(next);
                     }
                 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotSequenceEntryJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotSequenceEntryJsonConverter.cs
@@ -19,6 +19,7 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
             // ReSharper disable once UseObjectOrCollectionInitializer - easier to debug when on separate lines
             BotSequenceEntry sequenceEntry = new();
             sequenceEntry.path = jObject.GetValue("path").ToObject<string>(serializer);
+            sequenceEntry.resourcePath = BotSequence.ToResourcePath(sequenceEntry.path);
             // dynamically find out the type
             var result = BotSequence.LoadBotSegmentOrBotSegmentListFromPath(sequenceEntry.path);
             if (result.Item3 is BotSegmentList bsl)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
@@ -34,6 +34,9 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
          */
         public string name;
 
+        // NOT WRITTEN TO JSON - The resource path for this botSegment... normally populated during load of saved segments
+        public string resourcePath;
+
         /**
          * <summary>Description for this bot segment. Used for naming on the UI.</summary>
          */
@@ -299,7 +302,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                         var sequenceEntry = BotSequence.CreateBotSequenceEntryForJson(null, resourceFilename, sequenceInfo.text ?? "");
 
                         // add the new sequence if its filename doesn't already exist
-                        segments.Add(resourceFilename, sequenceEntry);
+                        segments.Add(sequenceEntry.resourcePath, sequenceEntry);
                     }
                 }
                 catch (Exception e)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegmentList.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegmentList.cs
@@ -21,9 +21,12 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public int EffectiveApiVersion => Math.Max(apiVersion, segments.DefaultIfEmpty().Max(a=>a?.EffectiveApiVersion ?? SdkApiVersion.CURRENT_VERSION));
 
         /**
-         * <summary>Title for this bot segment list. Used for naming on the UI.e</summary>
+         * <summary>Title for this bot segment list. Used for naming on the UI.</summary>
          */
         public string name;
+
+        // NOT WRITTEN TO JSON - The resource path for this botSegmentList... normally populated during load of saved lists
+        public string resourcePath;
 
         /**
          * <summary>Description for this bot segment list. Used for naming on the UI.</summary>
@@ -43,9 +46,8 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             {
                 if (string.IsNullOrEmpty(botSegment.name))
                 {
-                    botSegment.name = name + " - Segment #" + segmentNumber;
+                    botSegment.name = (name ?? resourcePath) + " - Segment #" + segmentNumber;
                 }
-
                 ++segmentNumber;
             }
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSequence.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSequence.cs
@@ -92,9 +92,12 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             {
                 var segment = (BotSegment)result.Item3;
                 sessionId = segment.sessionId;
-                var segmentList = new BotSegmentList(path, new List<BotSegment> { segment });
-                segmentList.name = segment.name;
-                segmentList.description = segment.description;
+                var segmentList = new BotSegmentList(path, new List<BotSegment> { segment })
+                {
+                    name = segment.name,
+                    resourcePath = segment.resourcePath,
+                    description = segment.description
+                };
                 segmentList.FixupNames();
                 return segmentList;
             }
@@ -115,10 +118,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                     throw new Exception($"BotSegmentList file contains a segment which requires SDK version {segmentList.EffectiveApiVersion}, but the currently installed SDK version is {SdkApiVersion.CURRENT_VERSION}");
                 }
 
-                if (string.IsNullOrEmpty(segmentList.name))
-                {
-                    segmentList.name = resourcePath;
-                }
+                segmentList.resourcePath = resourcePath;
 
                 segmentList.FixupNames();
                 return segmentList;
@@ -133,11 +133,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                     throw new Exception($"BotSegment file requires SDK version {segment.EffectiveApiVersion}, but the currently installed SDK version is {SdkApiVersion.CURRENT_VERSION}");
                 }
 
-                if (string.IsNullOrEmpty(segment.name))
-                {
-                    segment.name = resourcePath;
-                }
-
+                segment.resourcePath = resourcePath;
                 return segment;
             }
         }
@@ -357,14 +353,8 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         }
 
-        /**
-         * <summary>Load the json resource at the specified path.  If .json is not on this path it will be auto appended.</summary>
-         * <returns>A (FilePath [null - if loaded as resource], resourcePath, contentString) tuple</returns>
-         */
-        public static (string, string, string) LoadJsonResource(string path)
+        public static string ToResourcePath(string path)
         {
-            (string, string, string)? result = null;
-
             var resourcePath = path;
             if (resourcePath.Contains("Resources/"))
             {
@@ -376,6 +366,19 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             {
                 resourcePath = resourcePath.Substring(0, lastIndex);
             }
+
+            return resourcePath;
+        }
+
+        /**
+         * <summary>Load the json resource at the specified path.  If .json is not on this path it will be auto appended.</summary>
+         * <returns>A (FilePath [null - if loaded as resource], resourcePath, contentString) tuple</returns>
+         */
+        public static (string, string, string) LoadJsonResource(string path)
+        {
+            (string, string, string)? result = null;
+
+            var resourcePath = ToResourcePath(path);
 
             // document ..
 #if UNITY_EDITOR
@@ -474,6 +477,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                     {
                         type = BotSequenceEntryType.SegmentList,
                         path = filePath ?? resourcePath,
+                        resourcePath = resourcePath,
                         name = bsl.name,
                         description = bsl.description
                     };
@@ -484,6 +488,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                 {
                     type = BotSequenceEntryType.Segment,
                     path = filePath ?? resourcePath,
+                    resourcePath = resourcePath,
                     name = botSegment.name,
                     description = botSegment.description
                 };
@@ -511,6 +516,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                     {
                         type = BotSequenceEntryType.SegmentList,
                         path = result.Item1 ?? result.Item2,
+                        resourcePath = result.Item2,
                         name = bsl.name,
                         description = bsl.description
                     });
@@ -521,6 +527,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                 {
                     type = BotSequenceEntryType.Segment,
                     path = result.Item1 ?? result.Item2,
+                    resourcePath = result.Item2,
                     name = botSegment.name,
                     description = botSegment.description
                 });

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSequenceEntry.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSequenceEntry.cs
@@ -15,8 +15,11 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
     public class BotSequenceEntry
     {
         public int apiVersion = SdkApiVersion.VERSION_20;
+        // filePath (if not null) OR resourcePath
         public string path;
 
+        // NOT WRITTEN TO JSON - Populated at file load time
+        public string resourcePath;
         // NOT WRITTEN TO JSON - Computed dynamically when loaded from disk or created
         public BotSequenceEntryType type;
         // NOT WRITTEN TO JSON - Populated from the BotSegment/BotSegmentList at file load time

--- a/src/gg.regression.unity.bots/Tests/Scripts/RGOverlay/RGDraggableCard.test.cs
+++ b/src/gg.regression.unity.bots/Tests/Scripts/RGOverlay/RGDraggableCard.test.cs
@@ -34,6 +34,7 @@ namespace RegressionGames.Tests.RGOverlay
             var text = RGTestUtils.CreateTMProPlaceholder();
             card.namePrefab = text;
             card.descriptionPrefab = text;
+            card.resourcePathPrefab = text;
 
             // ensure public prefabs are mocked
             card.restingStatePrefab = new GameObject


### PR DESCRIPTION
- Handles dis-ambiguating segments that have the same 'name' but different paths on the editor UI
  - If the segment has a name, then the name and path will be shown
  - If the segment DOES NOT have a name, then the path will be shown in place of the name, but the path sub text will be hidden
- Makes needed updates to the prefab to make decription/overlow expansion respect this new layout
- Stops setting the 'resourcePath' as the name on segments/segmentLists loaded from sequences and tracks the resourcePath separately.  This allows us to know if a user supplied name was truly set or not.

Long descriptions example with ...
![image](https://github.com/user-attachments/assets/2685a865-3af0-4f66-9ec8-bbdd615c8024)


Empty name example
![image](https://github.com/user-attachments/assets/8fa88101-82dc-4fe0-b186-c924a45c6d2a)

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
