### PR TITLE
[REG-2105] Allow absolute paths to be used in segment and sequence loading

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using RegressionGames.StateRecorder.BotSegments;
@@ -124,6 +125,18 @@ namespace RegressionGames
                 {
                     if (i + 1 < argsLength)
                     {
+
+                        var path = args[i + 1];
+                        
+                        // Sequences that are run via -rgsequencepath must be relative, as we only allows sequences
+                        // included in the Resource or persistent path directories.
+                        if (Path.IsPathRooted(path))
+                        {
+                            RGDebug.LogError($"{SequencePathArgument} command line argument requires a relative path");
+                            Application.Quit(Rc_SequencePathMissing);
+                            return null;
+                        }
+                        
                         return args[i + 1];
                     }
                     // else

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
@@ -24,6 +24,7 @@ namespace RegressionGames
         internal static readonly int Rc_SequenceTimeoutNeedsPath = 5;
         internal static readonly int Rc_SequenceTimeoutMissing = 6;
         internal static readonly int Rc_SequenceTimeoutNotInt = 7;
+        internal static readonly int Rc_SequencePathNotRelative = 8;
 
         internal static readonly string SequencePathArgument = "-rgsequencepath";
         internal static readonly string SequenceTimeoutArgument = "-rgsequencetimeout";
@@ -133,7 +134,7 @@ namespace RegressionGames
                         if (Path.IsPathRooted(path))
                         {
                             RGDebug.LogError($"{SequencePathArgument} command line argument requires a relative path");
-                            Application.Quit(Rc_SequencePathMissing);
+                            Application.Quit(Rc_SequencePathNotRelative);
                             return null;
                         }
                         

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
@@ -137,7 +137,7 @@ namespace RegressionGames
                             return null;
                         }
                         
-                        return args[i + 1];
+                        return path;
                     }
                     // else
                     RGDebug.LogError($"{SequencePathArgument} command line argument requires a path value to be passed after it");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSequence.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSequence.cs
@@ -46,11 +46,6 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                 return (null, null, null);
             }
 
-            if (path.StartsWith('/') || path.StartsWith('\\'))
-            {
-                throw new Exception("Invalid path.  Path must be relative, not absolute in order to support editor vs production runtimes interchangeably.");
-            }
-
             path = path.Replace('\\', '/');
 
             (string, string, string) sequenceJson;
@@ -144,10 +139,6 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
          */
         public static (string, string, object) LoadBotSegmentOrBotSegmentListFromPath(string path)
         {
-            if (path.StartsWith('/') || path.StartsWith('\\'))
-            {
-                throw new Exception("Invalid path.  Path must be relative, not absolute, in order to support editor vs production runtimes interchangeably.");
-            }
 
             path = path.Replace('\\', '/');
 


### PR DESCRIPTION
There was a bug where sequences and segments could not be loaded from the application data path in builds. I am not super familiar with all of the logic here so wanted to take a minute to explain my observations and decisions here:

* I was getting errors like this in **production builds**: `Error reading Bot Sequence /Users/aaronvontell/Library/Application Support/DefaultCompany/normal/RegressionGames/Resources/BotSequences/Latest_Recording.json: System.Exception: Invalid path.  Path must be relative, not absolute in order to support editor vs production runtimes interchangeably.`
* In the editor, paths look like `Assets/RegressionGames/Resources/BotSequences/asdasd.json`
* When in a build, the paths look like `/Users/aaronvontell/Library/Application Support/com.DefaultCompany.This--should-break-/RegressionGames/Resources/BotSequences/Latest_Recording.json`
* The code for loading these sequences had an explicit catch for JSONs coming from an absolute path, and wouldn't allow it.
* The fix I found was to remove that check, **but** this seemed weird... because we are basically taking the absolute path, trimming off most of it in the `ToResourcePath` function, and then reconstructing it... and the LoadJsonResource function knows how to handle both scenarios. 

An alternative to my change is to only call ToResourcePath inside of the `UNITY_EDITOR` scenarios and then use the path directly inside of the else block, so that the path doesn't need to be reconstructed. However, I wanted to check with @RG-nAmKcAz and @addisonbgross that this is still fine considering the "override" behavior, or if there is additional logic I need to consider.

At least on mac, I confirmed that this allows us to both create and see sequences that are in the application data path, and everything behaves as expected in builds and in editor. Note, however, that the sequences and segments inside the application data path do not show in the editor (which I believe is expected, but wanted to confirm).