### PR TITLE
[REG-2063] Enable running unity with -rgsequencepath startup option

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
@@ -21,7 +21,7 @@ namespace RegressionGames
         internal static readonly int Rc_OverlayNotInScene = 3;
         internal static readonly int Rc_SequenceLoadFailure = 4;
 
-        internal static readonly string CommandLineArgument = "-rgSequencePath";
+        internal static readonly string CommandLineArgument = "-rgsequencepath";
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         public static void Initialize()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections;
+using RegressionGames.StateRecorder.BotSegments;
+using RegressionGames.StateRecorder.BotSegments.Models;
+using RegressionGames.Types;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+// ReSharper disable InconsistentNaming
+namespace RegressionGames
+{
+    public static class RGHeadlessSequenceRunner
+    {
+
+        internal static readonly int Rc_RunSuccess = 0;
+        internal static readonly int Rc_RunFailed = 1;
+        internal static readonly int Rc_SequencePathMissing = 2;
+        internal static readonly int Rc_OverlayNotInScene = 3;
+        internal static readonly int Rc_SequenceLoadFailure = 4;
+
+        internal static readonly string CommandLineArgument = "-rgSequencePath";
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        public static void Initialize()
+        {
+            var resourcePath = ParsePathArgument();
+            if (resourcePath != null)
+            {
+                BotSegmentsPlaybackController playbackController = Object.FindObjectOfType<BotSegmentsPlaybackController>();
+                if (playbackController == null)
+                {
+                    RGDebug.LogError($"RGOverlay must be in the first scene loaded for your game to utilize {CommandLineArgument} command line argument");
+                    Application.Quit(Rc_OverlayNotInScene);
+                }
+
+                playbackController.gameObject.AddComponent<RGHeadlessSequenceRunnerBehaviour>();
+            }
+        }
+
+        internal static string ParsePathArgument()
+        {
+            var args = Environment.GetCommandLineArgs();
+            var argsLength = args.Length;
+            for (var i = 0; i < argsLength; i++)
+            {
+                var arg = args[i];
+                if (arg == CommandLineArgument)
+                {
+                    if (i + 1 < argsLength)
+                    {
+                        return args[i + 1];
+                    }
+                    // else
+                    RGDebug.LogError($"{CommandLineArgument} command line argument requires a path value to be passed after it");
+                    Application.Quit(Rc_SequencePathMissing);
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Plays back a bot sequence, and then returns the save location of the recording.
+        /// </summary>
+        /// <param name="botSequenceInfo">(filePath,resourcePath,BotSequence) tuple of the bot sequence</param>
+        /// <param name="setPlaybackResult">A callback that will be called with the results of this playback</param>
+        /// <param name="timeout">How long in seconds to wait for this sequence to complete, less than or == 0 means wait forever (default=0)</param>
+        internal static IEnumerator StartBotSequence((string,string, BotSequence) botSequenceInfo, Action<PlaybackResult> setPlaybackResult, int timeout = 0)
+        {
+            var startTime = Time.unscaledTime;
+
+            botSequenceInfo.Item3.Play();
+
+            var playbackController = Object.FindObjectOfType<BotSegmentsPlaybackController>();
+
+            yield return null; // Allow the recording to start playing
+            var didTimeout = false;
+            while (playbackController.GetState() == PlayState.Playing || playbackController.GetState() == PlayState.Paused)
+            {
+                if (timeout > 0 && Time.unscaledTime > startTime + timeout )
+                {
+                    didTimeout = true;
+                    break;
+                }
+                yield return null;
+            }
+            yield return null;
+            var result = new PlaybackResult
+            {
+                saveLocation = playbackController.SaveLocation() + ".zip",
+                success = !didTimeout
+            };
+            setPlaybackResult(result);
+        }
+    }
+
+    public class RGHeadlessSequenceRunnerBehaviour : MonoBehaviour
+    {
+        private bool _started;
+
+        private readonly Action<PlaybackResult> _result = (result) =>
+        {
+            if (result.success)
+            {
+                RGDebug.LogInfo("Regression Games bot sequence playback complete - SUCCESS");
+                Application.Quit(RGHeadlessSequenceRunner.Rc_RunSuccess);
+            }
+            else
+            {
+                RGDebug.LogError("Regression Games bot sequence playback complete - FAILED");
+                Application.Quit(RGHeadlessSequenceRunner.Rc_RunFailed);
+            }
+
+        };
+
+        private void Update()
+        {
+            if (_started)
+            {
+                return;
+            }
+
+            _started = true;
+            var sequencePath = RGHeadlessSequenceRunner.ParsePathArgument();
+            RGDebug.LogInfo("Regression Games bot sequence playback - loading and starting bot sequence from path: " + sequencePath);
+
+            try
+            {
+                var botSequenceInfo = BotSequence.LoadSequenceJsonFromPath(sequencePath);
+                StartCoroutine(RGHeadlessSequenceRunner.StartBotSequence(botSequenceInfo, _result));
+            }
+            catch (Exception ex)
+            {
+                RGDebug.LogException(ex, "Regression Games bot sequence playback - exception loading bot sequence from path: " + sequencePath);
+                Application.Quit(RGHeadlessSequenceRunner.Rc_SequenceLoadFailure);
+            }
+        }
+
+
+
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
@@ -34,7 +34,29 @@ namespace RegressionGames
                 }
 
                 playbackController.gameObject.AddComponent<RGHeadlessSequenceRunnerBehaviour>();
+
+                //ensure a keyboard exists for the input playback
+                if (IsBatchMode())
+                {
+
+                }
             }
+        }
+
+        internal static bool IsBatchMode()
+        {
+            var args = Environment.GetCommandLineArgs();
+            var argsLength = args.Length;
+            for (var i = 0; i < argsLength; i++)
+            {
+                var arg = args[i];
+                if (arg == "-batchmode")
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         internal static string ParsePathArgument()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f129e3c6e1b6408e964fdbb3f93a6c70
+timeCreated: 1727892379

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSequence.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSequence.cs
@@ -422,7 +422,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             }
             catch (Exception e)
             {
-                throw new Exception($"Exception reading json files from resource path: {runtimePath}", e);
+                throw new Exception($"Exception reading json files from resource path: {resourcePath}", e);
             }
 #endif
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardEventSender.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardEventSender.cs
@@ -46,7 +46,7 @@ namespace RegressionGames.StateRecorder
         /// Queues a StateEvent onto the InputSystem event queue containing the desired state changes
         /// in the _keyStates field.
         /// </summary>
-        private static void QueueKeyboardUpdateEvent()
+        private static void QueueKeyboardUpdateEvent(int replaySegment)
         {
             var keyboard = Keyboard.current;
             if (keyboard != null)
@@ -65,7 +65,7 @@ namespace RegressionGames.StateRecorder
                             inputControl.WriteValueIntoEvent(entry.Value == KeyState.Down ? 1f : 0f, eventPtr);
                         }
                     }
-
+                    RGDebug.LogDebug($"({replaySegment}) [frame: {Time.frameCount}] - Queueing Keyboard Event to InputSystem");
                     InputSystem.QueueEvent(eventPtr);
                 }
             }
@@ -165,7 +165,7 @@ namespace RegressionGames.StateRecorder
                 }
             }
 
-            QueueKeyboardUpdateEvent();
+            QueueKeyboardUpdateEvent(replaySegment);
 
             foreach (var entry in keyStates)
             {
@@ -198,7 +198,7 @@ namespace RegressionGames.StateRecorder
 
             _keyStates[key] = upOrDown;
 
-            QueueKeyboardUpdateEvent();
+            QueueKeyboardUpdateEvent(replaySegment);
 
             if (upOrDown == KeyState.Down)
             {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardEventSender.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardEventSender.cs
@@ -18,7 +18,7 @@ namespace RegressionGames.StateRecorder
 
         // Stores the changed state of keys. When the Input System completes an update, this is cleared.
         // If multiple key state changes occur within the same frame, all of these are added to the keyboard event that is sent to the Input System.
-        private static Dictionary<Key, KeyState> _keyStates = new Dictionary<Key, KeyState>();
+        private static Dictionary<Key, KeyState> _keyStates = new ();
 
         private static bool _isInitialized = false;
 
@@ -49,22 +49,25 @@ namespace RegressionGames.StateRecorder
         private static void QueueKeyboardUpdateEvent()
         {
             var keyboard = Keyboard.current;
-            using (StateEvent.From(keyboard, out var eventPtr))
+            if (keyboard != null)
             {
-                var time = InputState.currentTime;
-                eventPtr.time = time;
-
-                // Include all key states that have been changed since the last InputSystem update cycle
-                foreach (var entry in _keyStates)
+                using (StateEvent.From(keyboard, out var eventPtr))
                 {
-                    var inputControl = keyboard.allControls.FirstOrDefault(a => a is KeyControl kc && kc.keyCode == entry.Key);
-                    if (inputControl != null)
-                    {
-                        inputControl.WriteValueIntoEvent(entry.Value == KeyState.Down ? 1f : 0f, eventPtr);
-                    }
-                }
+                    var time = InputState.currentTime;
+                    eventPtr.time = time;
 
-                InputSystem.QueueEvent(eventPtr);
+                    // Include all key states that have been changed since the last InputSystem update cycle
+                    foreach (var entry in _keyStates)
+                    {
+                        var inputControl = keyboard.allControls.FirstOrDefault(a => a is KeyControl kc && kc.keyCode == entry.Key);
+                        if (inputControl != null)
+                        {
+                            inputControl.WriteValueIntoEvent(entry.Value == KeyState.Down ? 1f : 0f, eventPtr);
+                        }
+                    }
+
+                    InputSystem.QueueEvent(eventPtr);
+                }
             }
         }
 
@@ -73,52 +76,63 @@ namespace RegressionGames.StateRecorder
         /// </summary>
         private static bool IsKeyPressedOrPending(Key key)
         {
-            return Keyboard.current[key].isPressed
+            var keyboard = Keyboard.current;
+            if (keyboard == null)
+            {
+                return false;
+            }
+
+            return keyboard[key].isPressed
                    || (_keyStates.TryGetValue(key, out KeyState state) && state == KeyState.Down);
         }
 
         private static void QueueTextEvent(int replaySegment, Key key)
         {
-            // send a text event so that 'onChange' text events fire
-            // convert key to text
-            if (KeyboardInputActionObserver.KeyboardKeyToValueMap.TryGetValue(key, out var possibleValues))
+            var currentKeyboard = Keyboard.current;
+            if (currentKeyboard != null)
             {
-                var value = _isShiftDown ? possibleValues.Item2 : possibleValues.Item1;
-                if (value == 0x00)
+                // send a text event so that 'onChange' text events fire
+                // convert key to text
+                if (KeyboardInputActionObserver.KeyboardKeyToValueMap.TryGetValue(key, out var possibleValues))
                 {
-                    RGDebug.LogError($"Found null value for keyboard input {key}");
-                    return;
-                }
-
-                var inputEvent = TextEvent.Create(Keyboard.current.deviceId, value, InputState.currentTime);
-                RGDebug.LogInfo($"({replaySegment}) Sending Text Event for char: '{value}'");
-                InputSystem.QueueEvent(ref inputEvent);
-            }
-
-            // If there are active UI input fields, simulate a KeyDown UI event for newly pressed keys
-            // This simulation is done directly on the components, because there is no way to directly queue the event to Unity's event manager
-            var inputFields = UnityEngine.Object.FindObjectsOfType<InputField>();
-            var tmpInputFields = UnityEngine.Object.FindObjectsOfType<TMP_InputField>();
-            if (inputFields.Length > 0 || tmpInputFields.Length > 0)
-            {
-                var keyCode = RGLegacyInputUtils.InputSystemKeyToKeyCode(key);
-                Event evt = CreateUIKeyboardEvent(keyCode,
-                    isShiftDown: _isShiftDown,
-                    isCommandDown: IsKeyPressedOrPending(Key.LeftCommand) || IsKeyPressedOrPending(Key.RightCommand),
-                    isAltDown: IsKeyPressedOrPending(Key.LeftAlt) || IsKeyPressedOrPending(Key.RightAlt),
-                    isControlDown: IsKeyPressedOrPending(Key.LeftCtrl) || IsKeyPressedOrPending(Key.RightCtrl));
-                foreach (var inputField in inputFields)
-                {
-                    if (inputField.isFocused)
+                    var value = _isShiftDown ? possibleValues.Item2 : possibleValues.Item1;
+                    if (value == 0x00)
                     {
-                        SendKeyEventToInputField(evt, inputField);
+                        RGDebug.LogError($"Found null value for keyboard input {key}");
+                        return;
                     }
+
+                    var inputEvent = TextEvent.Create(currentKeyboard.deviceId, value, InputState.currentTime);
+                    RGDebug.LogInfo($"({replaySegment}) Sending Text Event for char: '{value}'");
+                    InputSystem.QueueEvent(ref inputEvent);
                 }
-                foreach (var tmpInputField in tmpInputFields)
+
+                // If there are active UI input fields, simulate a KeyDown UI event for newly pressed keys
+                // This simulation is done directly on the components, because there is no way to directly queue the event to Unity's event manager
+                var inputFields = UnityEngine.Object.FindObjectsOfType<InputField>();
+                var tmpInputFields = UnityEngine.Object.FindObjectsOfType<TMP_InputField>();
+                if (inputFields.Length > 0 || tmpInputFields.Length > 0)
                 {
-                    if (tmpInputField.isFocused)
+                    var keyCode = RGLegacyInputUtils.InputSystemKeyToKeyCode(key);
+                    Event evt = CreateUIKeyboardEvent(keyCode,
+                        isShiftDown: _isShiftDown,
+                        isCommandDown: IsKeyPressedOrPending(Key.LeftCommand) || IsKeyPressedOrPending(Key.RightCommand),
+                        isAltDown: IsKeyPressedOrPending(Key.LeftAlt) || IsKeyPressedOrPending(Key.RightAlt),
+                        isControlDown: IsKeyPressedOrPending(Key.LeftCtrl) || IsKeyPressedOrPending(Key.RightCtrl));
+                    foreach (var inputField in inputFields)
                     {
-                        SendKeyEventToInputField(evt, tmpInputField);
+                        if (inputField.isFocused)
+                        {
+                            SendKeyEventToInputField(evt, inputField);
+                        }
+                    }
+
+                    foreach (var tmpInputField in tmpInputFields)
+                    {
+                        if (tmpInputField.isFocused)
+                        {
+                            SendKeyEventToInputField(evt, tmpInputField);
+                        }
                     }
                 }
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
@@ -51,50 +51,52 @@ namespace RegressionGames.StateRecorder
 
         private void UpdateKeyStatesForFrame()
         {
-            if (Keyboard.current[Key.LeftCtrl].wasPressedThisFrame || Input.GetKeyDown(KeyCode.LeftControl))
+            if (Keyboard.current != null)
             {
-                IsLeftCtrlPressed = true;
-            }
+                if (Keyboard.current[Key.LeftCtrl].wasPressedThisFrame || Input.GetKeyDown(KeyCode.LeftControl))
+                {
+                    IsLeftCtrlPressed = true;
+                }
 
-            if (Keyboard.current[Key.LeftCtrl].wasReleasedThisFrame || Input.GetKeyUp(KeyCode.LeftControl))
-            {
-                IsLeftCtrlPressed = false;
-            }
+                if (Keyboard.current[Key.LeftCtrl].wasReleasedThisFrame || Input.GetKeyUp(KeyCode.LeftControl))
+                {
+                    IsLeftCtrlPressed = false;
+                }
 
-            if (Keyboard.current[Key.RightCtrl].wasPressedThisFrame || Input.GetKeyDown(KeyCode.RightControl))
-            {
-                IsRightCtrlPressed = true;
-            }
+                if (Keyboard.current[Key.RightCtrl].wasPressedThisFrame || Input.GetKeyDown(KeyCode.RightControl))
+                {
+                    IsRightCtrlPressed = true;
+                }
 
-            if (Keyboard.current[Key.RightCtrl].wasReleasedThisFrame || Input.GetKeyUp(KeyCode.RightControl))
-            {
-                IsRightCtrlPressed = false;
-            }
+                if (Keyboard.current[Key.RightCtrl].wasReleasedThisFrame || Input.GetKeyUp(KeyCode.RightControl))
+                {
+                    IsRightCtrlPressed = false;
+                }
 
-            if (Keyboard.current[Key.LeftShift].wasPressedThisFrame || Input.GetKeyDown(KeyCode.LeftShift))
-            {
-                IsLeftShiftPressed = true;
-            }
+                if (Keyboard.current[Key.LeftShift].wasPressedThisFrame || Input.GetKeyDown(KeyCode.LeftShift))
+                {
+                    IsLeftShiftPressed = true;
+                }
 
-            if (Keyboard.current[Key.LeftShift].wasReleasedThisFrame || Input.GetKeyUp(KeyCode.LeftShift))
-            {
-                IsLeftShiftPressed = false;
-            }
+                if (Keyboard.current[Key.LeftShift].wasReleasedThisFrame || Input.GetKeyUp(KeyCode.LeftShift))
+                {
+                    IsLeftShiftPressed = false;
+                }
 
-            if (Keyboard.current[Key.RightShift].wasPressedThisFrame || Input.GetKeyDown(KeyCode.RightShift))
-            {
-                IsRightShiftPressed = true;
-            }
+                if (Keyboard.current[Key.RightShift].wasPressedThisFrame || Input.GetKeyDown(KeyCode.RightShift))
+                {
+                    IsRightShiftPressed = true;
+                }
 
-            if (Keyboard.current[Key.RightShift].wasReleasedThisFrame || Input.GetKeyUp(KeyCode.RightShift))
-            {
-                IsRightShiftPressed = false;
+                if (Keyboard.current[Key.RightShift].wasReleasedThisFrame || Input.GetKeyUp(KeyCode.RightShift))
+                {
+                    IsRightShiftPressed = false;
+                }
             }
-
         }
 
-        private bool WasF9PressedThisFrame => Keyboard.current[Key.F9].wasPressedThisFrame || Input.GetKeyDown(KeyCode.F9);
-        private bool WasF10PressedThisFrame => Keyboard.current[Key.F10].wasPressedThisFrame || Input.GetKeyDown(KeyCode.F10);
+        private bool WasF9PressedThisFrame => (Keyboard.current != null && Keyboard.current[Key.F9].wasPressedThisFrame) || Input.GetKeyDown(KeyCode.F9);
+        private bool WasF10PressedThisFrame => (Keyboard.current != null && Keyboard.current[Key.F10].wasPressedThisFrame) || Input.GetKeyDown(KeyCode.F10);
 
         private void Update()
         {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/Types/PlaybackResult.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/Types/PlaybackResult.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace RegressionGames.Types
 {
-    
+
     [Serializable]
     public class PlaybackResult
     {
@@ -11,7 +11,9 @@ namespace RegressionGames.Types
         /// The location that the playback recording is saved to on disk.
         /// </summary>
         public string saveLocation;
-        
+
+        public bool success;
+
     }
-    
+
 }


### PR DESCRIPTION
- Adds -rgsequencepath command line option
  - This allows you to start Unity , automatically run an RG bot sequence, and then exit the unity runtime
  - Also supports -rgsequencetimeout option to put a number of seconds limit on your runtime before it closes Unity and reports a failure
  - Supports RC=0 for successful run and RC=1 for timeout failure and RC=# for various arg parsing errors
- Fixes some cases for -batchmode where keyboard and mouse devices needed to handle being null, and/or needed a virtual keyboard device registered to function correctly 

Usage samples

- Run the game with the full on screen graphics
  - Supports ALL of our SDK features
  - `./com.unity.multiplayer.samples.coop.exe -rgsequencepath "Assets/RegressionGames/Resources/BotSequences/TypeADF.json" -rgsequencetimeout 7`

- Run the game without rendering
  - Does NOT support anything involving graphics including (screenshots, anything CV related)
  - `./com.unity.multiplayer.samples.coop.exe -batchmode -logFile C:/Users/zack/bossroom_build/headless.log -rgsequencepath "Assets/RegressionGames/Resources/BotSequences/TypeADF.json"`

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
