### PR TITLE
feat: add resource path to large segment cards

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/DraggedCard.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/DraggedCard.prefab
@@ -35,7 +35,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 135.7, y: -0}
+  m_AnchoredPosition: {x: 135.7, y: 5.4}
   m_SizeDelta: {x: 220, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7010279462997247453
@@ -75,8 +75,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 2164260863
-  m_fontColor: {r: 1, g: 1, b: 1, a: 0.5019608}
+    rgba: 2483027967
+  m_fontColor: {r: 1, g: 1, b: 1, a: 0.5764706}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -129,7 +129,142 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_margin: {x: 0, y: 0, z: 1.4905548, w: 4.0988812}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &1460021408813356233
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4199082892991687235}
+  - component: {fileID: 3977411229488103171}
+  - component: {fileID: 2925637495028967151}
+  m_Layer: 0
+  m_Name: ResourcePath
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4199082892991687235
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1460021408813356233}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2260437724637879798}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 136.4, y: -6.6}
+  m_SizeDelta: {x: 220, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3977411229488103171
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1460021408813356233}
+  m_CullTransparentMesh: 1
+--- !u!114 &2925637495028967151
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1460021408813356233}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Draggable segment card resource path
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 2164260863
+  m_fontColor: {r: 1, g: 1, b: 1, a: 0.5019608}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 11
+  m_fontSizeBase: 11
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 1
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 1
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 2.9811401, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0
@@ -170,13 +305,14 @@ RectTransform:
   m_Children:
   - {fileID: 9091176184789263363}
   - {fileID: 4443318425089055569}
+  - {fileID: 4199082892991687235}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 5}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 250, y: 30}
+  m_SizeDelta: {x: 250, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1609899089925627103
 CanvasRenderer:
@@ -229,9 +365,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   draggedCardName: Placeholder dragged card name
-  draggedCardDescription: 
+  draggedCardResourcePath: 
   iconPrefab: {fileID: 9081759233827119378}
-  namePrefab: {fileID: 7153013761642342452}
+  nameComponent: {fileID: 7153013761642342452}
+  resourcePathComponent: {fileID: 2925637495028967151}
 --- !u!114 &3635310732519825840
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -292,7 +429,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 14.3, y: 0}
+  m_AnchoredPosition: {x: 14.3, y: 4.7}
   m_SizeDelta: {x: 16, y: 16}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1581957145374094649

--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/PotientialDropSpot.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/PotientialDropSpot.prefab
@@ -36,7 +36,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 250, y: 30}
+  m_SizeDelta: {x: 250, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2237756043604120487
 CanvasRenderer:

--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/SegmentCardLarge.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlay/SegmentCardLarge.prefab
@@ -32,7 +32,7 @@ RectTransform:
   m_Children:
   - {fileID: 9068513970110723880}
   m_Father: {fileID: 4383038157323776768}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -79,6 +79,141 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 2
   m_VerticalFit: 0
+--- !u!1 &928317273393523382
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8171657886148214059}
+  - component: {fileID: 4990448639412199388}
+  - component: {fileID: 1776732767320228946}
+  m_Layer: 0
+  m_Name: ResourcePath
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8171657886148214059
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 928317273393523382}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4383038157323776768}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 100, y: -67}
+  m_SizeDelta: {x: 180, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4990448639412199388
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 928317273393523382}
+  m_CullTransparentMesh: 1
+--- !u!114 &1776732767320228946
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 928317273393523382}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Resource path of the card to disambiguate names
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4291480266
+  m_fontColor: {r: 0.7921569, g: 0.7921569, b: 0.7921569, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 11
+  m_fontSizeBase: 11
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 1
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 1
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0.5078125, y: 0.0126953125, z: 0.41992188, w: 23.776123}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &4199513441948227604
 GameObject:
   m_ObjectHideFlags: 0
@@ -111,6 +246,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1883248460156222526}
+  - {fileID: 8171657886148214059}
   - {fileID: 8475846025723501542}
   - {fileID: 6396921774335534201}
   - {fileID: 879949454364062997}
@@ -174,10 +310,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   segmentName: 
   description: 
-  path: 
+  filePath: 
+  resourcePath: 
   type: 0
   playButton: {fileID: 2445726624697383442}
   nameComponent: {fileID: 714608286913792316}
+  resourcePathComponent: {fileID: 1776732767320228946}
   descriptionComponent: {fileID: 568061730793287071}
   segmentListIndicatorComponent: {fileID: 5681023320253614783}
 --- !u!1 &5681023320253614783
@@ -211,7 +349,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4383038157323776768}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -443,8 +581,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Segment name can be three lines long. If they are any longer, they will
-    be truncated
+  m_text: Segment name can be two lines long. If longer, truncation!
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
   m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
@@ -507,7 +644,7 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: 0.5078125, y: 0.0126953125, z: 0.41992188, w: 0}
+  m_margin: {x: 0.5078125, y: 0.0126953125, z: 0.41992188, w: 16.534668}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0
@@ -566,7 +703,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 7390251111716423299, guid: e49ee355d192d4b3baa7709272c0cd36, type: 3}
       propertyPath: m_AnchorMax.x

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGDraggableCard.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGDraggableCard.cs
@@ -134,6 +134,7 @@ namespace RegressionGames
                 {
                     dragged.payload = payload;
                     dragged.draggedCardName = draggableCardName;
+                    dragged.draggedCardResourcePath = draggableCardResourcePath;
                     dragged.iconPrefab.GetComponent<Image>().overrideSprite = icon;
                 }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGDraggedCard.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGDraggedCard.cs
@@ -14,19 +14,43 @@ namespace RegressionGames
     {
         public string draggedCardName;
 
-        public string draggedCardDescription;
+        public string draggedCardResourcePath;
 
         public Dictionary<string, string> payload;
 
         public GameObject iconPrefab;
 
-        [SerializeField] public TMP_Text namePrefab;
+        [SerializeField]
+        public TMP_Text nameComponent;
+        
+        [SerializeField]
+        public TMP_Text resourcePathComponent;
 
         public void Start()
         {
-            if (namePrefab != null)
+            // if we have a name set
+            if (!string.IsNullOrEmpty(draggedCardName))
             {
-                namePrefab.text = draggedCardName;
+                if (nameComponent != null)
+                {
+                    nameComponent.text = draggedCardName;
+                }
+
+                if (resourcePathComponent != null)
+                {
+                    resourcePathComponent.text = draggedCardResourcePath;
+                    resourcePathComponent.gameObject.SetActive(true);
+                }
+            }
+            else
+            {
+                // use the resource path as the name and hide the hint path
+                nameComponent.text = draggedCardResourcePath;
+                if (resourcePathComponent != null)
+                {
+                    resourcePathComponent.text = "";
+                    resourcePathComponent.gameObject.SetActive(false);
+                }
             }
         }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGDropZone.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGDropZone.cs
@@ -36,7 +36,7 @@ namespace RegressionGames
         private int _currentDropIndex = -1;
 
         // if not specified, default to this child height
-        private const int DEFAULT_CHILD_HEIGHT = 30;
+        private const int DEFAULT_CHILD_HEIGHT = 40;
 
         // if not specified, default to this spacing between children
         private const int DEFAULT_CHILD_SPACING = 8;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSegmentEntry.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSegmentEntry.cs
@@ -34,6 +34,9 @@ public class RGSegmentEntry : MonoBehaviour
     
     [SerializeField]
     public TMP_Text nameComponent;
+    
+    [SerializeField]
+    public TMP_Text resourcePathComponent;
 
     [SerializeField]
     public TMP_Text descriptionComponent;
@@ -48,8 +51,32 @@ public class RGSegmentEntry : MonoBehaviour
      */
     public void Start()
     {
+        // if we have a name set
+        if (!string.IsNullOrEmpty(segmentName))
+        {
+            if (nameComponent != null)
+            {
+                nameComponent.text = segmentName;
+            }
+
+            if (resourcePathComponent != null)
+            {
+                resourcePathComponent.text = resourcePath;
+                resourcePathComponent.gameObject.SetActive(true);
+            }
+        }
+        else
+        {
+            // use the resource path as the name and hide the hint path
+            nameComponent.text = resourcePath;
+            if (resourcePathComponent != null)
+            {
+                resourcePathComponent.text = "";
+                resourcePathComponent.gameObject.SetActive(false);
+            }
+        }
+        
         // assign values to the UI components
-        nameComponent.text = segmentName;
         descriptionComponent.text = description;
         playButton.onClick.AddListener(OnPlay);
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
@@ -313,6 +313,7 @@ public class RGSequenceManager : MonoBehaviour
             if (prefabComponent != null)
             {
                 prefabComponent.segmentName = segment.name;
+                prefabComponent.resourcePath = resourcePath;
                 prefabComponent.description = segment.description;
                 prefabComponent.filePath = filePath;
                 prefabComponent.resourcePath = resourcePath;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7d436d92-c6d4-4527-8462-1b7aa3ae6be7)

## What has been done
- Added a resource path text component to the large Segment Cards
  - This will show beneath the card's name field. If the name field is missing, we will use the resource path in its stead
- Added the resource path text to the dragging card prefab
- Increased the height of the potential drop spot prefab

## LOOM (It cuts before I'm done talking, but its ok)
https://www.loom.com/share/66adb820a05b4fbe88991f499813945a