### PR TITLE
[REG-2153] Fix/Harden Remote workAssignments managing active sequence states

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSegmentEntry.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSegmentEntry.cs
@@ -25,22 +25,22 @@ public class RGSegmentEntry : MonoBehaviour
     public string resourcePath;
 
     public BotSequenceEntryType type;
-    
+
     /**
      * UI component fields
      */
     [SerializeField]
     public Button playButton;
-    
+
     [SerializeField]
     public TMP_Text nameComponent;
-    
+
     [SerializeField]
     public TMP_Text resourcePathComponent;
 
     [SerializeField]
     public TMP_Text descriptionComponent;
-    
+
     [SerializeField]
     public GameObject segmentListIndicatorComponent;
 
@@ -75,7 +75,7 @@ public class RGSegmentEntry : MonoBehaviour
                 resourcePathComponent.gameObject.SetActive(false);
             }
         }
-        
+
         // assign values to the UI components
         descriptionComponent.text = description;
         playButton.onClick.AddListener(OnPlay);
@@ -112,7 +112,7 @@ public class RGSegmentEntry : MonoBehaviour
             return;
         }
         toolbarManager.selectedReplayFilePath = null;
-        
+
         // set the recording toolbar's state for playing this segment
         var botManager = RGBotManager.GetInstance();
         botManager.OnBeginPlaying();
@@ -120,17 +120,15 @@ public class RGSegmentEntry : MonoBehaviour
         // create the list of segments to play. This list will either contain an individual segment, or a segment list
         var segmentList = BotSequence.CreateBotSegmentListForPath(filePath ?? resourcePath, out var sessId);
         var sessionId = sessId ?? Guid.NewGuid().ToString();
-        
+
         var playbackController = FindObjectOfType<BotSegmentsPlaybackController>();
         if (playbackController == null)
         {
             Debug.LogError("RGSegmentEntry cannot find the BotSegmentsPlaybackController in its OnPlay function");
             return;
         }
-        
+
         // play the segment
-        playbackController.Stop();
-        playbackController.Reset();
         playbackController.SetDataContainer(new BotSegmentsPlaybackContainer(segmentList.segments, sessionId));
         playbackController.Play();
     }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentsPlaybackController.cs
@@ -118,7 +118,7 @@ namespace RegressionGames.StateRecorder.BotSegments
 
         public void SetDataContainer(BotSegmentsPlaybackContainer dataPlaybackContainer)
         {
-            Stop();
+            UnloadSegmentsAndReset();
             _replaySuccessful = null;
             _lastSegmentPlaybackWarning = null;
 
@@ -212,7 +212,7 @@ namespace RegressionGames.StateRecorder.BotSegments
             }
         }
 
-        public void Stop()
+        public void UnloadSegmentsAndReset()
         {
             if (_nextBotSegments.Count > 0)
             {
@@ -251,7 +251,7 @@ namespace RegressionGames.StateRecorder.BotSegments
 
         }
 
-        public void Reset()
+        public void Stop()
         {
             _nextBotSegments.Clear();
             _playState = PlayState.Stopped;
@@ -282,7 +282,7 @@ namespace RegressionGames.StateRecorder.BotSegments
             }
         }
 
-        public void ResetForLooping()
+        public void PrepareForNextLoop()
         {
             _nextBotSegments.Clear();
             _playState = PlayState.Starting;
@@ -438,8 +438,8 @@ namespace RegressionGames.StateRecorder.BotSegments
                         {
                             var loggedMessage = $"({firstActionSegment.Replay_SegmentNumber}) - Bot Segment - Exception processing BotAction\r\n" + ex.Message;
                             LogPlaybackWarning(loggedMessage);
-                            // uncaught exception... stop the segment
-                            Stop();
+                            // uncaught exception... stop and unload the segment
+                            UnloadSegmentsAndReset();
                             throw;
                         }
                     }
@@ -561,7 +561,7 @@ namespace RegressionGames.StateRecorder.BotSegments
                 var loggedMessage = $"(?) - Bot Segment - Exception processing BotSegments\r\n" + ex.Message;
                 LogPlaybackWarning(loggedMessage);
                 // uncaught exception... stop the segment
-                Stop();
+                UnloadSegmentsAndReset();
                 throw;
             }
         }
@@ -582,12 +582,13 @@ namespace RegressionGames.StateRecorder.BotSegments
                     // we hit the end of the replay
                     if (_loopCount > -1)
                     {
-                        ResetForLooping();
+                        PrepareForNextLoop();
                         _loopCountCallback.Invoke(++_loopCount);
                     }
                     else
                     {
-                        Reset();
+                        // stop ready to play again
+                        Stop();
                         _replaySuccessful = true;
                     }
                 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
@@ -302,7 +302,7 @@ namespace RegressionGames.StateRecorder
         {
             SetDefaultButtonStates();
             // stop and clear the old replay data
-            replayDataController.Stop();
+            replayDataController.UnloadSegmentsAndReset();
         }
 
         public void ToggleRecording()
@@ -327,11 +327,13 @@ namespace RegressionGames.StateRecorder
         private void LateUpdate()
         {
             var state = replayDataController.GetState();
-            if (replayDataController.ReplayCompletedSuccessfully() != null)
+            // keep the button states up to date so that we can handle work assignments/segments/sequences without tightly wiring this into all those classes like spaghetti
+            if (state == PlayState.Stopped)
             {
-                if (state == PlayState.Stopped)
+                if (replayDataController.ReplayCompletedSuccessfully() != null)
                 {
-                    replayDataController.Reset();
+                    // stopped, but ready to play again
+                    replayDataController.Stop();
                     // playback complete
                     chooseReplayButton.SetActive(false);
                     successIcon.SetActive(true);
@@ -342,23 +344,24 @@ namespace RegressionGames.StateRecorder
                     recordButton.SetActive(false);
                 }
             }
-            else
+            else if (state == PlayState.Paused)
             {
-                // keep the button states up to date so that we can handle work assignments/segments/sequences without tightly wiring this into all those classes like spaghetti
-                if (state == PlayState.Paused)
-                {
-                    chooseReplayButton.SetActive(false);
-                    successIcon.SetActive(false);
-                    playButton.SetActive(true);
-                    pauseButton.SetActive(false);
-                    loopButton.SetActive(false);
-                    stopButton.SetActive(true);
-                    recordButton.SetActive(false);
-                }
-                else if (state == PlayState.Playing)
-                {
-                    SetInUseButtonStates();
-                }
+                chooseReplayButton.SetActive(false);
+                successIcon.SetActive(false);
+                playButton.SetActive(true);
+                pauseButton.SetActive(false);
+                loopButton.SetActive(false);
+                stopButton.SetActive(true);
+                recordButton.SetActive(false);
+            }
+            else if (state == PlayState.Playing)
+            {
+                SetInUseButtonStates();
+            }
+            else if (state == PlayState.NotLoaded && !ScreenRecorder.GetInstance().IsRecording)
+            {
+                // stop ready to play again
+                SetDefaultButtonStates();
             }
         }
 


### PR DESCRIPTION
- Fixes a bug where the replay toolbar wasn't always reset to the correct button states on succesful workAssignment completion
- Fixes a bug where the activeSequence status was incorrect because the activeBotSequence was getting cleared accidentally right after it was set
- Refactored some very confusingly named methods to avoid this happening again !

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
