### PR TITLE
[REG-2064] Manually write files on OSX platforms

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -333,7 +333,7 @@ namespace RegressionGames.StateRecorder
                     {
                         var sourcePath = botSegmentsDirectoryPrefix + "/" + segmentFile;
                         var destinationPath = segmentResourceDirectory + "/" + segmentFile;
-                        await File.WriteAllBytesAsync(destinationPath, await File.ReadAllBytesAsync(sourcePath));
+                        File.Copy(sourcePath, destinationPath);
                     }
                     // Then delete the original directory
                     Directory.Delete(botSegmentsDirectoryPrefix, true);

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -332,7 +332,7 @@ namespace RegressionGames.StateRecorder
                 // If on a Mac, for some weird reason, .Move will fail for project paths that have spaces. We predict
                 // that downstream, something is happening where the space is not properly handled in Unix commands. 
                 // Unfortunately, we could only reproduce this once, but this change should fix it. On Mac, we instead
-                // read and write the files by hand, and avoid any move operations.
+                // use the File.Copy function.
                 if (Application.platform == RuntimePlatform.OSXEditor || Application.platform == RuntimePlatform.OSXPlayer)
                 {
                     Directory.CreateDirectory(segmentResourceDirectory); // Since we aren't moving, we need to create the directory


### PR DESCRIPTION
I'm not very happy with this PR... I cannot determine if it fixes the original issue because while we were able to reproduce the bug on Wednesday afternoon, as of Thursday I was **not** able to reproduce the issue... Also, this works as expected when in the editor, but in the build, the sequence is not created correctly (the segments and sequence are not created). I have a feeling that the build issue is unrelated to this particular PR.

I am opening this as a draft and would like to chat with @batu and @addisonbgross about this perhaps?

UPDATE (Oct 8th, Mon afternoon) - I've now updated this to use the File.Copy function, but once again, I won't be able to determine if this fix works until we try it out with the user.