### PR TITLE
[REG-2145] Add test APIs for using bot segments, actions, and criteria

### DIFF
--- a/src/RGUnityBots/Assets/RegressionGames/Resources/RGBotSequences.asset
+++ b/src/RGUnityBots/Assets/RegressionGames/Resources/RGBotSequences.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6a1cef64117020e5645e68740077aab3a63c3485b4568bf878fa3191799d425e
-size 3473
+oid sha256:07260048a3fe079b2491c175db73d46d5db9eb5b6eba57c2b9055f1748cf220a
+size 2080

--- a/src/RGUnityBots/ProjectSettings/EditorBuildSettings.asset
+++ b/src/RGUnityBots/ProjectSettings/EditorBuildSettings.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:04c7a717a8f3bae00b4c12e94aba0f94bc3e9ab45fce3399d3702f63fa218b10
-size 679
+oid sha256:fa832b8cfeb97333de0dfbae586e1a9abc26bc7ab0a23620c695b692daa7d961
+size 782

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
@@ -390,8 +390,8 @@ namespace RegressionGames.StateRecorder.BotSegments
 
                 var objectFinders = FindObjectsByType<ObjectFinder>(FindObjectsSortMode.None);
 
-                var transformStatuses = new Dictionary<long, ObjectStatus>();
-                var entityStatuses = new Dictionary<long, ObjectStatus>();
+                Dictionary<long, ObjectStatus> transformStatuses = null;
+                Dictionary<long, ObjectStatus> entityStatuses = null;
 
                 foreach (var objectFinder in objectFinders)
                 {
@@ -404,6 +404,9 @@ namespace RegressionGames.StateRecorder.BotSegments
                         entityStatuses = objectFinder.GetObjectStatusForCurrentFrame().Item2;
                     }
                 }
+
+                transformStatuses ??= new Dictionary<long, ObjectStatus>();
+                entityStatuses ??= new Dictionary<long, ObjectStatus>();
 
                 // track if any segment matched this update
                 var matchedThisUpdate = false;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IKeyFrameCriteriaData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/IKeyFrameCriteriaData.cs
@@ -2,10 +2,8 @@
 
 namespace RegressionGames.StateRecorder.BotSegments.Models
 {
-    public interface IKeyFrameCriteriaData
+    public interface IKeyFrameCriteriaData : IStringBuilderWriteable
     {
-        public void WriteToStringBuilder(StringBuilder stringBuilder);
-
         public int EffectiveApiVersion();
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/InputPlaybackActionData.cs
@@ -35,14 +35,20 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                 var now = Time.unscaledTime;
                 var currentInputTimePoint = now - startTime;
 
-                foreach (var keyboardInputActionData in inputData.keyboard)
+                if (inputData.keyboard != null)
                 {
-                    keyboardInputActionData.Replay_OffsetTime = currentInputTimePoint;
+                    foreach (var keyboardInputActionData in inputData.keyboard)
+                    {
+                        keyboardInputActionData.Replay_OffsetTime = currentInputTimePoint;
+                    }
                 }
 
-                foreach (var mouseInputActionData in inputData.mouse)
+                if (inputData.mouse != null)
                 {
-                    mouseInputActionData.Replay_OffsetTime = currentInputTimePoint;
+                    foreach (var mouseInputActionData in inputData.mouse)
+                    {
+                        mouseInputActionData.Replay_OffsetTime = currentInputTimePoint;
+                    }
                 }
             }
         }
@@ -60,19 +66,25 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                 var now = Time.unscaledTime;
                 var delta = now - pauseTime;
 
-                foreach (var keyboardInputActionData in inputData.keyboard)
+                if (inputData.keyboard != null)
                 {
-                    if (!keyboardInputActionData.Replay_IsDone)
+                    foreach (var keyboardInputActionData in inputData.keyboard)
                     {
-                        keyboardInputActionData.Replay_OffsetTime += delta;
+                        if (!keyboardInputActionData.Replay_IsDone)
+                        {
+                            keyboardInputActionData.Replay_OffsetTime += delta;
+                        }
                     }
                 }
 
-                foreach (var mouseInputActionData in inputData.mouse)
+                if (inputData.mouse != null)
                 {
-                    if (!mouseInputActionData.Replay_IsDone)
+                    foreach (var mouseInputActionData in inputData.mouse)
                     {
-                        mouseInputActionData.Replay_OffsetTime += delta;
+                        if (!mouseInputActionData.Replay_IsDone)
+                        {
+                            mouseInputActionData.Replay_OffsetTime += delta;
+                        }
                     }
                 }
             }
@@ -168,19 +180,25 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         {
             if (!_isStopped)
             {
-                foreach (var keyboardInputActionData in inputData.keyboard)
+                if (inputData.keyboard != null)
                 {
-                    if (!keyboardInputActionData.Replay_IsDone)
+                    foreach (var keyboardInputActionData in inputData.keyboard)
                     {
-                        return false;
+                        if (!keyboardInputActionData.Replay_IsDone)
+                        {
+                            return false;
+                        }
                     }
                 }
 
-                foreach (var mouseInputActionData in inputData.mouse)
+                if (inputData.mouse != null)
                 {
-                    if (!mouseInputActionData.Replay_IsDone)
+                    foreach (var mouseInputActionData in inputData.mouse)
                     {
-                        return false;
+                        if (!mouseInputActionData.Replay_IsDone)
+                        {
+                            return false;
+                        }
                     }
                 }
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/KeyFrameCriteria.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/KeyFrameCriteria.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Text;
+using System.Threading;
 using RegressionGames.StateRecorder.JsonConverters;
+// ReSharper disable InconsistentNaming
 
 namespace RegressionGames.StateRecorder.BotSegments.Models
 {
     [Serializable]
-    public class KeyFrameCriteria
+    public class KeyFrameCriteria : IStringBuilderWriteable
     {
         // api version of this top level schema, update if we add/change fields
         public int apiVersion = SdkApiVersion.VERSION_7;
@@ -15,7 +17,6 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public IKeyFrameCriteriaData data;
 
         public int EffectiveApiVersion => Math.Max(apiVersion, data?.EffectiveApiVersion() ?? SdkApiVersion.CURRENT_VERSION);
-
 
         // Replay only - used to track if transient has ever matched during replay
         [NonSerialized]
@@ -42,7 +43,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         public override string ToString()
         {
-            return "{type:" + type + ",transient:" + transient + ",data:" + data.ToString() + "}";
+            return ((IStringBuilderWriteable) this).ToJsonString();
         }
 
         public void WriteToStringBuilder(StringBuilder stringBuilder)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/KeyFrameCriteria.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/KeyFrameCriteria.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Text;
-using System.Threading;
 using RegressionGames.StateRecorder.JsonConverters;
 // ReSharper disable InconsistentNaming
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/InputData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/InputData.cs
@@ -29,43 +29,49 @@ namespace RegressionGames.StateRecorder.Models
             {
                 allInputsSorted = new();
 
-                // add all the keyboard data, and then we will interleave the mouse data into it
-                allInputsSorted.AddRange(keyboard);
-
-                foreach (var mouseInputActionData in mouse)
+                if (keyboard != null)
                 {
-                    var allInputsSortedCount = allInputsSorted.Count;
-                    var didAdd = false;
-                    for (var i = 0; i < allInputsSortedCount; i++)
-                    {
-                        var input = allInputsSorted[i];
-                        if (input is KeyboardInputActionData keyboardData)
-                        {
-                            // if a keyboard entry time is after the new mouse time.. insert the mouse before this one
-                            if ((keyboardData.startTime.HasValue && keyboardData.startTime.Value > mouseInputActionData.startTime) ||
-                                (keyboardData.endTime.HasValue && keyboardData.endTime.Value > mouseInputActionData.startTime))
-                            {
-                                allInputsSorted.Insert(i, mouseInputActionData);
-                                didAdd = true;
-                                break;
-                            }
-                        }
-                        else if (input is MouseInputActionData mouseData)
-                        {
-                            // if an existing mouse time is after the new mouse time.. insert the new mouse before this one
-                            if (mouseData.startTime > mouseInputActionData.startTime)
-                            {
-                                allInputsSorted.Insert(i, mouseInputActionData);
-                                didAdd = true;
-                                break;
-                            }
-                        }
-                    }
+                    // add all the keyboard data, and then we will interleave the mouse data into it
+                    allInputsSorted.AddRange(keyboard);
+                }
 
-                    if (!didAdd)
+                if (mouse != null)
+                {
+                    foreach (var mouseInputActionData in mouse)
                     {
-                        // didn't find something to put it before, stick it on the end
-                        allInputsSorted.Add(mouseInputActionData);
+                        var allInputsSortedCount = allInputsSorted.Count;
+                        var didAdd = false;
+                        for (var i = 0; i < allInputsSortedCount; i++)
+                        {
+                            var input = allInputsSorted[i];
+                            if (input is KeyboardInputActionData keyboardData)
+                            {
+                                // if a keyboard entry time is after the new mouse time.. insert the mouse before this one
+                                if ((keyboardData.startTime.HasValue && keyboardData.startTime.Value > mouseInputActionData.startTime) ||
+                                    (keyboardData.endTime.HasValue && keyboardData.endTime.Value > mouseInputActionData.startTime))
+                                {
+                                    allInputsSorted.Insert(i, mouseInputActionData);
+                                    didAdd = true;
+                                    break;
+                                }
+                            }
+                            else if (input is MouseInputActionData mouseData)
+                            {
+                                // if an existing mouse time is after the new mouse time.. insert the new mouse before this one
+                                if (mouseData.startTime > mouseInputActionData.startTime)
+                                {
+                                    allInputsSorted.Insert(i, mouseInputActionData);
+                                    didAdd = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (!didAdd)
+                        {
+                            // didn't find something to put it before, stick it on the end
+                            allInputsSorted.Add(mouseInputActionData);
+                        }
                     }
                 }
             }
@@ -76,22 +82,31 @@ namespace RegressionGames.StateRecorder.Models
 
         public void MarkSent()
         {
-            foreach (var keyboardInputActionData in keyboard)
+            if (keyboard != null)
             {
-                keyboardInputActionData.HasBeenSent = true;
+                foreach (var keyboardInputActionData in keyboard)
+                {
+                    keyboardInputActionData.HasBeenSent = true;
+                }
             }
         }
 
         public void ReplayReset()
         {
-            foreach (var keyboardInputActionData in keyboard)
+            if (keyboard != null)
             {
-                keyboardInputActionData.ReplayReset();
+                foreach (var keyboardInputActionData in keyboard)
+                {
+                    keyboardInputActionData.ReplayReset();
+                }
             }
 
-            foreach (var mouseInputActionData in mouse)
+            if (mouse != null)
             {
-                mouseInputActionData.ReplayReset();
+                foreach (var mouseInputActionData in mouse)
+                {
+                    mouseInputActionData.ReplayReset();
+                }
             }
         }
 
@@ -100,23 +115,30 @@ namespace RegressionGames.StateRecorder.Models
             stringBuilder.Append("{\n\"apiVersion\":");
             IntJsonConverter.WriteToStringBuilder(stringBuilder, apiVersion);
             stringBuilder.Append(",\n\"keyboard\":[\n");
-            var keyboardCount = keyboard.Count;
-            for (var i = 0; i < keyboardCount; i++)
+            if (keyboard != null)
             {
-                keyboard[i].WriteToStringBuilder(stringBuilder);
-                if (i + 1 < keyboardCount)
+                var keyboardCount = keyboard.Count;
+                for (var i = 0; i < keyboardCount; i++)
                 {
-                    stringBuilder.Append(",\n");
+                    keyboard[i].WriteToStringBuilder(stringBuilder);
+                    if (i + 1 < keyboardCount)
+                    {
+                        stringBuilder.Append(",\n");
+                    }
                 }
             }
+
             stringBuilder.Append("\n],\n\"mouse\":[\n");
-            var mouseCount = mouse.Count;
-            for (var i = 0; i < mouseCount; i++)
+            if (mouse != null)
             {
-                mouse[i].WriteToStringBuilder(stringBuilder);
-                if (i + 1 < mouseCount)
+                var mouseCount = mouse.Count;
+                for (var i = 0; i < mouseCount; i++)
                 {
-                    stringBuilder.Append(",\n");
+                    mouse[i].WriteToStringBuilder(stringBuilder);
+                    if (i + 1 < mouseCount)
+                    {
+                        stringBuilder.Append(",\n");
+                    }
                 }
             }
             stringBuilder.Append("\n]\n}");

--- a/src/gg.regression.unity.bots/Runtime/Scripts/Types/PlaybackResult.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/Types/PlaybackResult.cs
@@ -7,12 +7,20 @@ namespace RegressionGames.Types
     public class PlaybackResult
     {
 
-        /// <summary>
-        /// The location that the playback recording is saved to on disk.
-        /// </summary>
+        /**
+         * <summary>The location that the playback recording is saved to on disk.</summary>
+         */
         public string saveLocation;
 
+        /**
+         * <summary>Did this playback succeed (true) or timeout (false)</summary>
+         */
         public bool success;
+
+        /**
+         * <summary>The last status of the playback when it timed out.  Generally only populated when 'success' is false</summary>
+         */
+        public string statusMessage;
 
     }
 

--- a/src/gg.regression.unity.bots/Tests/Scripts/ActionManager/RGActionManagerTests.cs
+++ b/src/gg.regression.unity.bots/Tests/Scripts/ActionManager/RGActionManagerTests.cs
@@ -1,10 +1,8 @@
-using System;
 using System.Collections;
 using System.Linq;
 using System.Text;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
-using RegressionGames;
 using RegressionGames.ActionManager;
 using RegressionGames.ActionManager.Actions;
 using RegressionGames.RGLegacyInputUtility;
@@ -15,7 +13,6 @@ using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
-using UnityEngine.UI;
 using Object = UnityEngine.Object;
 
 namespace RegressionGames.Tests.ActionManager
@@ -228,6 +225,7 @@ namespace RegressionGames.Tests.ActionManager
             InputSystem.onAfterUpdate -= OnAfterInputSystemUpdate;
 
             RGLegacyInputWrapper.UpdateMode = RGLegacyInputUpdateMode.AUTOMATIC;
+            MouseEventSender.Reset();
         }
 
         private void OnAfterInputSystemUpdate()

--- a/src/gg.regression.unity.bots/Tests/Scripts/BotSegments.meta
+++ b/src/gg.regression.unity.bots/Tests/Scripts/BotSegments.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 34c2641010324d8d83f882fa8889a085
+timeCreated: 1730464654

--- a/src/gg.regression.unity.bots/Tests/Scripts/BotSegments/BotSegmentsTests.cs
+++ b/src/gg.regression.unity.bots/Tests/Scripts/BotSegments/BotSegmentsTests.cs
@@ -17,11 +17,6 @@ namespace RegressionGames.Tests.BotSegments
     [TestFixture]
     public class BotSegmentsTests : InputTestFixture
     {
-        [OneTimeSetUp]
-        public void OneTimeSetUp()
-        {
-            MouseEventSender.InitializeVirtualMouse();
-        }
 
          [UnitySetUp]
         public IEnumerator SetUp()
@@ -37,6 +32,7 @@ namespace RegressionGames.Tests.BotSegments
             SceneManager.LoadSceneAsync("UniRxTestScene", LoadSceneMode.Single);
             yield return RGTestUtils.WaitForScene("UniRxTestScene");
 
+            MouseEventSender.InitializeVirtualMouse();
         }
 
         [UnityTest]
@@ -161,12 +157,8 @@ namespace RegressionGames.Tests.BotSegments
             }
 
             SceneManager.UnloadSceneAsync("UniRxTestScene");
-        }
-
-        [OneTimeTearDown]
-        public void OneTimeTearDown()
-        {
             MouseEventSender.Reset();
         }
+
     }
 }

--- a/src/gg.regression.unity.bots/Tests/Scripts/BotSegments/BotSegmentsTests.cs
+++ b/src/gg.regression.unity.bots/Tests/Scripts/BotSegments/BotSegmentsTests.cs
@@ -7,7 +7,6 @@ using RegressionGames.StateRecorder.Models;
 using RegressionGames.TestFramework;
 using RegressionGames.Types;
 using UnityEngine;
-using UnityEngine.InputSystem;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 using Object = UnityEngine.Object;
@@ -15,7 +14,7 @@ using Object = UnityEngine.Object;
 namespace RegressionGames.Tests.BotSegments
 {
     [TestFixture]
-    public class BotSegmentsTests : InputTestFixture
+    public class BotSegmentsTests
     {
 
          [UnitySetUp]
@@ -97,13 +96,29 @@ namespace RegressionGames.Tests.BotSegments
                             new MouseInputActionData()
                             {
                                 startTime = 0.1f,
-                                leftButton = true,
+                                leftButton = false,
                                 position = new Vector2Int(700, 630),
                                 screenSize = new Vector2Int(1920,1080)
                             },
                             new MouseInputActionData()
                             {
                                 startTime = 0.2f,
+                                leftButton = true,
+                                position = new Vector2Int(700, 630),
+                                screenSize = new Vector2Int(1920,1080),
+                                clickedObjectNormalizedPaths = new []{"Canvas/LegacyButton (Button)"}
+                            },
+                            new MouseInputActionData()
+                            {
+                                startTime = 0.3f,
+                                leftButton = false,
+                                position = new Vector2Int(700, 630),
+                                screenSize = new Vector2Int(1920,1080),
+                                clickedObjectNormalizedPaths = new []{"Canvas/LegacyButton (Button)"}
+                            },
+                            new MouseInputActionData()
+                            {
+                                startTime = 0.4f,
                                 leftButton = false,
                                 position = new Vector2Int(700, 630),
                                 screenSize = new Vector2Int(1920,1080)
@@ -127,7 +142,7 @@ namespace RegressionGames.Tests.BotSegments
             {
                 new ()
                 {
-                    type = KeyFrameCriteriaType.NormalizedPath,
+                    type = KeyFrameCriteriaType.PartialNormalizedPath,
                     data = new PathKeyFrameCriteriaData()
                     {
                         count = 1,

--- a/src/gg.regression.unity.bots/Tests/Scripts/BotSegments/BotSegmentsTests.cs
+++ b/src/gg.regression.unity.bots/Tests/Scripts/BotSegments/BotSegmentsTests.cs
@@ -1,0 +1,172 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using RegressionGames.StateRecorder;
+using RegressionGames.StateRecorder.BotSegments.Models;
+using RegressionGames.StateRecorder.Models;
+using RegressionGames.TestFramework;
+using RegressionGames.Types;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+using Object = UnityEngine.Object;
+
+namespace RegressionGames.Tests.BotSegments
+{
+    [TestFixture]
+    public class BotSegmentsTests : InputTestFixture
+    {
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            MouseEventSender.InitializeVirtualMouse();
+        }
+
+         [UnitySetUp]
+        public IEnumerator SetUp()
+        {
+            var botManager = Object.FindObjectOfType<RGBotManager>();
+            if (botManager != null)
+            {
+                // destroy any existing overlay before loading new test scene
+                Object.Destroy(botManager.gameObject);
+            }
+
+            // Wait for the scene
+            SceneManager.LoadSceneAsync("UniRxTestScene", LoadSceneMode.Single);
+            yield return RGTestUtils.WaitForScene("UniRxTestScene");
+
+        }
+
+        [UnityTest]
+        public IEnumerator TestRGUtilsBotActionsAndCriteria()
+        {
+            PlaybackResult sequenceResult = null;
+
+            // validate that the 'clicked' text is NOT visible
+            var botCriteria = new List<KeyFrameCriteria>()
+            {
+                new ()
+                {
+                    type = KeyFrameCriteriaType.NormalizedPath,
+                    data = new PathKeyFrameCriteriaData()
+                    {
+                        count = 0,
+                        countRule = CountRule.Zero,
+                        path = "Text-Clicked"
+                    }
+                }
+            };
+
+            yield return RGTestUtils.WaitForBotCriteria(botCriteria,result => sequenceResult = result, timeout: 5);
+            if (!sequenceResult.success)
+            {
+                RGDebug.LogWarning("Text-Clicked was visible, but shouldn't have been");
+            }
+            Assert.IsTrue(sequenceResult.success);
+
+            // check that the negative case will result in a failure (false) value
+            botCriteria = new List<KeyFrameCriteria>()
+            {
+                new ()
+                {
+                    type = KeyFrameCriteriaType.NormalizedPath,
+                    data = new PathKeyFrameCriteriaData()
+                    {
+                        count = 1,
+                        countRule = CountRule.NonZero,
+                        path = "Text-Clicked"
+                    }
+                }
+            };
+            yield return RGTestUtils.WaitForBotCriteria(botCriteria,result => sequenceResult = result, timeout: 5);
+            if (sequenceResult.success)
+            {
+                RGDebug.LogWarning("Text-Clicked was visible, but shouldn't have been");
+            }
+            Assert.IsTrue(!sequenceResult.success);
+
+            // click the Button Button (<- that is the title of the button)
+            var botAction = new BotAction()
+            {
+                type = BotActionType.InputPlayback,
+                data = new InputPlaybackActionData()
+                {
+                    startTime = 0,
+                    inputData = new InputData()
+                    {
+                        mouse = new List<MouseInputActionData>()
+                        {
+                            new MouseInputActionData()
+                            {
+                                startTime = 0.1f,
+                                leftButton = true,
+                                position = new Vector2Int(700, 630),
+                                screenSize = new Vector2Int(1920,1080)
+                            },
+                            new MouseInputActionData()
+                            {
+                                startTime = 0.2f,
+                                leftButton = false,
+                                position = new Vector2Int(700, 630),
+                                screenSize = new Vector2Int(1920,1080)
+                            }
+                        }
+                    }
+                }
+            };
+
+            yield return RGTestUtils.PerformBotAction(botAction, result => sequenceResult = result, timeout: 5);
+
+            if (!sequenceResult.success)
+            {
+                RGDebug.LogWarning("Bot action timed out");
+            }
+            Assert.IsTrue(sequenceResult.success);
+
+
+            // validate that the 'clicked' text IS visible
+            botCriteria = new List<KeyFrameCriteria>()
+            {
+                new ()
+                {
+                    type = KeyFrameCriteriaType.NormalizedPath,
+                    data = new PathKeyFrameCriteriaData()
+                    {
+                        count = 1,
+                        countRule = CountRule.NonZero,
+                        path = "Text-Clicked"
+                    }
+                }
+            };
+
+            yield return RGTestUtils.WaitForBotCriteria(botCriteria,result => sequenceResult = result, timeout: 5);
+            if (!sequenceResult.success)
+            {
+                RGDebug.LogWarning("Text-Clicked was not visible");
+            }
+            Assert.IsTrue(sequenceResult.success);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            // just get some component on the top level RGOverlayCanvas
+            var botManager = Object.FindObjectOfType<RGBotManager>();
+            if (botManager != null)
+            {
+                // remove our overlay
+                Object.Destroy(botManager.gameObject);
+            }
+
+            SceneManager.UnloadSceneAsync("UniRxTestScene");
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            MouseEventSender.Reset();
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Tests/Scripts/BotSegments/BotSegmentsTests.cs
+++ b/src/gg.regression.unity.bots/Tests/Scripts/BotSegments/BotSegmentsTests.cs
@@ -54,7 +54,7 @@ namespace RegressionGames.Tests.BotSegments
             {
                 new ()
                 {
-                    type = KeyFrameCriteriaType.NormalizedPath,
+                    type = KeyFrameCriteriaType.PartialNormalizedPath,
                     data = new PathKeyFrameCriteriaData()
                     {
                         count = 0,
@@ -76,7 +76,7 @@ namespace RegressionGames.Tests.BotSegments
             {
                 new ()
                 {
-                    type = KeyFrameCriteriaType.NormalizedPath,
+                    type = KeyFrameCriteriaType.PartialNormalizedPath,
                     data = new PathKeyFrameCriteriaData()
                     {
                         count = 1,

--- a/src/gg.regression.unity.bots/Tests/Scripts/BotSegments/BotSegmentsTests.cs
+++ b/src/gg.regression.unity.bots/Tests/Scripts/BotSegments/BotSegmentsTests.cs
@@ -1,12 +1,14 @@
 using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
+using RegressionGames.RGLegacyInputUtility;
 using RegressionGames.StateRecorder;
 using RegressionGames.StateRecorder.BotSegments.Models;
 using RegressionGames.StateRecorder.Models;
 using RegressionGames.TestFramework;
 using RegressionGames.Types;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 using Object = UnityEngine.Object;
@@ -32,6 +34,14 @@ namespace RegressionGames.Tests.BotSegments
             yield return RGTestUtils.WaitForScene("UniRxTestScene");
 
             MouseEventSender.InitializeVirtualMouse();
+
+
+            RGUtils.SetupOverrideEventSystem();
+
+            GameObject eventSystem = GameObject.Find("EventSystem");
+            var eventSys = eventSystem.GetComponent<EventSystem>();
+            RGLegacyInputWrapper.UpdateMode = RGLegacyInputUpdateMode.AUTOMATIC;
+            RGLegacyInputWrapper.StartSimulation(eventSys);
         }
 
         [UnityTest]
@@ -173,6 +183,10 @@ namespace RegressionGames.Tests.BotSegments
 
             SceneManager.UnloadSceneAsync("UniRxTestScene");
             MouseEventSender.Reset();
+
+            RGLegacyInputWrapper.StopSimulation();
+
+            RGUtils.TeardownOverrideEventSystem();
         }
 
     }

--- a/src/gg.regression.unity.bots/Tests/Scripts/BotSegments/BotSegmentsTests.cs.meta
+++ b/src/gg.regression.unity.bots/Tests/Scripts/BotSegments/BotSegmentsTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 550f04d72c274de88ff720daea49b6cb
+timeCreated: 1730464658

--- a/src/gg.regression.unity.bots/Tests/Scripts/GameScene/GameSceneTests.cs
+++ b/src/gg.regression.unity.bots/Tests/Scripts/GameScene/GameSceneTests.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Collections;
-
+using System.Collections.Generic;
 using NUnit.Framework;
 using RegressionGames.StateRecorder;
+using RegressionGames.StateRecorder.BotSegments.Models;
 using RegressionGames.StateRecorder.Types;
 using RegressionGames.TestFramework;
 using RegressionGames.Types;
@@ -86,6 +87,30 @@ namespace RegressionGames.Tests.Z_RunMeLast_GameScene
             Assert.IsNotNull(sequenceResult.saveLocation);
 
         }
+
+        public void GeneratedBotSequenceTest_LoadAndSave()
+        {
+
+            // issue this all happens on the main thread, but we need to be able to do multiple sets of actions/criteria in a single update call :/
+
+            // await do actions - this needs to be able to evaluate every update call while we wait
+            //                    this also needs to be interleaved with the checks for end criteria
+
+            // what does an action look like in code ?
+
+
+            // await end criteria - this needs to be able to evaluate every update call while we wait
+
+
+            /// -- repeat N times for number of ticks
+
+        }
+
+        private BotSegment botSeg = new BotSegment()
+        {
+            endCriteria = new List<KeyFrameCriteria>(),
+            botAction = null
+        };
 
         [TearDown]
         public void TearDown()

--- a/src/gg.regression.unity.bots/Tests/Scripts/GameScene/GameSceneTests.cs
+++ b/src/gg.regression.unity.bots/Tests/Scripts/GameScene/GameSceneTests.cs
@@ -88,30 +88,6 @@ namespace RegressionGames.Tests.Z_RunMeLast_GameScene
 
         }
 
-        public void GeneratedBotSequenceTest_LoadAndSave()
-        {
-
-            // issue this all happens on the main thread, but we need to be able to do multiple sets of actions/criteria in a single update call :/
-
-            // await do actions - this needs to be able to evaluate every update call while we wait
-            //                    this also needs to be interleaved with the checks for end criteria
-
-            // what does an action look like in code ?
-
-
-            // await end criteria - this needs to be able to evaluate every update call while we wait
-
-
-            /// -- repeat N times for number of ticks
-
-        }
-
-        private BotSegment botSeg = new BotSegment()
-        {
-            endCriteria = new List<KeyFrameCriteria>(),
-            botAction = null
-        };
-
         [TearDown]
         public void TearDown()
         {
@@ -134,6 +110,7 @@ namespace RegressionGames.Tests.Z_RunMeLast_GameScene
             {
                 SetEditorAspectRatio(oldIndex);
             }
+            MouseEventSender.Reset();
         }
 
         private void SetEditorAspectRatio(int index)

--- a/src/gg.regression.unity.bots/Tests/Scripts/RGOverlay/RGCreateNewSequenceButton.test.cs
+++ b/src/gg.regression.unity.bots/Tests/Scripts/RGOverlay/RGCreateNewSequenceButton.test.cs
@@ -84,7 +84,7 @@ namespace RegressionGames.Tests.RGOverlay
                     parent = sequenceManager.transform
                 }
             };
-            editor.titleComponent = RGTestUtils.CreateTMProPlaceholder(_uat.transform);
+            editor.titleComponent = TestHelpers.CreateTMProPlaceholder(_uat.transform);
             var ni = new GameObject
             {
                 transform =

--- a/src/gg.regression.unity.bots/Tests/Scripts/RGOverlay/RGDeleteSequence.test.cs
+++ b/src/gg.regression.unity.bots/Tests/Scripts/RGOverlay/RGDeleteSequence.test.cs
@@ -35,7 +35,7 @@ namespace RegressionGames.Tests.RGOverlay
             // create the delete script we want to test
             _uat = new GameObject();
             deleter = _uat.AddComponent<RGDeleteSequence>();
-            deleter.sequenceNamePrefab = RGTestUtils.CreateTMProPlaceholder(_uat.transform);
+            deleter.sequenceNamePrefab = TestHelpers.CreateTMProPlaceholder(_uat.transform);
             deleter.confirmButton = new GameObject(){
                 transform =
                 {

--- a/src/gg.regression.unity.bots/Tests/Scripts/RGOverlay/RGDraggableCard.test.cs
+++ b/src/gg.regression.unity.bots/Tests/Scripts/RGOverlay/RGDraggableCard.test.cs
@@ -46,7 +46,7 @@ namespace RegressionGames.Tests.RGOverlay
             card.draggableCardDescription = "Card Description";
 
             // add placeholder text fields to the card
-            var text = RGTestUtils.CreateTMProPlaceholder(_uat.transform);
+            var text = TestHelpers.CreateTMProPlaceholder(_uat.transform);
             card.namePrefab = text;
             card.descriptionPrefab = text;
             card.resourcePathPrefab = text;
@@ -74,9 +74,9 @@ namespace RegressionGames.Tests.RGOverlay
                 }
             };
             draggedCard.iconPrefab.AddComponent<Image>();
-            draggedCard.nameComponent = RGTestUtils.CreateTMProPlaceholder(_uat.transform);
-            draggedCard.resourcePathComponent = RGTestUtils.CreateTMProPlaceholder(_uat.transform);
-            card.icon = RGTestUtils.CreateSpritePlaceholder();
+            draggedCard.nameComponent = TestHelpers.CreateTMProPlaceholder(_uat.transform);
+            draggedCard.resourcePathComponent = TestHelpers.CreateTMProPlaceholder(_uat.transform);
+            card.icon = TestHelpers.CreateSpritePlaceholder();
             card.iconPrefab = new GameObject(){
                 transform =
                 {

--- a/src/gg.regression.unity.bots/Tests/Scripts/RGOverlay/RGDraggedCard.test.cs
+++ b/src/gg.regression.unity.bots/Tests/Scripts/RGOverlay/RGDraggedCard.test.cs
@@ -44,8 +44,8 @@ namespace RegressionGames.Tests.RGOverlay
                     parent = _uat.transform
                 }
             };
-            card.nameComponent = RGTestUtils.CreateTMProPlaceholder(_uat.transform);
-            card.resourcePathComponent = RGTestUtils.CreateTMProPlaceholder(_uat.transform);
+            card.nameComponent = TestHelpers.CreateTMProPlaceholder(_uat.transform);
+            card.resourcePathComponent = TestHelpers.CreateTMProPlaceholder(_uat.transform);
             card.Start();
         }
 

--- a/src/gg.regression.unity.bots/Tests/Scripts/RGOverlay/RGSegmentEntry.test.cs
+++ b/src/gg.regression.unity.bots/Tests/Scripts/RGOverlay/RGSegmentEntry.test.cs
@@ -39,8 +39,8 @@ namespace RegressionGames.Tests.RGOverlay
             entry.description = "TestDescription";
             entry.filePath = "test/path";
             entry.type = BotSequenceEntryType.Segment;
-            entry.nameComponent = RGTestUtils.CreateTMProPlaceholder(_uat.transform);
-            entry.descriptionComponent = RGTestUtils.CreateTMProPlaceholder(_uat.transform);
+            entry.nameComponent = TestHelpers.CreateTMProPlaceholder(_uat.transform);
+            entry.descriptionComponent = TestHelpers.CreateTMProPlaceholder(_uat.transform);
             entry.playButton = _uat.AddComponent<Button>();
 
             // create tooltip child

--- a/src/gg.regression.unity.bots/Tests/Scripts/RGOverlay/RGSequenceEditor.test.cs
+++ b/src/gg.regression.unity.bots/Tests/Scripts/RGOverlay/RGSequenceEditor.test.cs
@@ -54,7 +54,7 @@ namespace RegressionGames.Tests.RGOverlay
             editor.NameInput = text;
             editor.DescriptionInput = text;
             editor.SearchInput = text;
-            editor.titleComponent = RGTestUtils.CreateTMProPlaceholder(_uat.transform);
+            editor.titleComponent = TestHelpers.CreateTMProPlaceholder(_uat.transform);
             editor.AvailableSegmentsList = new GameObject(){
                 transform =
                 {
@@ -75,9 +75,9 @@ namespace RegressionGames.Tests.RGOverlay
                 },
             };
             editor.DropZonePrefab = dropZone;
-            editor.SegmentListIcon = RGTestUtils.CreateSpritePlaceholder();
-            editor.SegmentIcon = RGTestUtils.CreateSpritePlaceholder();
-            editor.SegmentListIcon = RGTestUtils.CreateSpritePlaceholder();
+            editor.SegmentListIcon = TestHelpers.CreateSpritePlaceholder();
+            editor.SegmentIcon = TestHelpers.CreateSpritePlaceholder();
+            editor.SegmentListIcon = TestHelpers.CreateSpritePlaceholder();
 
             // mock segment entries for the editor to utilize
             segments = new List<BotSequenceEntry>()

--- a/src/gg.regression.unity.bots/Tests/Scripts/RGOverlay/RGSequenceEntry.test.cs
+++ b/src/gg.regression.unity.bots/Tests/Scripts/RGOverlay/RGSequenceEntry.test.cs
@@ -60,8 +60,8 @@ namespace RegressionGames.Tests.RGOverlay
                     parent = _uat.transform
                 }
             }.AddComponent<Button>();
-            entry.nameComponent = RGTestUtils.CreateTMProPlaceholder(_uat.transform);
-            entry.descriptionComponent = RGTestUtils.CreateTMProPlaceholder(_uat.transform);
+            entry.nameComponent = TestHelpers.CreateTMProPlaceholder(_uat.transform);
+            entry.descriptionComponent = TestHelpers.CreateTMProPlaceholder(_uat.transform);
 
             // mocks for the Sequence Editor + Manager
             manager = _uat.AddComponent<RGSequenceManager>();
@@ -99,7 +99,7 @@ namespace RegressionGames.Tests.RGOverlay
                     parent = _uat.transform
                 }
             };
-            editor.titleComponent = RGTestUtils.CreateTMProPlaceholder(_uat.transform);
+            editor.titleComponent = TestHelpers.CreateTMProPlaceholder(_uat.transform);
             var ni = new GameObject
             {
                 transform =

--- a/src/gg.regression.unity.bots/Tests/Scripts/RGUtilsTests.cs
+++ b/src/gg.regression.unity.bots/Tests/Scripts/RGUtilsTests.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using NUnit.Framework;
-using RegressionGames;
 
 namespace RegressionGames.Tests
 {

--- a/src/gg.regression.unity.bots/Tests/Scripts/TestHelpers.cs
+++ b/src/gg.regression.unity.bots/Tests/Scripts/TestHelpers.cs
@@ -1,0 +1,52 @@
+﻿using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace RegressionGames.Tests
+{
+    public class TestHelpers
+    {
+        /** <summary>
+         * Creates a placeholder for an instance of Sprite
+         * </summary>
+         */
+        public static Sprite CreateSpritePlaceholder()
+        {
+            return Sprite.Create(
+                new Texture2D(10, 10),
+                new Rect(0, 0, 10, 10),
+                new Vector2(0.5f, 0.5f),
+                100
+            );
+        }
+
+        /** <summary>
+         * Creates a placeholder for an instance of TMP_Text. This can be used to mock TMPro inputs
+         * </summary>
+         */
+        public static TMP_Text CreateTMProPlaceholder(Transform _parent)
+        {
+            var textObject = new GameObject()
+            {
+                transform =
+                {
+                    parent = _parent.transform
+                }
+            };
+            var placeholder = textObject.AddComponent<TextPlaceholder>();
+            return placeholder;
+        }
+
+        /** <summary>
+         * Implements the TMP_Text abstract class, in order to act as a placeholder for TMPro inputs
+         * </summary>
+         */
+        private class TextPlaceholder : TMP_Text
+        {
+            protected override void OnPopulateMesh(VertexHelper toFill)
+            {
+                toFill.Clear();
+            }
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Tests/Scripts/TestHelpers.cs.meta
+++ b/src/gg.regression.unity.bots/Tests/Scripts/TestHelpers.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8f78453ee45e4844962b01c543e83b28
+timeCreated: 1730384677

--- a/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/RGTestUtils.cs
+++ b/src/gg.regression.unity.bots/Tests/TestFramework/Scripts/RGTestUtils.cs
@@ -1,29 +1,36 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using RegressionGames.StateRecorder;
 using RegressionGames.StateRecorder.BotSegments;
 using RegressionGames.StateRecorder.BotSegments.Models;
+using RegressionGames.StateRecorder.Models;
 using RegressionGames.Types;
 using StateRecorder.BotSegments;
-using TMPro;
 using UnityEngine;
 using UnityEngine.Assertions;
 using UnityEngine.SceneManagement;
-using UnityEngine.UI;
 using Object = UnityEngine.Object;
 
+// ReSharper disable UnusedMember.Global - These are helper methods for customer projects, don't remove them
+// ReSharper disable MemberCanBePrivate.Global - These are helper methods for customer projects, don't make them private
 namespace RegressionGames.TestFramework
 {
-    /// <summary>
-    /// Utilities for running tests within the Unity Test Runner using Regression Games features.
-    /// </summary>
+    /**
+     * <summary>
+     * Utilities for running tests within the Unity Test Runner using Regression Games features.
+     * </summary>
+     */
     public class RGTestUtils
     {
-
-        /// <summary>
-        /// Waits until a specific scene has been loaded, and asserts that it has been loaded
-        /// </summary>
-        /// <param name="sceneName">The name of the scene to wait for</param>
-        /// <param name="timeout">The maximum time to wait for the scene to load (in seconds). Defaults to 5.</param>
+        /**
+         * <summary>
+         * Waits until a specific scene has been loaded, and asserts that it has been loaded
+         * </summary>
+         * <param name="sceneName">The name of the scene to wait for</param>
+         * <param name="timeout">The maximum time to wait for the scene to load (in seconds). Defaults to 5.</param>
+         */
         public static IEnumerator WaitForScene(string sceneName, int timeout = 5)
         {
             var startTime = Time.unscaledTime;
@@ -40,19 +47,23 @@ namespace RegressionGames.TestFramework
                         break;
                     }
                 }
+
                 yield return null;
             }
+
             yield return null;
             Assert.IsTrue(loaded, $"Scene {sceneName} failed to load within {timeout} seconds");
         }
 
-        /// <summary>
-        /// Wait for the specified condition to become true with a timeout.
-        /// This is similar to WaitUntil(), but also includes a failing assertion if the timeout expires.
-        /// </summary>
-        /// <param name="condition">The condition that should become true</param>
-        /// <param name="timeout">Maximum time to wait for the condition to become true (in seconds)</param>
-        /// <param name="message">Message to display upon failure (optional)</param>
+        /**
+         * <summary>
+         * Wait for the specified condition to become true with a timeout.
+         * This is similar to WaitUntil(), but also includes a failing assertion if the timeout expires.
+         * </summary>
+         * <param name="condition">The condition that should become true</param>
+         * <param name="timeout">Maximum time to wait for the condition to become true (in seconds)</param>
+         * <param name="message">Message to display upon failure (optional)</param>
+         */
         public static IEnumerator WaitUntil(Func<bool> condition, int timeout = 5, string message = null)
         {
             var startTime = Time.unscaledTime;
@@ -62,12 +73,15 @@ namespace RegressionGames.TestFramework
             Assert.IsTrue(result, message ?? $"Condition did not become true within {timeout} seconds");
         }
 
-        /// <summary>
-        /// Plays back an existing recording, and then returns the save location of the recording.
-        /// </summary>
-        /// <param name="recordingPath">The path to the recording to play back (the full data.zip file path)</param>
-        /// <param name="setPlaybackResult">A callback that will be called with the results of this playback</param>
-        public static IEnumerator StartPlaybackFromZipFile(string recordingPath, Action<PlaybackResult> setPlaybackResult)
+        /**
+         * <summary>
+         * Plays back an existing recording, and then returns the save location of the recording.
+         * </summary>
+         * <param name="recordingPath">The path to the recording to play back (the full data.zip file path)</param>
+         * <param name="setPlaybackResult">A callback that will be called with the results of this playback</param>
+         * <param name="timeout">How long in seconds to wait for this segment to complete, &lt;=0 means wait forever (default)</param>
+         */
+        public static IEnumerator StartPlaybackFromZipFile(string recordingPath, Action<PlaybackResult> setPlaybackResult, int timeout = 0)
         {
             RGDebug.LogInfo("Loading and starting playback recording from " + recordingPath);
             var playbackController = Object.FindObjectOfType<BotSegmentsPlaybackController>();
@@ -75,26 +89,43 @@ namespace RegressionGames.TestFramework
             var replayData = new BotSegmentsPlaybackContainer(botSegments, sessionId);
             playbackController.SetDataContainer(replayData);
             playbackController.Play();
+
             yield return null; // Allow the recording to start playing
+            var didTimeout = false;
+
+            var startTime = Time.unscaledTime;
             while (playbackController.GetState() == PlayState.Playing || playbackController.GetState() == PlayState.Paused)
             {
+                if (timeout > 0 && Time.unscaledTime > startTime + timeout)
+                {
+                    didTimeout = true;
+                    break;
+                }
+
                 yield return null;
             }
+
             yield return null;
-            RGDebug.LogInfo("Playback complete!");
+            RGDebug.LogInfo("Playback complete! - " + (didTimeout ? "TIMEOUT" : "SUCCESS"));
             var result = new PlaybackResult
             {
-                saveLocation = playbackController.SaveLocation() + ".zip"
+                saveLocation = playbackController.SaveLocation() + ".zip",
+                success = !didTimeout,
+                statusMessage = didTimeout?playbackController.GetLastSegmentPlaybackWarning():null
             };
             setPlaybackResult(result);
+            playbackController.Stop();
         }
 
-        /// <summary>
-        /// Plays back an existing recording, and then returns the save location of the recording.
-        /// </summary>
-        /// <param name="recordingPath">The path to the recording to play back.  Directory of numeric json files.</param>
-        /// <param name="setPlaybackResult">A callback that will be called with the results of this playback</param>
-        public static IEnumerator StartPlaybackFromDirectory(string recordingPath, Action<PlaybackResult> setPlaybackResult)
+        /**
+         * <summary>
+         * Plays back an existing recording, and then returns the save location of the recording.
+         * </summary>
+         * <param name="recordingPath">The path to the recording to play back.  Directory of numeric json files.</param>
+         * <param name="setPlaybackResult">A callback that will be called with the results of this playback</param>
+         * <param name="timeout">How long in seconds to wait for this segment to complete, &lt;= 0 means wait forever (default)</param>
+         */
+        public static IEnumerator StartPlaybackFromDirectory(string recordingPath, Action<PlaybackResult> setPlaybackResult, int timeout = 0)
         {
             RGDebug.LogInfo("Loading and starting playback recording from " + recordingPath);
             var playbackController = Object.FindObjectOfType<BotSegmentsPlaybackController>();
@@ -102,96 +133,348 @@ namespace RegressionGames.TestFramework
             var replayData = new BotSegmentsPlaybackContainer(botSegments, sessionId);
             playbackController.SetDataContainer(replayData);
             playbackController.Play();
+
             yield return null; // Allow the recording to start playing
+            var didTimeout = false;
+
+            var startTime = Time.unscaledTime;
             while (playbackController.GetState() == PlayState.Playing || playbackController.GetState() == PlayState.Paused)
+            {
+                if (timeout > 0 && Time.unscaledTime > startTime + timeout)
+                {
+                    didTimeout = true;
+                    break;
+                }
+
+                yield return null;
+            }
+
+            yield return null;
+            RGDebug.LogInfo("Playback complete! - " + (didTimeout ? "TIMEOUT" : "SUCCESS"));
+            var result = new PlaybackResult
+            {
+                saveLocation = playbackController.SaveLocation() + ".zip",
+                success = !didTimeout,
+                statusMessage = didTimeout?playbackController.GetLastSegmentPlaybackWarning():null
+            };
+            setPlaybackResult(result);
+            playbackController.Stop();
+        }
+
+        /**
+         * <summary>
+         * Runs a bot action and waits for it to complete, then returns success or failure
+         * </summary>
+         * <param name="botCriteria">The List of KeyFrameCriteria to wait for</param>
+         * <param name="setPlaybackResult">A callback that will be called with the results of this playback</param>
+         * <param name="timeout">How long in seconds to wait for this check to complete, &lt;= 0 means wait forever (default)</param>
+         */
+        public static IEnumerator WaitForBotCriteria(List<KeyFrameCriteria> botCriteria, Action<PlaybackResult> setPlaybackResult, int timeout = 0)
+        {
+            RGDebug.LogInfo("Waiting for match of bot criteria: " + string.Join(",", botCriteria.ToArray().Select(a=>a.ToString())));
+
+            // persist the starting state as the last successful key frame so that counts are reasonable and doesn't show everything as added on every evaluation
+            KeyFrameEvaluator.Evaluator.PersistPriorFrameStatus();
+
+            // wait a frame before starting evaluation
+            yield return null;
+
+            var matched = botCriteria.Count == 0;
+
+            var didTimeout = false;
+
+            var startTime = Time.unscaledTime;
+
+            while (!matched)
+            {
+                if (timeout > 0 && Time.unscaledTime > startTime + timeout)
+                {
+                    didTimeout = true;
+                    break;
+                }
+
+                matched = KeyFrameEvaluator.Evaluator.Matched(
+                    true,
+                    0,
+                    true,
+                    botCriteria
+                    );
+
+                if (!matched)
+                {
+                    // wait a frame before checking again each time
+                    yield return null;
+                }
+            }
+
+            RGDebug.LogInfo("Wait for match of bot criteria complete! - " + (didTimeout ? "TIMEOUT" : "SUCCESS"));
+            var result = new PlaybackResult
+            {
+                saveLocation = null, // not applicable for this
+                success = !didTimeout,
+                statusMessage = didTimeout ? KeyFrameEvaluator.Evaluator.GetUnmatchedCriteria() : null
+            };
+            setPlaybackResult(result);
+            KeyFrameEvaluator.Evaluator.Reset();
+
+        }
+
+        /**
+         * <summary>
+         * Runs a bot action and waits for it to complete, then returns success or failure
+         * </summary>
+         * <param name="botAction">The bot action</param>
+         * <param name="setPlaybackResult">A callback that will be called with the results of this playback</param>
+         * <param name="timeout">How long in seconds to wait for this action to complete, &lt;= 0 means wait forever (default)</param>
+         */
+        public static IEnumerator PerformBotAction(BotAction botAction, Action<PlaybackResult> setPlaybackResult, int timeout = 0)
+        {
+            RGDebug.LogInfo("Starting bot action of type: " + botAction.type);
+
+            var objectFinders = Object.FindObjectsByType<ObjectFinder>(FindObjectsSortMode.None);
+
+            Dictionary<long, ObjectStatus> transformStatuses = null;
+            Dictionary<long, ObjectStatus> entityStatuses = null;
+
+            foreach (var objectFinder in objectFinders)
+            {
+                if (objectFinder is TransformObjectFinder)
+                {
+                    transformStatuses = objectFinder.GetObjectStatusForCurrentFrame().Item2;
+                }
+                else
+                {
+                    entityStatuses = objectFinder.GetObjectStatusForCurrentFrame().Item2;
+                }
+            }
+
+            transformStatuses ??= new Dictionary<long, ObjectStatus>();
+            entityStatuses ??= new Dictionary<long, ObjectStatus>();
+
+            botAction.StartAction(0, transformStatuses, entityStatuses);
+            // process the action the first time
+            botAction.ProcessAction(0, transformStatuses, entityStatuses, out var lastError);
+
+            var didTimeout = false;
+
+            var startTime = Time.unscaledTime;
+            while (botAction?.IsCompleted != true)
+            {
+                // wait a frame before calling process again each time
+                yield return null;
+                if (timeout > 0 && Time.unscaledTime > startTime + timeout)
+                {
+                    didTimeout = true;
+                    break;
+                }
+
+                foreach (var objectFinder in objectFinders)
+                {
+                    if (objectFinder is TransformObjectFinder)
+                    {
+                        transformStatuses = objectFinder.GetObjectStatusForCurrentFrame().Item2;
+                    }
+                    else
+                    {
+                        entityStatuses = objectFinder.GetObjectStatusForCurrentFrame().Item2;
+                    }
+                }
+
+                transformStatuses ??= new Dictionary<long, ObjectStatus>();
+                entityStatuses ??= new Dictionary<long, ObjectStatus>();
+
+                // process the action
+                botAction.ProcessAction(0, transformStatuses, entityStatuses, out lastError);
+            }
+
+            yield return null;
+            RGDebug.LogInfo("Bot action complete! - " + (didTimeout ? "TIMEOUT" : (string.IsNullOrEmpty(lastError)?"SUCCESS":"ERROR")));
+            var result = new PlaybackResult
+            {
+                saveLocation = null, // not applicable for this
+                success = !didTimeout && string.IsNullOrEmpty(lastError),
+                statusMessage = lastError
+            };
+            setPlaybackResult(result);
+            botAction.AbortAction(0);
+
+        }
+
+        /**
+         * <summary>
+         * Plays back a bot segment, and then returns the save location of the recording.
+         * </summary>
+         * <param name="botSegment">The bot segment</param>
+         * <param name="setPlaybackResult">A callback that will be called with the results of this playback</param>
+         * <param name="timeout">How long in seconds to wait for this segment to complete, &lt;= 0 means wait forever (default)</param>
+         */
+        public static IEnumerator StartBotSegment(BotSegment botSegment, Action<PlaybackResult> setPlaybackResult, int timeout = 0)
+        {
+            RGDebug.LogInfo("Starting bot segment from path: " + botSegment.resourcePath);
+
+            var playbackController = Object.FindObjectOfType<BotSegmentsPlaybackController>();
+
+            playbackController.SetDataContainer(new BotSegmentsPlaybackContainer(new[] { botSegment }));
+
+            playbackController.Play();
+
+            yield return null; // Allow the recording to start playing
+            var didTimeout = false;
+
+            var startTime = Time.unscaledTime;
+            while (playbackController.GetState() == PlayState.Playing || playbackController.GetState() == PlayState.Paused)
+            {
+                if (timeout > 0 && Time.unscaledTime > startTime + timeout)
+                {
+                    didTimeout = true;
+                    break;
+                }
+
+                yield return null;
+            }
+
+            yield return null;
+            RGDebug.LogInfo("Playback complete! - " + (didTimeout ? "TIMEOUT" : "SUCCESS"));
+            var result = new PlaybackResult
+            {
+                saveLocation = playbackController.SaveLocation() + ".zip",
+                success = !didTimeout,
+                statusMessage = didTimeout?playbackController.GetLastSegmentPlaybackWarning():null
+            };
+            setPlaybackResult(result);
+            playbackController.Stop();
+        }
+
+        /**
+         * <summary>
+         * Plays back a bot segment list, and then returns the save location of the recording.
+         * </summary>
+         * <param name="botSegmentList">The bot segment list</param>
+         * <param name="setPlaybackResult">A callback that will be called with the results of this playback</param>
+         * <param name="timeout">How long in seconds to wait for this segment to complete, &lt;= 0 means wait forever (default)</param>
+         */
+        public static IEnumerator StartBotSegmentList(BotSegmentList botSegmentList, Action<PlaybackResult> setPlaybackResult, int timeout = 0)
+        {
+            RGDebug.LogInfo("Starting bot segment list from path: " + botSegmentList.resourcePath);
+
+            var playbackController = Object.FindObjectOfType<BotSegmentsPlaybackController>();
+
+            playbackController.SetDataContainer(new BotSegmentsPlaybackContainer(botSegmentList.segments));
+
+            playbackController.Play();
+
+            yield return null; // Allow the recording to start playing
+            var didTimeout = false;
+
+            var startTime = Time.unscaledTime;
+            while (playbackController.GetState() == PlayState.Playing || playbackController.GetState() == PlayState.Paused)
+            {
+                if (timeout > 0 && Time.unscaledTime > startTime + timeout)
+                {
+                    didTimeout = true;
+                    break;
+                }
+
+                yield return null;
+            }
+
+            yield return null;
+            RGDebug.LogInfo("Playback complete! - " + (didTimeout ? "TIMEOUT" : "SUCCESS"));
+            var result = new PlaybackResult
+            {
+                saveLocation = playbackController.SaveLocation() + ".zip",
+                success = !didTimeout,
+                statusMessage = didTimeout?playbackController.GetLastSegmentPlaybackWarning():null
+            };
+            setPlaybackResult(result);
+            playbackController.Stop();
+        }
+
+        /**
+         * <summary>
+         * Plays back a bot segment or segment list, and then returns the save location of the recording.
+         * </summary>
+         * <param name="segmentPath">The relative path to the bot segment or segment list</param>
+         * <param name="setPlaybackResult">A callback that will be called with the results of this playback</param>
+         * <param name="timeout">How long in seconds to wait for this segment to complete, &lt;= 0 means wait forever (default)</param>
+         */
+        public static IEnumerator StartBotSegmentOrSegmentList(string segmentPath, Action<PlaybackResult> setPlaybackResult, int timeout = 0)
+        {
+            RGDebug.LogInfo("Loading bot segment or segment list from path: " + segmentPath);
+
+            var botSegmentInfo = BotSequence.LoadBotSegmentOrBotSegmentListFromPath(segmentPath);
+
+            if (botSegmentInfo.Item3 is BotSegment botSegment)
+            {
+                yield return StartBotSegment(botSegment, setPlaybackResult, timeout);
+            }
+            else if (botSegmentInfo.Item3 is BotSegmentList botSegmentList)
+            {
+                yield return StartBotSegmentList(botSegmentList, setPlaybackResult, timeout);
+            }
+            else
             {
                 yield return null;
             }
-            yield return null;
-            RGDebug.LogInfo("Playback complete!");
-            var result = new PlaybackResult
-            {
-                saveLocation = playbackController.SaveLocation() + ".zip"
-            };
-            setPlaybackResult(result);
         }
 
-        /// <summary>
-        /// Plays back a bot sequence, and then returns the save location of the recording.
-        /// </summary>
-        /// <param name="sequencePath">The relative path to the bot sequence</param>
-        /// <param name="setPlaybackResult">A callback that will be called with the results of this playback</param>
-        /// <param name="timeout">How long in seconds to wait for this sequence to complete, <= 0 means wait forever (default)</param>
-        public static IEnumerator StartBotSequence(string sequencePath, Action<PlaybackResult> setPlaybackResult, int timeout = 0)
+        /**
+         * <summary>
+         * Plays back a bot sequence, and then returns the save location of the recording.
+         * </summary>
+         * <param name="botSequence">The bot sequence</param>
+         * <param name="setPlaybackResult">A callback that will be called with the results of this playback</param>
+         * <param name="timeout">How long in seconds to wait for this sequence to complete, &lt;= 0 means wait forever (default)</param>
+         */
+        public static IEnumerator StartBotSequence(BotSequence botSequence, Action<PlaybackResult> setPlaybackResult, int timeout = 0)
         {
-            var startTime = Time.unscaledTime;
-            RGDebug.LogInfo("Loading and starting bot sequence from " + sequencePath);
-
-            var botSequenceInfo = BotSequence.LoadSequenceJsonFromPath(sequencePath);
-
-            botSequenceInfo.Item3.Play();
+            RGDebug.LogInfo("Starting bot sequence from path: " + botSequence.resourcePath);
+            botSequence.Play();
 
             var playbackController = Object.FindObjectOfType<BotSegmentsPlaybackController>();
 
             yield return null; // Allow the recording to start playing
             var didTimeout = false;
+
+            var startTime = Time.unscaledTime;
             while (playbackController.GetState() == PlayState.Playing || playbackController.GetState() == PlayState.Paused)
             {
-                if (timeout > 0 && Time.unscaledTime > startTime + timeout )
+                if (timeout > 0 && Time.unscaledTime > startTime + timeout)
                 {
                     didTimeout = true;
                     break;
                 }
+
                 yield return null;
             }
+
             yield return null;
-            RGDebug.LogInfo("Playback complete! - " + (didTimeout? "TIMEOUT":"SUCCESS"));
+            RGDebug.LogInfo("Playback complete! - " + (didTimeout ? "TIMEOUT" : "SUCCESS"));
             var result = new PlaybackResult
             {
                 saveLocation = playbackController.SaveLocation() + ".zip",
-                success = !didTimeout
+                success = !didTimeout,
+                statusMessage = didTimeout?playbackController.GetLastSegmentPlaybackWarning():null
             };
             setPlaybackResult(result);
-            botSequenceInfo.Item3.Stop();
+            botSequence.Stop();
         }
 
-        // <summary>
-        // Creates a placeholder for an instance of Sprite
-        // </summary>
-        public static Sprite CreateSpritePlaceholder()
+        /**
+         * <summary>
+         * Plays back a bot sequence, and then returns the save location of the recording.
+         * </summary>
+         * <param name="sequencePath">The relative path to the bot sequence</param>
+         * <param name="setPlaybackResult">A callback that will be called with the results of this playback</param>
+         * <param name="timeout">How long in seconds to wait for this sequence to complete, &lt;= 0 means wait forever (default)</param>
+         */
+        public static IEnumerator StartBotSequence(string sequencePath, Action<PlaybackResult> setPlaybackResult, int timeout = 0)
         {
-            return Sprite.Create(
-                new Texture2D(10, 10),
-                new Rect(0, 0, 10, 10),
-                new Vector2(0.5f, 0.5f),
-                100
-            );
-        }
+            RGDebug.LogInfo("Loading bot sequence from path: " + sequencePath);
 
-        // <summary>
-        // Creates a placeholder for an instance of TMP_Text. This can be used to mock TMPro inputs
-        // </summary>
-        public static TMP_Text CreateTMProPlaceholder(Transform _parent)
-        {
-            var textObject = new GameObject(){
-                transform =
-                {
-                    parent = _parent.transform
-                }
-            };
-            var placeholder = textObject.AddComponent<TextPlaceholder>();
-            return placeholder;
-        }
+            var botSequenceInfo = BotSequence.LoadSequenceJsonFromPath(sequencePath);
 
-        // <summary>
-        // Implements the TMP_Text abstract class, in order to act as a placeholder for TMPro inputs
-        // </summary>
-        private class TextPlaceholder : TMP_Text
-        {
-            protected override void OnPopulateMesh(VertexHelper toFill)
-            {
-                toFill.Clear();
-            }
+            yield return StartBotSequence(botSequenceInfo.Item3, setPlaybackResult, timeout);
         }
 
     }


### PR DESCRIPTION
- Adds APIs to our RGTestUtils to allow users to think about their Unity tests in terms of our BotActions and BotCriteria
  - Allows running a bot segment or bot segment list (in addition to the existing sequence support we had)
  - (I put these in to unlock the use of CV or other powerful criteria types in regular unity tests)
    - Allows running a bot action as a standalone test step
    - Allows waiting for bot criteria as a standalone test step
- Adds test with actions and criteria (this was hard to get right with the setup needed based on which input system and which event system was in use)
- Moves some test code to a more appropriate location 
- Hardens some code around inputData to make this easier and allow null/non-set fields instead of requiring empty objects 
- TODO: Will need to create a follow up task to document these things for both legacy and new input/event systems

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
