### PR TITLE
[REG-2166] [REG-2165] [REG-2164] Fix remote worker bugs from PW play test

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotSegmentJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/JsonConverters/BotSegmentJsonConverter.cs
@@ -28,7 +28,10 @@ namespace RegressionGames.StateRecorder.BotSegments.JsonConverters
             {
                 botSegment.apiVersion = jObject.GetValue("apiVersion").ToObject<int>(serializer);
             }
-            botSegment.botAction = jObject.GetValue("botAction")?.ToObject<BotAction>(serializer);
+            if (jObject.ContainsKey("botAction"))
+            {
+                botSegment.botAction = jObject.GetValue("botAction").ToObject<BotAction>(serializer);
+            }
             if (jObject.ContainsKey("keyFrameCriteria"))
             {
                 // backwards compatibility before we renamed keyFrameCriteria to endCriteria

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
@@ -257,7 +257,14 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                 }
             }
             stringBuilder.Append("\n],\n\"botAction\":");
-            botAction.WriteToStringBuilder(stringBuilder);
+            if (botAction != null)
+            {
+                botAction.WriteToStringBuilder(stringBuilder);
+            }
+            else
+            {
+                stringBuilder.Append("null");
+            }
             stringBuilder.Append("}");
         }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
@@ -181,8 +181,15 @@ namespace RegressionGames.StateRecorder
             {
                 // FileBrowser.Result is null, if FileBrowser.Success is false
                 // Get the file path of the first selected file
-                selectedReplayFilePath = FileBrowser.Result[0];
-                RefreshSelectedFile();
+                if (FileBrowser.Result.Length > 0)
+                {
+                    selectedReplayFilePath = FileBrowser.Result[0];
+                    RefreshSelectedFile();
+                }
+                else
+                {
+                    selectedReplayFilePath = null;
+                }
             }
         }
 
@@ -246,7 +253,7 @@ namespace RegressionGames.StateRecorder
 
         public void PlayReplay()
         {
-            if (selectedReplayFilePath == null)
+            if (string.IsNullOrEmpty(selectedReplayFilePath))
             {
                 // this happens when the user plays a bot sequence from the overlay
                 // (no zip file to load)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
@@ -339,8 +339,6 @@ namespace RegressionGames.StateRecorder
             {
                 if (replayDataController.ReplayCompletedSuccessfully() != null)
                 {
-                    // stopped, but ready to play again
-                    replayDataController.Stop();
                     // playback complete
                     chooseReplayButton.SetActive(false);
                     successIcon.SetActive(true);

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -309,6 +309,8 @@ namespace RegressionGames.StateRecorder
             }
 
             await uploadTask;
+
+            _tokenSource?.Cancel();
         }
 
         private async Task MoveSegmentsToProject(string botSegmentsDirectoryPrefix)
@@ -677,7 +679,7 @@ namespace RegressionGames.StateRecorder
 
             if (wasRecording)
             {
-                Task.WaitAll(HandleEndRecording(
+                _ = HandleEndRecording(
                     _tickNumber,
                     _startTime,
                     DateTime.Now,
@@ -691,12 +693,12 @@ namespace RegressionGames.StateRecorder
                     _currentGameplaySessionThumbnailPath,
                     _currentGameplaySessionLogsDirectoryPrefix,
                     _currentGameplaySessionGameMetadataPath,
-                    true));
+                    true);
             }
-
-
-            _tokenSource?.Cancel();
-
+            else
+            {
+                _tokenSource?.Cancel();
+            }
 
             RGSettings rgSettings = RGSettings.GetOrCreateSettings();
             if (rgSettings.GetFeatureCodeCoverage())


### PR DESCRIPTION
- Fixes various bugs encountered during PW remote worker play button test
- Fixes a bug where remote work assignments weren't ending cleanly due to a mis-timed clearing of the complete success status
- Allows for parsing empty/null botAction in segments to make actionless segments easier to write

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
