### PR TITLE
[REG-2089] Fix timeout path validation check

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
@@ -30,9 +30,12 @@ namespace RegressionGames
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSplashScreen)]
         public static void FirstLoadChecks()
         {
-            // do this here to fail fast on bad args
-            ParsePathArgument();
-            ParseTimeoutArgument();
+            // If we are not in headless mode, we don't need these checks.
+            if (Application.isBatchMode){
+                // do this here to fail fast on bad args
+                ParsePathArgument();
+                ParseTimeoutArgument();
+            }
         }
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
@@ -30,12 +30,9 @@ namespace RegressionGames
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSplashScreen)]
         public static void FirstLoadChecks()
         {
-            // If we are not in headless mode, we don't need these checks.
-            if (Application.isBatchMode){
-                // do this here to fail fast on bad args
-                ParsePathArgument();
-                ParseTimeoutArgument();
-            }
+            // do this here to fail fast on bad args
+            ParsePathArgument();
+            ParseTimeoutArgument();
         }
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
@@ -140,12 +137,6 @@ namespace RegressionGames
 
         internal static int ParseTimeoutArgument()
         {
-            var pathArgument = ParsePathArgument();
-            if (pathArgument == null)
-            {
-                RGDebug.LogError($"{SequenceTimeoutArgument} command line argument requires {SequencePathArgument} to also be specified");
-                Application.Quit(Rc_SequenceTimeoutNeedsPath);
-            }
             var args = Environment.GetCommandLineArgs();
             var argsLength = args.Length;
             for (var i = 0; i < argsLength; i++)
@@ -153,6 +144,13 @@ namespace RegressionGames
                 var arg = args[i];
                 if (arg == SequenceTimeoutArgument)
                 {
+                    var pathArgument = ParsePathArgument();
+                    if (pathArgument == null)
+                    {
+                        RGDebug.LogError($"{SequenceTimeoutArgument} command line argument requires {SequencePathArgument} to also be specified");
+                        Application.Quit(Rc_SequenceTimeoutNeedsPath);
+                    }
+
                     if (i + 1 < argsLength)
                     {
                         var nextArg = args[i + 1];


### PR DESCRIPTION
Currently we log a:

```
{{RG}} 2024-10-04T11:57:48:9937 ERROR [1] --- -rgsequencetimeout command line argument requires -rgsequencepath to also be specified
UnityEngine.Debug:LogError (object)
RegressionGames.RGDebug:LogToConsole (string,RegressionGames.RGDebug/RGLogLevel,UnityEngine.Object) (at C:/Users/batu_regression/Desktop/reg/RGUnityBots/src/gg.regression.unity.bots/Runtime/Scripts/RGDebug.cs:146)
RegressionGames.RGDebug:LogError (string,UnityEngine.Object) (at C:/Users/batu_regression/Desktop/reg/RGUnityBots/src/gg.regression.unity.bots/Runtime/Scripts/RGDebug.cs:64)
RegressionGames.RGHeadlessSequenceRunner:ParseTimeoutArgument () (at C:/Users/batu_regression/Desktop/reg/RGUnityBots/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs:143)
RegressionGames.RGHeadlessSequenceRunner:FirstLoadChecks () (at C:/Users/batu_regression/Desktop/reg/RGUnityBots/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs:35)
```

error everytime playmode starts as there are no command line arguments specified.

With this PR we only try to parse args when in headless (batch) mode.