### PR TITLE
[REG-2125] Only capture logs when running a remote work assignment

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using RegressionGames.StateRecorder;
 using RegressionGames.StateRecorder.BotSegments;
 using RegressionGames.StateRecorder.BotSegments.Models;
 using RegressionGames.Types;
@@ -112,7 +113,7 @@ namespace RegressionGames
                     {
 
                         var path = args[i + 1];
-                        
+
                         // Sequences that are run via -rgsequencepath must be relative, as we only allows sequences
                         // included in the Resource or persistent path directories.
                         if (Path.IsPathRooted(path))
@@ -121,7 +122,7 @@ namespace RegressionGames
                             Application.Quit(Rc_SequencePathNotRelative);
                             return null;
                         }
-                        
+
                         return path;
                     }
                     // else
@@ -183,6 +184,12 @@ namespace RegressionGames
             botSequenceInfo.Item3.Play();
 
             var playbackController = Object.FindObjectOfType<BotSegmentsPlaybackController>();
+
+            var replayToolbar = Object.FindObjectOfType<ReplayToolbarManager>();
+            if (replayToolbar != null)
+            {
+                replayToolbar.SetInUseButtonStates();
+            }
 
             yield return null; // Allow the recording to start playing
             var didTimeout = false;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RemoteOrchestration/RGRemoteWorkerAssignmentManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RemoteOrchestration/RGRemoteWorkerAssignmentManager.cs
@@ -98,7 +98,9 @@ namespace RegressionGames.RemoteOrchestration
 
         private List<AvailableBotSequence> _availableBotSequences = null;
 
-        public volatile WorkAssignment ActiveWorkAssignment = null;
+        private volatile WorkAssignment ActiveWorkAssignment = null;
+
+        public bool HasActiveWorkAssignment => ActiveWorkAssignment != null;
 
 
         private void Update()
@@ -326,41 +328,5 @@ namespace RegressionGames.RemoteOrchestration
 
             return null;
         }
-
-        /// <summary>
-        /// Plays back a bot sequence, and then returns the save location of the recording.
-        /// </summary>
-        /// <param name="botSequenceInfo">(filePath,resourcePath,BotSequence) tuple of the bot sequence</param>
-        /// <param name="setPlaybackResult">A callback that will be called with the results of this playback</param>
-        /// <param name="timeout">How long in seconds to wait for this sequence to complete, less than or == 0 means wait forever (default=0)</param>
-        internal static IEnumerator StartBotSequence((string,string, BotSequence) botSequenceInfo, Action<PlaybackResult> setPlaybackResult, int timeout = 0)
-        {
-            var startTime = Time.unscaledTime;
-
-            botSequenceInfo.Item3.Play();
-
-            var playbackController = Object.FindObjectOfType<BotSegmentsPlaybackController>();
-
-            yield return null; // Allow the recording to start playing
-            var didTimeout = false;
-            while (playbackController.GetState() == PlayState.Playing || playbackController.GetState() == PlayState.Paused)
-            {
-                if (timeout > 0 && Time.unscaledTime > startTime + timeout )
-                {
-                    didTimeout = true;
-                    break;
-                }
-                yield return null;
-            }
-            yield return null;
-            var result = new PlaybackResult
-            {
-                saveLocation = playbackController.SaveLocation() + ".zip",
-                success = !didTimeout
-            };
-            setPlaybackResult(result);
-        }
-
-
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
@@ -253,7 +253,7 @@ namespace RegressionGames.StateRecorder.BotSegments
         public void Reset()
         {
             _nextBotSegments.Clear();
-            _isPlaying = PlayState.NotLoaded;
+            _isPlaying = PlayState.Stopped;
             _loopCount = -1;
             _replaySuccessful = null;
             WaitingForKeyFrameConditions = null;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/LoggingObserver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/LoggingObserver.cs
@@ -15,7 +15,7 @@ namespace RegressionGames.StateRecorder
     {
         public long LoggedWarnings { get; private set;  }
         public long LoggedErrors { get; private set; }
-        
+
         private ConcurrentQueue<LogDataPoint> _logQueue = new();
 
         public void StartCapturingLogs()
@@ -24,33 +24,38 @@ namespace RegressionGames.StateRecorder
             LoggedErrors = 0;
             Application.logMessageReceivedThreaded += OnLogMessageReceived;
         }
-        
+
         public void StopCapturingLogs()
         {
             Application.logMessageReceivedThreaded -= OnLogMessageReceived;
         }
-        
+
         private void OnLogMessageReceived(string message, string stacktrace, LogType type)
         {
             if (type == LogType.Warning)
             {
                 LoggedWarnings++;
-            } 
+            }
             else if (type == LogType.Error || type == LogType.Exception)
             {
                 LoggedErrors++;
             }
-            
+
             // PERF: DateTimeOffset.Now is surprisingly costly, use DateTimeOffset.UtcNow unless we have to know the local timezone.
             // It's still good to use a DateTimeOffset here though because it ensures that when we serialize the data,
             // it is clearly marked as a UTC time (with the `Z` suffix)
             var dataPoint = new LogDataPoint(
                 timestamp: DateTimeOffset.UtcNow,
-                level: type, 
-                message: message, 
+                level: type,
+                message: message,
                 stackTrace: stacktrace
             );
             _logQueue.Enqueue(dataPoint);
+        }
+
+        public int QueueLength()
+        {
+            return _logQueue.Count;
         }
 
         /// <summary>
@@ -64,11 +69,11 @@ namespace RegressionGames.StateRecorder
             {
                 return string.Empty;
             }
-            
+
             // Atomically swap the logs queue with an empty queue.
             // Then we can record this queue's logs while new logs continue to accumulate in the new queue
             var logsThisTick = Interlocked.Exchange(ref _logQueue, new());
-            
+
             // Convert the list into JSONL format
             var builder = new StringBuilder();
             foreach (var line in logsThisTick)
@@ -79,7 +84,7 @@ namespace RegressionGames.StateRecorder
             // Combine the JSON strings with newline characters
             return builder.ToString();
         }
-        
+
     }
-    
+
 }


### PR DESCRIPTION
- When running a remote work assignment, the SDK will now only capture log statements, not state/images/etc
  - This utilizes the fact that a remote work assignment is active, not any startup args.. Thus if you use this system with the overlays it will still behave normally
- Fixes some bugs managing the replay button bar states that were recently introduced
- Removes some un-used code
- Fixes a bug where directories weren't getting clean up correctly after zipping

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
