### PR TITLE
[REG-2110] Implement the GetRuntimeLogs command in the Runespawn server.

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardEventSender.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/KeyboardEventSender.cs
@@ -103,7 +103,7 @@ namespace RegressionGames.StateRecorder
                     }
 
                     var inputEvent = TextEvent.Create(currentKeyboard.deviceId, value, InputState.currentTime);
-                    RGDebug.LogInfo($"({replaySegment}) Sending Text Event for char: '{value}'");
+                    RGDebug.LogDebug($"({replaySegment}) Sending Text Event for char: '{value}'");
                     InputSystem.QueueEvent(ref inputEvent);
                 }
 
@@ -147,7 +147,7 @@ namespace RegressionGames.StateRecorder
             SendKeysInOneEventLegacy(keyStates);
             #endif
 
-            RGDebug.LogInfo($"({replaySegment}) Sending Multiple Key Event: [" +
+            RGDebug.LogDebug($"({replaySegment}) Sending Multiple Key Event: [" +
                             string.Join(", ", keyStates.Select(a => a.Key + ":" + a.Value).ToArray()) + "]");
 
             foreach (var (key, upOrDown) in keyStates)
@@ -194,7 +194,7 @@ namespace RegressionGames.StateRecorder
                 RGDebug.LogWarning($"KeyboardEventSender - Multiple key events have been sent within one frame for {key}. Only the last state ({upOrDown}) will be kept.");
             }
 
-            RGDebug.LogInfo($"({replaySegment}) [frame: {Time.frameCount}] - Sending Key Event: {key} - {upOrDown}");
+            RGDebug.LogDebug($"({replaySegment}) [frame: {Time.frameCount}] - Sending Key Event: {key} - {upOrDown}");
 
             _keyStates[key] = upOrDown;
 

--- a/src/gg.regression.unity.experimental.runespawn/Editor/Scripts/EditorCommandServer.cs
+++ b/src/gg.regression.unity.experimental.runespawn/Editor/Scripts/EditorCommandServer.cs
@@ -39,6 +39,8 @@ public class EditorCommandServer
         EditorApplication.update += OnEditorUpdate;
         AssemblyReloadEvents.beforeAssemblyReload += OnBeforeAssemblyReload;
         EditorApplication.quitting += OnEditorQuitting;
+
+        // TODO (REG-2113): Use LoggingObserver to parse runtime logs.
         Application.logMessageReceived += PlayModeController.OnLogMessageReceived;
     }
 

--- a/src/gg.regression.unity.experimental.runespawn/Editor/Scripts/EditorCommandServer.cs
+++ b/src/gg.regression.unity.experimental.runespawn/Editor/Scripts/EditorCommandServer.cs
@@ -19,7 +19,8 @@ public class EditorCommandServer
         Stop,
         GetScripts,
         Compile,
-        GetCompilationMessages
+        GetCompilationMessages,
+        GetRuntimeLogs
     }
 
     // Configuration: Read from environment variables with defaults
@@ -38,6 +39,7 @@ public class EditorCommandServer
         EditorApplication.update += OnEditorUpdate;
         AssemblyReloadEvents.beforeAssemblyReload += OnBeforeAssemblyReload;
         EditorApplication.quitting += OnEditorQuitting;
+        Application.logMessageReceived += PlayModeController.OnLogMessageReceived;
     }
 
     /// <summary>
@@ -206,6 +208,10 @@ public class EditorCommandServer
                         PlayModeController.StopPlayMode(editorCommand.Client);
                         break;
 
+                    case CommandType.GetRuntimeLogs:
+                        PlayModeController.SendRuntimeLogsToClient(editorCommand.Client);
+                        break;
+
                     case CommandType.GetScripts:
                         ScriptExporterController.SendScriptsToClient(editorCommand.Client);
                         break;
@@ -252,6 +258,7 @@ public class EditorCommandServer
         EditorApplication.update -= OnEditorUpdate;
         AssemblyReloadEvents.beforeAssemblyReload -= OnBeforeAssemblyReload;
         EditorApplication.quitting -= OnEditorQuitting;
+        Application.logMessageReceived -= PlayModeController.OnLogMessageReceived;
     }
 
     /// <summary>

--- a/src/gg.regression.unity.experimental.runespawn/Editor/Scripts/PlayModeController.cs
+++ b/src/gg.regression.unity.experimental.runespawn/Editor/Scripts/PlayModeController.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEditor;
 using System;
 using System.Net.Sockets;
+using System.Collections.Generic;
 using UnityEditor.Compilation;
 using RegressionGames;
 
@@ -9,6 +10,50 @@ using RegressionGames;
 public static class PlayModeController
 {
     private static bool originalRunInBackground = Application.runInBackground;
+
+    private static List<string> _logs = new List<string>();
+    private static List<string> _errors = new List<string>();
+
+    /// <summary>
+    /// Static constructor for PlayModeController.
+    /// Initializes event subscriptions and prevents multiple subscriptions.
+    /// </summary>
+    static PlayModeController()
+    {
+        // Prevent multiple subscriptions.
+        EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+        AssemblyReloadEvents.beforeAssemblyReload -= CleanUpSubscriptions;
+
+        EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+
+        // Unsubscribe from playModeStateChanged before the assembly reloads.
+        // This is to prevent multiple subscriptions.
+        AssemblyReloadEvents.beforeAssemblyReload += CleanUpSubscriptions;
+    }
+
+    /// <summary>
+    /// Cleans up event subscriptions to prevent multiple subscriptions.
+    /// This is called before the assembly is reloaded.
+    /// </summary>
+    private static void CleanUpSubscriptions()
+    {
+        EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+        AssemblyReloadEvents.beforeAssemblyReload -= CleanUpSubscriptions;
+    }
+
+    /// <summary>
+    /// Clears logs and errors when entering play mode.
+    /// </summary>
+    /// <param name="state">The current state of the play mode.</param>
+    private static void OnPlayModeStateChanged(PlayModeStateChange state)
+    {
+        if (state == PlayModeStateChange.EnteredPlayMode)
+        {
+            // Clear logs and errors when manually entering play mode as well. 
+            _logs.Clear();
+            _errors.Clear();
+        }
+    }
 
     /// <summary>
     /// Starts Play mode and sends a response to the client.
@@ -28,6 +73,10 @@ public static class PlayModeController
             EditorApplication.isPlaying = true;
             RGDebug.Log("PlayModeController: Play mode started.");
 
+            // Clear the previous logs and errors when entering play mode.
+            _logs.Clear();
+            _errors.Clear();
+           
             // Send success response
             Utilities.SendJsonResponse(client.GetStream(), new { status = "Started" });
         }
@@ -69,6 +118,52 @@ public static class PlayModeController
         finally
         {
             client.Close();
+        }
+    }
+
+    /// <summary>
+    /// Sends the collected runtime logs and errors to the connected client.
+    /// </summary>
+    /// <param name="client">The TcpClient object representing the connected client.</param>
+    public static void SendRuntimeLogsToClient(TcpClient client)
+    {
+        try
+        {
+            string logs_string = string.Join("\n", _logs);
+            string errors_string = string.Join("\n", _errors);
+            Utilities.SendJsonResponse(client.GetStream(), new {
+                status = "Success",
+                logs = logs_string,
+                errors = errors_string
+            });
+        }
+        catch (Exception ex)
+        {
+            RGDebug.LogError($"PlayModeController: Exception in SendLogsToClient - {ex.Message}");
+            Utilities.SendJsonResponse(client.GetStream(), new { status = "Error", message = ex.Message });
+        }
+        finally
+        {
+            client.Close();
+        }
+    }
+
+
+    /// <summary>
+    /// Handles log messages received from Unity.
+    /// </summary>
+    /// <param name="logString">The log message.</param>
+    /// <param name="stackTrace">The stack trace (if any).</param>
+    /// <param name="type">The type of log message.</param>
+    public static void OnLogMessageReceived(string logString, string stackTrace, LogType type)
+    {
+        if (type == LogType.Error || type == LogType.Exception || type == LogType.Assert)
+        {
+            _errors.Add($"[{type}] {logString}\n{stackTrace}");
+        }
+        else if (type == LogType.Log)
+        {
+            _logs.Add($"[{type}] {logString}"); // We don't need stack trace for normal logs.
         }
     }
 }


### PR DESCRIPTION
[Python side component.](https://github.com/Regression-Games/Runespawn/pull/10)

I tried to be mindful of unsubscribing events, but I don't know if what I ended up with is the right way to do it.

I ended up simply writing the code myself instead of using our built in log detailing as it was as simple as: 
`_logs.Add($"[{type}] {logString}");`

I also made KeyboardEventSender default log level from info to debug, as it would clog up the LLM context.

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
