### PR TITLE
[REG-2126] Collapse multiline error logs in Runespawn.

### DIFF
--- a/src/gg.regression.unity.experimental.runespawn/Editor/Scripts/PlayModeController.cs
+++ b/src/gg.regression.unity.experimental.runespawn/Editor/Scripts/PlayModeController.cs
@@ -157,9 +157,9 @@ public static class PlayModeController
     /// <param name="type">The type of log message.</param>
     public static void OnLogMessageReceived(string logString, string stackTrace, LogType type)
     {
-        if (type == LogType.Error || type == LogType.Exception || type == LogType.Assert)
+        if (type == LogType.Error || type == LogType.Exception || type == LogType.Warning || type == LogType.Assert)
         {
-            _errors.Add($"[{type}] {logString}\n{stackTrace}");
+            _errors.Add($"[{type}] {logString}\n{stackTrace}\n");
         }
         else if (type == LogType.Log)
         {

--- a/src/gg.regression.unity.experimental.runespawn/Editor/Scripts/PlayModeController.cs
+++ b/src/gg.regression.unity.experimental.runespawn/Editor/Scripts/PlayModeController.cs
@@ -12,8 +12,8 @@ public static class PlayModeController
     private static bool originalRunInBackground = Application.runInBackground;
 
     private static List<string> _logs = new List<string>();
+    private static List<string> _warnings = new List<string>();
     private static List<string> _errors = new List<string>();
-
     /// <summary>
     /// Static constructor for PlayModeController.
     /// Initializes event subscriptions and prevents multiple subscriptions.
@@ -51,6 +51,7 @@ public static class PlayModeController
         {
             // Clear logs and errors when manually entering play mode as well. 
             _logs.Clear();
+            _warnings.Clear();
             _errors.Clear();
         }
     }
@@ -75,6 +76,7 @@ public static class PlayModeController
 
             // Clear the previous logs and errors when entering play mode.
             _logs.Clear();
+            _warnings.Clear();
             _errors.Clear();
            
             // Send success response
@@ -130,10 +132,12 @@ public static class PlayModeController
         try
         {
             string logs_string = string.Join("\n", _logs);
+            string warnings_string = string.Join("\n", _warnings);
             string errors_string = string.Join("\n", _errors);
             Utilities.SendJsonResponse(client.GetStream(), new {
                 status = "Success",
                 logs = logs_string,
+                warnings = warnings_string,
                 errors = errors_string
             });
         }
@@ -157,9 +161,13 @@ public static class PlayModeController
     /// <param name="type">The type of log message.</param>
     public static void OnLogMessageReceived(string logString, string stackTrace, LogType type)
     {
-        if (type == LogType.Error || type == LogType.Exception || type == LogType.Warning || type == LogType.Assert)
+        if (type == LogType.Error || type == LogType.Exception || type == LogType.Assert)
         {
             _errors.Add($"[{type}] {logString}\n{stackTrace}\n");
+        }
+        else if (type == LogType.Warning)
+        {
+            _warnings.Add($"[{type}] {logString}\n{stackTrace}\n");
         }
         else if (type == LogType.Log)
         {


### PR DESCRIPTION
[Main Python side PR.](https://github.com/Regression-Games/Runespawn/pull/16)

- This PR adds an extra '\n' between errors for easier splitting.
- This PR also adds capturing of warnings.