### PR TITLE
[REG-2130] Exclude transform renderers outside the view frustrum

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/TransformObjectFinder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/TransformObjectFinder.cs
@@ -406,7 +406,8 @@ namespace RegressionGames.StateRecorder
                 for (var i = 0; i < rendererListLength; i++)
                 {
                     var nextRenderer = RendererQueryList[i];
-                    if (nextRenderer.transform.GetComponentInParent<RGExcludeFromState>() == null)
+                    // exclude objects outside the view frustrum of ANY camera... this can be a problem in the editor scene view though as that counts as a camera
+                    if (nextRenderer.isVisible && nextRenderer.transform.GetComponentInParent<RGExcludeFromState>() == null)
                     {
                         var theBounds = nextRenderer.bounds;
 


### PR DESCRIPTION
- Updates the bounds computation for world space transforms to consider whether their renderer is within ANY camera's view frustrum before including them in the state

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
