### PR TITLE
[REG-2005] part 1 - Mark 'isOverride' on segments/sequences as they are loaded

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGHeadlessSequenceRunner.cs
@@ -174,10 +174,10 @@ namespace RegressionGames
         /// <summary>
         /// Plays back a bot sequence, and then returns the save location of the recording.
         /// </summary>
-        /// <param name="botSequenceInfo">(filePath,resourcePath,BotSequence) tuple of the bot sequence</param>
+        /// <param name="botSequenceInfo">(filePath,resourcePath,BotSequence,isOverride) tuple of the bot sequence</param>
         /// <param name="setPlaybackResult">A callback that will be called with the results of this playback</param>
         /// <param name="timeout">How long in seconds to wait for this sequence to complete, less than or == 0 means wait forever (default=0)</param>
-        internal static IEnumerator StartBotSequence((string,string, BotSequence) botSequenceInfo, Action<PlaybackResult> setPlaybackResult, int timeout = 0)
+        internal static IEnumerator StartBotSequence((string,string, BotSequence, bool) botSequenceInfo, Action<PlaybackResult> setPlaybackResult, int timeout = 0)
         {
             var startTime = Time.unscaledTime;
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegment.cs
@@ -37,6 +37,9 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         // NOT WRITTEN TO JSON - The resource path for this botSegment... normally populated during load of saved segments
         public string resourcePath;
 
+        // NOT WRITTEN TO JSON - Populated at load time
+        public bool isOverride;
+
         /**
          * <summary>Description for this bot segment. Used for naming on the UI.</summary>
          */
@@ -291,8 +294,8 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             }
 
             segments = LoadSegmentsInDirectory(segmentPath);
-
 #else
+
 
             // 1. check the persistentDataPath for segments
             var persistentDataPath = Application.persistentDataPath + "/RegressionGames/Resources/BotSegments";
@@ -309,7 +312,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             {
                 try
                 {
-                    if (!segments.ContainsKey(resourceFilename))
+                    if (!segments.TryGetValue(resourceFilename, out var segment))
                     {
                         var sequenceInfo = Resources.Load<TextAsset>(resourceFilename);
                         var sequenceEntry = BotSequence.CreateBotSequenceEntryForJson(null, resourceFilename, sequenceInfo.text ?? "");
@@ -317,6 +320,10 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
                         // add the new sequence if its filename doesn't already exist
                         // add the new sequence with a null filePath
                         segments.Add(sequenceEntry.resourcePath, (null, sequenceEntry));
+                    }
+                    else
+                    {
+                        segment.Item2.isOverride = true;
                     }
                 }
                 catch (Exception e)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegmentList.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSegmentList.cs
@@ -28,6 +28,9 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         // NOT WRITTEN TO JSON - The resource path for this botSegmentList... normally populated during load of saved lists
         public string resourcePath;
 
+        // NOT WRITTEN TO JSON - Populated at load time
+        public bool isOverride;
+
         /**
          * <summary>Description for this bot segment list. Used for naming on the UI.</summary>
          */

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSequenceEntry.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/BotSequenceEntry.cs
@@ -26,6 +26,8 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         public string name;
         // NOT WRITTEN TO JSON - Populated from the BotSegment/BotSegmentList at file load time
         public string description;
+        // NOT WRITTEN TO JSON - Populated at file load time
+        public bool isOverride;
 
         private static readonly ThreadLocal<StringBuilder> _stringBuilder = new (()=>new(100));
 


### PR DESCRIPTION
- The loading code changes to mark `isOverride` on objects as they are loaded ... enables REG-2005 UI work

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
