### PR TITLE
[REG-2144] Simplify recorded BotSegment criteria + performance optimizations

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/LoggingObserver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/LoggingObserver.cs
@@ -78,7 +78,7 @@ namespace RegressionGames.StateRecorder
             var builder = new StringBuilder();
             foreach (var line in logsThisTick)
             {
-                builder.AppendLine(JsonConvert.SerializeObject(line));
+                builder.AppendLine(line.ToJsonString());
             }
 
             // Combine the JSON strings with newline characters

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/LogDataPoint.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/LogDataPoint.cs
@@ -1,26 +1,50 @@
 using System;
+using System.Globalization;
+using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using RegressionGames.StateRecorder.JsonConverters;
 using UnityEngine;
+// ReSharper disable InconsistentNaming
 
 namespace RegressionGames.StateRecorder.Models
 {
     [Serializable]
     public class LogDataPoint
     {
+        private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new StringBuilder(500));
+
         public DateTimeOffset timestamp { get; }
 
         [JsonConverter(typeof(StringEnumConverter))]
         public LogType level { get; }
         public string message { get; }
         public string stackTrace { get; }
-        
+
         public LogDataPoint(DateTimeOffset timestamp, LogType level, string message, string stackTrace)
         {
             this.timestamp = timestamp;
             this.level = level;
             this.message = message;
             this.stackTrace = stackTrace;
+        }
+
+        public string ToJsonString()
+        {
+            var stringBuilder = _stringBuilder.Value;
+            stringBuilder.Clear();
+            stringBuilder.Append("{\"timestamp\":");
+            // gives timestamps in ISO 8601 Z format with milliseconds - "2024-10-29T14:19:39.3795249Z"
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, timestamp.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture));
+            stringBuilder.Append(",\"level\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, level.ToString());
+            stringBuilder.Append(",\"message\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, message);
+            stringBuilder.Append(",\"stackTrace\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, stackTrace);
+            stringBuilder.Append("}");
+            return stringBuilder.ToString();
         }
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseInputActionObserver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseInputActionObserver.cs
@@ -172,13 +172,32 @@ namespace RegressionGames.StateRecorder
             _mouseInputActions.Clear();
         }
 
-        public List<MouseInputActionData> FlushInputDataBuffer(bool ignoreLastClick)
+        /**
+         * <summary>Flush the latest captured mouse movements</summary>
+         * <param name="ignoreLastClick">Ignore the last click.. useful for recordings to avoid capturing the click of the stop recording button</param>
+         * <param name="minimizeOutput">Flag to leave out everything except the key movements around clicks.</param>
+         */
+        public List<MouseInputActionData> FlushInputDataBuffer(bool ignoreLastClick, bool minimizeOutput)
         {
             List<MouseInputActionData> result = new();
+            MouseInputActionData lastAction = null;
             while (_mouseInputActions.TryPeek(out var action))
             {
                 _mouseInputActions.TryDequeue(out _);
-                result.Add(action);
+
+                // when minimizing output, only capture the inputs 1 before 1 after and during mouse clicks or holds... the normalized paths is populated for both clicks and unclicks so is useful for determining the unclick data
+
+                if (lastAction != null && (!minimizeOutput || action.IsButtonClicked || action.clickedObjectNormalizedPaths.Length > 0 || lastAction?.IsButtonClicked == true|| lastAction?.clickedObjectNormalizedPaths.Length > 0))
+                {
+                    result.Add(lastAction);
+                }
+
+                lastAction = action;
+            }
+
+            if (lastAction != null)
+            {
+                result.Add(lastAction);
             }
 
             if (result.Count == 0 && _priorMouseState != null)


### PR DESCRIPTION
- By default, now captures only the changed or clicked on options in recorded bot segment endCriteria
- Adds an internal/dev option for testing out recording minimum mouse state around clicks
  - This currently breaks games that lock the mouse to the camera, like First Person shooter style
- Improves performance and memory allocation issues around log capture 
- Improves performance and memory allocation issues around screenshot capture

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
