### PR TITLE
[REG-2180] Add monkey bot action space analysis results

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionInput.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionInput.cs
@@ -14,11 +14,12 @@ namespace RegressionGames.ActionManager
         /// <summary>
         /// Simulate the input onto the game.
         /// </summary>
-        public abstract void Perform();
+        /// <param name="segmentNumber">The bot segmentNumber</param>
+        public abstract void Perform(int segmentNumber);
 
         /// <summary>
         /// Returns whether this input affects the same part of the device as another.
-        /// 
+        ///
         /// This is used to decide whether two actions can be performed simultaneously:
         /// if two actions affect the same part of the input device then they should NOT be performed together.
         /// </summary>
@@ -50,16 +51,16 @@ namespace RegressionGames.ActionManager
     {
         public readonly KeyCode KeyCode;
         public readonly bool IsPressed;
-        
+
         public LegacyKeyInput(KeyCode keyCode, bool isPressed)
         {
             KeyCode = keyCode;
             IsPressed = isPressed;
         }
-        
-        public override void Perform()
+
+        public override void Perform(int segmentNumber)
         {
-            RGActionManager.SimulateKeyState(KeyCode, IsPressed);
+            RGActionManager.SimulateKeyState(segmentNumber, KeyCode, IsPressed);
         }
 
         public override bool Overlaps(RGActionInput other)
@@ -97,17 +98,17 @@ namespace RegressionGames.ActionManager
             Key = key;
             IsPressed = isPressed;
         }
-        
-        public override void Perform()
+
+        public override void Perform(int segmentNumber)
         {
-            RGActionManager.SimulateKeyState(Key, IsPressed);
+            RGActionManager.SimulateKeyState(segmentNumber, Key, IsPressed);
         }
 
         public override bool Overlaps(RGActionInput other)
         {
             if (other is LegacyKeyInput keyInput)
             {
-                return !(keyInput.KeyCode >= KeyCode.Mouse0 && keyInput.KeyCode <= KeyCode.Mouse6) 
+                return !(keyInput.KeyCode >= KeyCode.Mouse0 && keyInput.KeyCode <= KeyCode.Mouse6)
                        && Key == RGLegacyInputUtils.KeyCodeToInputSystemKey(keyInput.KeyCode);
             } else if (other is InputSystemKeyInput inputSysKeyInput)
             {
@@ -133,10 +134,10 @@ namespace RegressionGames.ActionManager
         {
             MousePosition = mousePosition;
         }
-        
-        public override void Perform()
+
+        public override void Perform(int segmentNumber)
         {
-            RGActionManager.SimulateMouseMovement(MousePosition);
+            RGActionManager.SimulateMouseMovement(segmentNumber, MousePosition);
         }
 
         public override bool Overlaps(RGActionInput other)
@@ -158,10 +159,10 @@ namespace RegressionGames.ActionManager
         {
             MousePositionDelta = mousePositionDelta;
         }
-        
-        public override void Perform()
+
+        public override void Perform(int segmentNumber)
         {
-            RGActionManager.SimulateMouseMovementDelta(MousePositionDelta);
+            RGActionManager.SimulateMouseMovementDelta(segmentNumber, MousePositionDelta);
         }
 
         public override bool Overlaps(RGActionInput other)
@@ -183,10 +184,10 @@ namespace RegressionGames.ActionManager
         {
             MouseScroll = mouseScroll;
         }
-        
-        public override void Perform()
+
+        public override void Perform(int segmentNumber)
         {
-            RGActionManager.SimulateMouseScroll(MouseScroll);
+            RGActionManager.SimulateMouseScroll(segmentNumber, MouseScroll);
         }
 
         public override bool Overlaps(RGActionInput other)
@@ -207,7 +208,7 @@ namespace RegressionGames.ActionManager
         public const int MIDDLE_MOUSE_BUTTON = 2;
         public const int FORWARD_MOUSE_BUTTON = 3;
         public const int BACK_MOUSE_BUTTON = 4;
-        
+
         public readonly int MouseButton;
         public readonly bool IsPressed;
 
@@ -216,10 +217,10 @@ namespace RegressionGames.ActionManager
             MouseButton = mouseButton;
             IsPressed = isPressed;
         }
-        
-        public override void Perform()
+
+        public override void Perform(int segmentNumber)
         {
-            RGActionManager.SimulateMouseButton(MouseButton, IsPressed);
+            RGActionManager.SimulateMouseButton(segmentNumber, MouseButton, IsPressed);
         }
 
         public override bool Overlaps(RGActionInput other)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionManager.cs
@@ -143,9 +143,10 @@ namespace RegressionGames.ActionManager
         /// <summary>
         /// Start an action manager session. This should be called prior to any calls to GetValidActions().
         /// </summary>
+        /// <param name="segmentNumber">The bot sequence segment number</param>
         /// <param name="context">The MonoBehaviour context under which actions will be simulated.</param>
         /// <param name="actionSettings">Session-specific action settings (optional - if null will use saved configuration)</param>
-        public static void StartSession(MonoBehaviour context, RGActionManagerSettings actionSettings = null)
+        public static void StartSession(int segmentNumber, MonoBehaviour context, RGActionManagerSettings actionSettings = null)
         {
             if (_context != null)
             {
@@ -175,7 +176,7 @@ namespace RegressionGames.ActionManager
                 RGUtils.ConfigureInputSettings();
             }
 
-            InitInputState();
+            InitInputState(segmentNumber);
         }
 
         /// <summary>
@@ -288,10 +289,10 @@ namespace RegressionGames.ActionManager
         public static Dictionary<long, ObjectStatus> CurrentTransforms { get; private set; }
         public static List<EventSystem> CurrentEventSystems { get; private set; }
 
-        private static void InitInputState()
+        private static void InitInputState(int segmentNumber)
         {
             // move mouse off screen
-            _mousePosition = MouseEventSender.MoveMouseOffScreen();
+            _mousePosition = MouseEventSender.MoveMouseOffScreen(segmentNumber);
 
             #if ENABLE_LEGACY_INPUT_MANAGER
             _mouseScroll = RGLegacyInputWrapper.mouseScrollDelta;
@@ -312,7 +313,7 @@ namespace RegressionGames.ActionManager
             CurrentEventSystems = new List<EventSystem>();
         }
 
-        public static void SimulateKeyState(KeyCode keyCode, bool isPressed)
+        public static void SimulateKeyState(int segmentNumber, KeyCode keyCode, bool isPressed)
         {
             if (keyCode >= KeyCode.Mouse0 && keyCode <= KeyCode.Mouse6)
             {
@@ -323,7 +324,7 @@ namespace RegressionGames.ActionManager
                     keyCode == KeyCode.Mouse3 ? isPressed : _forwardMouseButton;
                 bool backButton =
                     keyCode == KeyCode.Mouse4 ? isPressed : _backMouseButton;
-                MouseEventSender.SendRawPositionMouseEvent(0,
+                MouseEventSender.SendRawPositionMouseEvent(segmentNumber,
                     _mousePosition,
                     leftButton: leftButton, middleButton: middleButton, rightButton: rightButton,
                     forwardButton: forwardButton, backButton: backButton, scroll: _mouseScroll);
@@ -336,43 +337,43 @@ namespace RegressionGames.ActionManager
             else
             {
                 Key key = RGLegacyInputUtils.KeyCodeToInputSystemKey(keyCode);
-                SimulateKeyState(key, isPressed);
+                SimulateKeyState(segmentNumber, key, isPressed);
             }
         }
 
-        public static void SimulateKeyState(Key key, bool isPressed)
+        public static void SimulateKeyState(int segmentNumber, Key key, bool isPressed)
         {
             if (key != Key.None)
             {
-                KeyboardEventSender.SendKeyEvent(0, key, isPressed ? KeyState.Down : KeyState.Up);
+                KeyboardEventSender.SendKeyEvent(segmentNumber, key, isPressed ? KeyState.Down : KeyState.Up);
             }
         }
 
-        public static void SimulateMouseMovement(Vector2 mousePosition)
+        public static void SimulateMouseMovement(int segmentNumber, Vector2 mousePosition)
         {
-            MouseEventSender.SendRawPositionMouseEvent(0, mousePosition, leftButton: _leftMouseButton, middleButton: _middleMouseButton,
+            MouseEventSender.SendRawPositionMouseEvent(segmentNumber, mousePosition, leftButton: _leftMouseButton, middleButton: _middleMouseButton,
                 rightButton: _rightMouseButton, forwardButton: _forwardMouseButton, backButton: _backMouseButton, scroll: _mouseScroll);
             _mousePosition = mousePosition;
         }
 
-        public static void SimulateMouseMovementDelta(Vector2 mousePositionDelta)
+        public static void SimulateMouseMovementDelta(int segmentNumber, Vector2 mousePositionDelta)
         {
             Vector3 delta = mousePositionDelta;
-            SimulateMouseMovement(_mousePosition + delta);
+            SimulateMouseMovement(segmentNumber, _mousePosition + delta);
         }
 
-        public static void SimulateMouseScroll(Vector2 mouseScroll)
+        public static void SimulateMouseScroll(int segmentNumber, Vector2 mouseScroll)
         {
-            MouseEventSender.SendRawPositionMouseEvent(0, _mousePosition, leftButton: _leftMouseButton,
+            MouseEventSender.SendRawPositionMouseEvent(segmentNumber, _mousePosition, leftButton: _leftMouseButton,
                 middleButton: _middleMouseButton,
                 rightButton: _rightMouseButton, forwardButton: _forwardMouseButton, backButton: _backMouseButton,
                 scroll: mouseScroll);
             _mouseScroll = mouseScroll;
         }
 
-        public static void SimulateMouseButton(int mouseButton, bool isPressed)
+        public static void SimulateMouseButton(int segmentNumber, int mouseButton, bool isPressed)
         {
-            SimulateKeyState(KeyCode.Mouse0 + mouseButton, isPressed);
+            SimulateKeyState(segmentNumber, KeyCode.Mouse0 + mouseButton, isPressed);
         }
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionManager.cs
@@ -228,12 +228,12 @@ namespace RegressionGames.ActionManager
 
                 foreach (var obj in objects)
                 {
-                    if (obj is Component c && !c.gameObject.activeInHierarchy)
+                    if (obj is Component { gameObject: { activeInHierarchy: false } })
                     {
                         // skip components that are on inactive game objects
                         continue;
                     }
-                    if (obj is Behaviour b && !b.isActiveAndEnabled)
+                    if (obj is Behaviour { isActiveAndEnabled: false })
                     {
                         // skip disabled behaviours
                         continue;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionRuntimeCoverageAnalysis.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionRuntimeCoverageAnalysis.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using RegressionGames.StateRecorder;
+using RegressionGames.StateRecorder.JsonConverters;
+using RegressionGames.StateRecorder.Models;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+// ReSharper disable InconsistentNaming
+namespace RegressionGames.ActionManager
+{
+    public static class RGActionRuntimeCoverageAnalysis
+    {
+        private static readonly Dictionary<int, Dictionary<RGGameAction, RGActionUsageMetrics>> _analysisData = new ();
+
+        private static readonly HashSet<RGGameAction> _allActions = new();
+
+        private static bool _inProgress;
+
+        private static int _currentSegment = -1;
+
+        public static void Reset()
+        {
+            _allActions.Clear();
+            _analysisData.Clear();
+            _currentSegment = -1;
+        }
+
+        public static void StartRecording(int segmentNumber)
+        {
+            if (!_inProgress)
+            {
+                // do not Reset here as they could record multiple times in a single bot sequence
+
+                if (_allActions.Count == 0)
+                {
+                    var allActions = RGActionManager.Actions;
+                    foreach (var rgGameAction in allActions)
+                    {
+                        _allActions.Add(rgGameAction);
+                    }
+                }
+
+                _inProgress = true;
+
+                SetCurrentSegmentNumber(segmentNumber);
+            }
+
+        }
+
+        public static void SetCurrentSegmentNumber(int segmentNumber)
+        {
+            if (_inProgress)
+            {
+                _currentSegment = segmentNumber;
+                if (!_analysisData.ContainsKey(_currentSegment))
+                {
+                    _analysisData[_currentSegment] = new();
+                }
+            }
+        }
+
+        public static void RecordActionUsage(RGGameAction action, Object targetObject)
+        {
+            if (_inProgress)
+            {
+                if (!_analysisData[_currentSegment].TryGetValue(action, out var metrics))
+                {
+                    metrics = new RGActionUsageMetrics();
+                    _analysisData[_currentSegment][action] = metrics;
+                }
+
+                ++metrics.invocations;
+                metrics.objectsActedOn.Add(CreateLabelForTargetObject(targetObject));
+            }
+        }
+
+        private static string CreateLabelForTargetObject(Object targetObject)
+        {
+            if (targetObject is GameObject gameObject)
+            {
+                // get the path to this game object
+                return TransformStatus.GetOrCreateTransformStatus(gameObject.transform).Path;
+            }
+
+            if (targetObject is Component component)
+            {
+                // everything else attached to a game object (including the transform) - this is Intentionally a // instead of / so we can differentiate components vs transforms in the path easily
+                return TransformStatus.GetOrCreateTransformStatus(component.transform).Path + "//" + targetObject.name;
+            }
+
+            return targetObject.ToString();
+        }
+
+        public static void StopRecording()
+        {
+            _inProgress = false;
+        }
+
+        public static RGActionUsageSummary BuildSummary()
+        {
+            if (_currentSegment >= 0)
+            {
+                var summary = new RGActionUsageSummary();
+                foreach (var (_, data) in _analysisData)
+                {
+                    foreach (var (action, metrics) in data)
+                    {
+                        if (!summary.usedActionMetrics.TryGetValue(action, out var existingMetric))
+                        {
+                            existingMetric = new RGActionUsageMetrics();
+                            summary.usedActionMetrics[action] = existingMetric;
+                        }
+
+                        existingMetric.invocations += metrics.invocations;
+                        foreach (var s in metrics.objectsActedOn)
+                        {
+                            existingMetric.objectsActedOn.Add(s);
+                        }
+
+                    }
+                }
+
+                foreach (var rgGameAction in _allActions)
+                {
+                    if (!summary.usedActionMetrics.ContainsKey(rgGameAction))
+                    {
+                        summary.unusedActions.Add(rgGameAction);
+                    }
+                }
+
+                return summary;
+            }
+
+            // we didn't actually record anything
+            return null;
+        }
+
+    }
+
+    [Serializable]
+    public class RGActionUsageMetrics : IStringBuilderWriteable
+    {
+        public long invocations = 0;
+        public readonly HashSet<string> objectsActedOn = new();
+        public void WriteToStringBuilder(StringBuilder stringBuilder)
+        {
+            stringBuilder.Append("{\"invocations\":");
+            LongJsonConverter.WriteToStringBuilder(stringBuilder, invocations);
+            stringBuilder.Append(",\"objectsActedOn\":[");
+            var objectsActedOnCount = objectsActedOn.Count;
+            var counter = 1;
+            foreach (var objectName in objectsActedOn)
+            {
+                StringJsonConverter.WriteToStringBuilder(stringBuilder, objectName);
+                if (counter++ < objectsActedOnCount) // we start the counter at 1 (not 0) so this is a post increment as we want to compare the value this pass before incrementing
+                {
+                    stringBuilder.Append(",");
+                }
+            }
+            stringBuilder.Append("]}");
+        }
+    }
+
+    [Serializable]
+    public class RGActionUsageSummary : IStringBuilderWriteable
+    {
+        public readonly HashSet<RGGameAction> unusedActions = new();
+
+        public readonly Dictionary<RGGameAction, RGActionUsageMetrics> usedActionMetrics = new();
+        public void WriteToStringBuilder(StringBuilder stringBuilder)
+        {
+            stringBuilder.Append("{\n\"unusedActions\":[\n");
+            var unusedActionsCount = unusedActions.Count;
+            var counter = 1;
+            foreach (var rgGameAction in unusedActions)
+            {
+                rgGameAction.WriteToStringBuilder(stringBuilder);
+                if (counter++ < unusedActionsCount) // we start the counter at 1 (not 0) so this is a post increment as we want to compare the value this pass before incrementing
+                {
+                    stringBuilder.Append(",\n");
+                }
+            }
+            stringBuilder.Append("],\n");
+            stringBuilder.Append("\"usedActionMetrics\":[\n");
+            var usedActionMetricsCount = usedActionMetrics.Count;
+            counter = 1;
+            // sort by number of invocations descending
+            var sortedUsedActionMetrics = usedActionMetrics.ToList().OrderBy(kvp => -1 * kvp.Value.invocations);
+            foreach (var (action, metrics) in sortedUsedActionMetrics)
+            {
+                stringBuilder.Append("{\"metrics\":");
+                metrics.WriteToStringBuilder(stringBuilder);
+                stringBuilder.Append(",\"action\":");
+                action.WriteToStringBuilder(stringBuilder);
+                stringBuilder.Append("}");
+                if (counter++ < usedActionMetricsCount) // we start the counter at 1 (not 0) so this is a post increment as we want to compare the value this pass before incrementing
+                {
+                    stringBuilder.Append(",\n");
+                }
+            }
+            stringBuilder.Append("]}");
+        }
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionRuntimeCoverageAnalysis.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGActionRuntimeCoverageAnalysis.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2ba35c65c27243bc8e61bb211b8edd08
+timeCreated: 1730992494

--- a/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGGameAction.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/ActionManager/RGGameAction.cs
@@ -5,26 +5,27 @@ using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using RegressionGames.ActionManager.JsonConverters;
+using RegressionGames.StateRecorder;
 using RegressionGames.StateRecorder.JsonConverters;
 
 namespace RegressionGames.ActionManager
 {
     [JsonConverter(typeof(RGGameActionJsonConverter))]
-    public abstract class RGGameAction : ICloneable
+    public abstract class RGGameAction : ICloneable, IStringBuilderWriteable
     {
-        
+
         /// The path of the action, typically derived from
         /// the location where the associated input handling logic takes place.
         /// An action may have multiple paths if multiple code locations were inferred to
         /// have equivalent actions by IsEquivalentTo and were grouped together.
         public List<string[]> Paths { get; set; }
-        
+
         /// The type of object that the action is associated with.
         /// The object must be derived from UnityEngine.Object, and
         /// all instances of the object should be retrievable via
         /// UnityEngine.Object.FindObjectsOfType(ObjectType).
         public Type ObjectType { get; set; }
-        
+
         /// The range of parameter values accepted by this action's
         /// Perform() method.
         [RGActionProperty("Parameter Range", true)]
@@ -64,6 +65,16 @@ namespace RegressionGames.ActionManager
             ParameterRange = serializedAction["parameterRange"].ToObject<IRGValueRange>();
         }
 
+        public override int GetHashCode()
+        {
+            return DisplayName.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            return GetHashCode() == obj?.GetHashCode();
+        }
+
         /// <summary>
         /// Determines whether this action is valid for the object.
         /// </summary>
@@ -73,7 +84,7 @@ namespace RegressionGames.ActionManager
         /// </param>
         /// <returns>Whether the action is valid for the object.</returns>
         public abstract bool IsValidForObject(UnityEngine.Object obj);
-        
+
         /// <summary>
         /// Obtain an instance of this action for the target object.
         /// This method is only called if IsValidForObject is true for the given object.
@@ -178,7 +189,7 @@ namespace RegressionGames.ActionManager
         /// <returns>The set of inputs needed to perform the action in the current state.</returns>
         public IEnumerable<RGActionInput> GetInputs(object param);
     }
-    
+
     public abstract class RGGameActionInstance<TAction, TParam> : IRGGameActionInstance where TAction : RGGameAction
     {
         /// <summary>
@@ -189,7 +200,7 @@ namespace RegressionGames.ActionManager
 
         /// <inheritdoc cref="IRGGameActionInstance.BaseAction"/>
         public RGGameAction BaseAction => Action;
-        
+
         /// <inheritdoc cref="IRGGameActionInstance.TargetObject"/>
         public UnityEngine.Object TargetObject { get; private set; }
 
@@ -216,7 +227,7 @@ namespace RegressionGames.ActionManager
         /// This already has the parameter casted to the appropriate type.
         /// </summary>
         protected abstract bool IsValidActionParameter(TParam param);
-        
+
         /// <summary>
         /// Derived classes implement this method to implement GetInputs().
         /// This already has the parameter casted to the appropriate type.

--- a/src/gg.regression.unity.bots/Runtime/Scripts/CodeCoverage/CodeCoverageMetadata.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/CodeCoverage/CodeCoverageMetadata.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using RegressionGames.StateRecorder;
+using RegressionGames.StateRecorder.JsonConverters;
 
 namespace RegressionGames.CodeCoverage
 {
@@ -8,8 +11,10 @@ namespace RegressionGames.CodeCoverage
     /// Metadata about a single code point
     /// </summary>
     [Serializable]
-    public class CodePointMetadata
+    public class CodePointMetadata : IStringBuilderWriteable
     {
+        public int apiVersion = SdkApiVersion.VERSION_13;
+
         public string sourceFilePath;
         public int startLine;
         public int startCol;
@@ -17,24 +22,77 @@ namespace RegressionGames.CodeCoverage
         public int endCol;
         public string typeName;
         public string methodSig;
+        public void WriteToStringBuilder(StringBuilder stringBuilder)
+        {
+            stringBuilder.Append("{\n\"apiVersion\":");
+            IntJsonConverter.WriteToStringBuilder(stringBuilder, apiVersion);
+            stringBuilder.Append("\n,\"sourceFilePath\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, sourceFilePath);
+            stringBuilder.Append("\n,\"startLine\":");
+            IntJsonConverter.WriteToStringBuilder(stringBuilder, startLine);
+            stringBuilder.Append("\n,\"startCol\":");
+            IntJsonConverter.WriteToStringBuilder(stringBuilder, startCol);
+            stringBuilder.Append("\n,\"endLine\":");
+            IntJsonConverter.WriteToStringBuilder(stringBuilder, endLine);
+            stringBuilder.Append("\n,\"endCol\":");
+            IntJsonConverter.WriteToStringBuilder(stringBuilder, endCol);
+            stringBuilder.Append("\n,\"typeName\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, typeName);
+            stringBuilder.Append("\n,\"methodSig\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, methodSig);
+            stringBuilder.Append("\n}");
+        }
     }
-    
+
     [Serializable]
-    public class CodeCoverageMetadata
+    public class CodeCoverageMetadata : IStringBuilderWriteable
     {
         // Increment this whenever breaking changes are made to the metadata format
-        public const int CURRENT_API_VERSION = SdkApiVersion.VERSION_13;
+        public int apiVersion = SdkApiVersion.VERSION_13;
 
-        public int apiVersion = CURRENT_API_VERSION;
-        
+        public int EffectiveApiVersion => Math.Max(apiVersion, codePointMetadata?.Values.Max(a=>a.Max(b=>b.apiVersion)) ?? SdkApiVersion.CURRENT_VERSION);
+
         /// <summary>
         /// Mapping from assembly name -> list of metadata for each code point
         /// </summary>
+        // ReSharper disable once InconsistentNaming
         public Dictionary<string, List<CodePointMetadata>> codePointMetadata = new();
 
         public bool IsValid()
         {
-            return apiVersion == CURRENT_API_VERSION && codePointMetadata != null;
+            return SdkApiVersion.CURRENT_VERSION >= EffectiveApiVersion && codePointMetadata != null;
+        }
+
+        public void WriteToStringBuilder(StringBuilder stringBuilder)
+        {
+            stringBuilder.Append("{\n\"apiVersion\":");
+            IntJsonConverter.WriteToStringBuilder(stringBuilder, apiVersion);
+            stringBuilder.Append("\n,\"codePointMetadata\":{\n");
+            var codePointMetadataCount = codePointMetadata.Count;
+            var currentIndex = 1;
+            foreach (var (key, list) in codePointMetadata)
+            {
+                StringJsonConverter.WriteToStringBuilder(stringBuilder, key);
+                stringBuilder.Append(":[\n");
+                var listCount = list.Count;
+                for (var i = 0; i < listCount; i++)
+                {
+                    var listEntry = list[i];
+                    listEntry.WriteToStringBuilder(stringBuilder);
+                    if (i + 1 < listCount)
+                    {
+                        stringBuilder.Append(",\n");
+                    }
+                }
+                stringBuilder.Append("\n]");
+
+                if (currentIndex++ < codePointMetadataCount)
+                {
+                    stringBuilder.Append(",\n");
+                }
+            }
+            stringBuilder.Append("\n}\n}");
+
         }
     }
 }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/GenericBots/Experimental/QLearningBot.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/GenericBots/Experimental/QLearningBot.cs
@@ -21,34 +21,34 @@ namespace RegressionGames.GenericBots.Experimental
     {
         public RGGameAction Action;
         public object ParamValue;
-    
+
         public List<IRGGameActionInstance> CurrentInstances;
-        
+
         private string identifier;
-    
+
         public string Identifier => identifier;
-        
+
         public QAction(RGGameAction action, object paramValue)
         {
             Action = action;
             ParamValue = paramValue;
-    
+
             StringBuilder identifierStringBuilder = new StringBuilder();
             Action.WriteToStringBuilder(identifierStringBuilder);
             identifierStringBuilder.Append(ParamValue);
-    
+
             identifier = identifierStringBuilder.ToString();
-    
+
             CurrentInstances = new List<IRGGameActionInstance>();
         }
-    
+
         public bool Equals(QAction other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return identifier == other.identifier;
         }
-    
+
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj)) return false;
@@ -56,17 +56,17 @@ namespace RegressionGames.GenericBots.Experimental
             if (obj.GetType() != this.GetType()) return false;
             return Equals((QAction)obj);
         }
-    
+
         public override int GetHashCode()
         {
             return (identifier != null ? identifier.GetHashCode() : 0);
         }
-    
+
         public static bool operator ==(QAction left, QAction right)
         {
             return Equals(left, right);
         }
-    
+
         public static bool operator !=(QAction left, QAction right)
         {
             return !Equals(left, right);
@@ -88,7 +88,7 @@ namespace RegressionGames.GenericBots.Experimental
             NextState = nextState;
         }
     }
-    
+
     /// <summary>
     /// This bot implements the Q-learning reinforcement learning algorithm.
     /// It uses the Action Manager to automatically compute a discrete action space for the game,
@@ -125,8 +125,8 @@ namespace RegressionGames.GenericBots.Experimental
         public float Gamma = 0.6f; // Discount factor
         public int ExperienceBufferSize = 64; // Size of the experience buffer (size of fixed-length queue of the last N experiences)
         public string ModelFilePath = "qbot_model.json"; // Path where to save the trained model (Q-table)
-        public float TrainingTimeScale = 3.0f; // the Time.timeScale value to use while training 
-            
+        public float TrainingTimeScale = 3.0f; // the Time.timeScale value to use while training
+
         private List<QAction> _actionSpace;
         private Dictionary<string, Dictionary<string, float>> _qTable;
         private List<QAction> _validActions;
@@ -134,7 +134,7 @@ namespace RegressionGames.GenericBots.Experimental
         private float _epStartTime;
         private float _epRew;
         private Queue<QExperience> _experienceBuf;
-    
+
         private string _lastState;
         private string _lastActionKey;
         private List<RGActionInput> _lastInputs;
@@ -142,8 +142,8 @@ namespace RegressionGames.GenericBots.Experimental
         private float _epsilon;
         private ISet<int> _mouseBtnsBuf;
         private IRewardModule _rewardModule;
-        private GameSpeedup _speedup; // only active if training 
-        
+        private GameSpeedup _speedup; // only active if training
+
         /// <summary>
         /// Obtain an abstract string representation of the current game state.
         /// The default implementation concatenates all the active component type names
@@ -156,7 +156,7 @@ namespace RegressionGames.GenericBots.Experimental
                 .Select(c => c.GetType()).Distinct()
                 .Select(type => type.FullName));
             names.Sort();
-    
+
             // include the current keyboard/mouse button input state as well, since this affects the behavior of the action
             List<string> inputs = new List<string>();
             foreach (var control in Keyboard.current.allControls)
@@ -179,7 +179,7 @@ namespace RegressionGames.GenericBots.Experimental
                 inputs.Add("mouseForwardButton");
             if (Mouse.current.backButton.isPressed)
                 inputs.Add("mouseBackButton");
-            
+
             inputs.Sort();
             return string.Join(",", names) + ":" + string.Join(",", inputs);
         }
@@ -201,7 +201,7 @@ namespace RegressionGames.GenericBots.Experimental
         {
             SceneManager.LoadScene(_initialSceneName);
         }
-        
+
         /// <summary>
         /// Obtains a set of discrete parameter values for the given action.
         /// If the action is already discrete, returns each parameter value.
@@ -226,7 +226,7 @@ namespace RegressionGames.GenericBots.Experimental
                 }
             }
         }
-    
+
         /// <summary>
         /// Generates a discrete action space for the game.
         /// </summary>
@@ -250,7 +250,7 @@ namespace RegressionGames.GenericBots.Experimental
         {
             return false;
         }
-    
+
         private void SaveModel()
         {
             JObject result = new JObject();
@@ -268,7 +268,7 @@ namespace RegressionGames.GenericBots.Experimental
             result["qtable"] = qtable;
             File.WriteAllText(ModelFilePath, result.ToString());
         }
-    
+
         private bool LoadModel()
         {
             if (!File.Exists(ModelFilePath))
@@ -301,14 +301,14 @@ namespace RegressionGames.GenericBots.Experimental
                 return;
             }
             DontDestroyOnLoad(this);
-    
+
             _validActions = new List<QAction>();
             _lastInputs = new List<RGActionInput>();
             _mouseBtnsBuf = new HashSet<int>();
             _initialSceneName = SceneManager.GetActiveScene().name;
             _rewardModule = CreateRewardModule();
             _experienceBuf = new Queue<QExperience>();
-            
+
             if (LoadModel())
             {
                 RGDebug.Log("Loaded existing model with epsilon " + _epsilon);
@@ -323,15 +323,15 @@ namespace RegressionGames.GenericBots.Experimental
                 _qTable = new Dictionary<string, Dictionary<string, float>>();
                 _epsilon = 1.0f;
             }
-            
+
             if (Training)
             {
                 _speedup = new GameSpeedup(TrainingTimeScale);
             }
-            
+
             OnEpisodeStart();
         }
-    
+
         /// <summary>
         /// Calls RGActionManager.GetValidActions() to get the set of valid actions, then transforms
         /// this result into the discrete action space representation used by the Q learning bot.
@@ -350,7 +350,7 @@ namespace RegressionGames.GenericBots.Experimental
                 }
                 instances.Add(actionInst);
             }
-    
+
             _validActions.Clear();
             foreach (var qact in _actionSpace)
             {
@@ -372,7 +372,7 @@ namespace RegressionGames.GenericBots.Experimental
                 }
             }
         }
-    
+
         public void OnDestroy()
         {
             if (Training)
@@ -383,10 +383,10 @@ namespace RegressionGames.GenericBots.Experimental
             _rewardModule.Dispose();
             RGActionManager.StopSession();
         }
-        
+
         private void OnEpisodeStart()
         {
-            RGActionManager.StartSession(this);
+            RGActionManager.StartSession(0,this);
             _actionSpace = GenerateActionSpace();
             _epStartTime = Time.time;
             _epRew = 0.0f;
@@ -396,7 +396,7 @@ namespace RegressionGames.GenericBots.Experimental
             _rewardModule.Reset();
             _experienceBuf.Clear();
         }
-    
+
         private void OnEpisodeEnd()
         {
             RGDebug.Log($"Episode reward: {_epRew}, State count: {_qTable.Count}, Epsilon: {_epsilon}");
@@ -408,12 +408,12 @@ namespace RegressionGames.GenericBots.Experimental
             RGActionManager.StopSession();
             SaveModel();
         }
-    
+
         private static string ActionKey(QAction action, IRGGameActionInstance actionInst)
         {
             return action.Identifier + ":" + actionInst.TargetObject.name;
         }
-    
+
         private float ReadQTable(string stateKey, string actionKey)
         {
             if (_qTable.TryGetValue(stateKey, out var actionVals))
@@ -432,7 +432,7 @@ namespace RegressionGames.GenericBots.Experimental
                 return 0.0f;
             }
         }
-    
+
         private float GetStateQValue(string stateKey)
         {
             if (_qTable.TryGetValue(stateKey, out var actionVals))
@@ -452,7 +452,7 @@ namespace RegressionGames.GenericBots.Experimental
         private bool PerformHeuristics()
         {
             bool didHeuristic = false;
-            
+
             // If the last set of inputs was a mouse position movement + mouse button press,
             // then release the mouse button over the same location.
             {
@@ -477,23 +477,23 @@ namespace RegressionGames.GenericBots.Experimental
                         }
                     }
                 }
-             
+
                 if (haveMousePos && _mouseBtnsBuf.Count > 0)
                 {
                     _lastInputs.Clear();
                     foreach (var btn in _mouseBtnsBuf)
                     {
                         var inp = new MouseButtonInput(btn, false);
-                        inp.Perform();
+                        inp.Perform(0);
                         _lastInputs.Add(inp);
                     }
                     didHeuristic = true;
                 }
             }
-            
+
             return didHeuristic;
         }
-        
+
         public void Update()
         {
             var now = Time.time;
@@ -503,34 +503,34 @@ namespace RegressionGames.GenericBots.Experimental
                 RestartGame();
                 OnEpisodeStart();
             }
-    
+
             if (_lastActionTime.HasValue && now - _lastActionTime < ActionInterval)
             {
                 // Repeat the previous inputs
                 foreach (var inp in _lastInputs)
                 {
-                    inp.Perform();
+                    inp.Perform(0);
                 }
                 return;
             }
-            
+
             if (PerformHeuristics())
             {
                 _lastActionTime = Time.time;
                 return;
             }
-            
+
             string state = GetCurrentState();
-            
+
             if (Training)
             {
                 _speedup.Update();
-                
+
                 if (!_qTable.TryGetValue(state, out _))
                 {
                     _qTable.Add(state, new Dictionary<string, float>());
                 }
-                
+
                 // Record latest experience
                 if (_lastState != null)
                 {
@@ -540,7 +540,7 @@ namespace RegressionGames.GenericBots.Experimental
                         _experienceBuf.Dequeue();
                     _epRew += rew;
                 }
-            
+
                 // Update Q-table with experience
                 foreach (var exp in _experienceBuf)
                 {
@@ -554,18 +554,18 @@ namespace RegressionGames.GenericBots.Experimental
             {
                 _epRew += _rewardModule.GetRewardForLastAction();
             }
-            
+
             _lastState = null;
             _lastActionKey = null;
-            
+
             ComputeValidActions();
-            
+
             if (_validActions.Count == 0)
             {
                 // nothing to do
                 return;
             }
-    
+
             // Select the action to take
             QAction action;
             IRGGameActionInstance actionInst;
@@ -597,7 +597,7 @@ namespace RegressionGames.GenericBots.Experimental
                 action = maxAction;
                 actionInst = maxActionInst;
             }
-    
+
             // Perform the chosen action
             _lastInputs.Clear();
             if (actionInst != null)
@@ -605,7 +605,7 @@ namespace RegressionGames.GenericBots.Experimental
                 foreach (var inp in actionInst.GetInputs(action.ParamValue))
                 {
                     _lastInputs.Add(inp);
-                    inp.Perform();
+                    inp.Perform(0);
                 }
                 _lastState = state;
                 _lastActionKey = ActionKey(action, actionInst);
@@ -615,7 +615,7 @@ namespace RegressionGames.GenericBots.Experimental
                 _lastState = null;
                 _lastActionKey = null;
             }
-    
+
             _lastActionTime = now;
         }
     }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/GenericBots/RGMonkeyBot.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/GenericBots/RGMonkeyBot.cs
@@ -7,7 +7,7 @@ namespace RegressionGames.GenericBots
     {
         public float actionInterval = 0.05f; // unscaled time
         private RGMonkeyBotLogic monkey;
-    
+
         void Start()
         {
             if (!RGActionManager.IsAvailable)
@@ -16,16 +16,16 @@ namespace RegressionGames.GenericBots
                 Destroy(this);
                 return;
             }
-            RGActionManager.StartSession(this);
+            RGActionManager.StartSession(0, this);
 
             monkey = new RGMonkeyBotLogic();
             DontDestroyOnLoad(this);
         }
-    
+
         void Update()
         {
             monkey.ActionInterval = actionInterval;
-            monkey.Update();
+            monkey.Update(0);
         }
 
         void OnDestroy()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/GenericBots/RGMonkeyBotLogic.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/GenericBots/RGMonkeyBotLogic.cs
@@ -13,7 +13,7 @@ namespace RegressionGames.GenericBots
         public bool Performed;
         public IList<RGActionInput> Inputs;
     }
-    
+
     public class RGMonkeyBotLogic
     {
         public float ActionInterval { get; set; } = 0.05f;
@@ -35,7 +35,7 @@ namespace RegressionGames.GenericBots
             _remainingActionsBuf = new List<MonkeyBotActionEntry>();
             _mouseBtnsBuf = new HashSet<int>();
         }
-        
+
         private void ResetState()
         {
             _actionsBuf.Clear();
@@ -55,7 +55,7 @@ namespace RegressionGames.GenericBots
                 // Pause sending events while the overlay panel is open
                 return didAnyAction;
             }
-         
+
             float currentTimeUnscaled = Time.unscaledTime;
             if (currentTimeUnscaled - _lastActionTime < ActionInterval)
             {
@@ -67,13 +67,14 @@ namespace RegressionGames.GenericBots
                         inp.Perform();
                         didAnyAction = true;
                     }
+                    RGActionRuntimeCoverageAnalysis.RecordActionUsage(act.ActionInstance.BaseAction, act.ActionInstance.TargetObject);
                 }
                 return didAnyAction;
             }
             _lastActionTime = currentTimeUnscaled;
-                     
+
             bool didHeuristic = false;
-                     
+
             // Heuristic: If the last action was a mouse down on a Unity UI button, always release the mouse button on this frame over
             // the same mouse coordinate to trigger the click event
             foreach (var performedAction in _actionsBuf.Where(act => act.Performed))
@@ -92,6 +93,7 @@ namespace RegressionGames.GenericBots
                                 inp.Perform();
                                 didAnyAction = true;
                             }
+                            RGActionRuntimeCoverageAnalysis.RecordActionUsage(inst.BaseAction, inst.TargetObject);
                         }
                         didHeuristic = true;
                     }
@@ -102,8 +104,8 @@ namespace RegressionGames.GenericBots
                 ResetState();
                 return didAnyAction;
             }
-                     
-            // Heuristic: If the last set of inputs was a mouse position movement + a set of mouse button presses, 
+
+            // Heuristic: If the last set of inputs was a mouse position movement + a set of mouse button presses,
             // then have some random chance of releasing those buttons over the same mouse position to complete a potential click event.
             // Otherwise, in general it is very unlikely that a mouse button press and release would occur over the same position.
             {
@@ -128,7 +130,7 @@ namespace RegressionGames.GenericBots
                         }
                     }
                 }
-         
+
                 if (haveMousePos && _mouseBtnsBuf.Count > 0)
                 {
                     if (Random.Range(0, 2) == 1) // 50% chance of attempting a click event
@@ -147,9 +149,9 @@ namespace RegressionGames.GenericBots
                 ResetState();
                 return didAnyAction;
             }
-                     
+
             ResetState();
-         
+
             // Compute the set of valid actions
             foreach (var actionInstance in RGActionManager.GetValidActions())
             {
@@ -163,7 +165,7 @@ namespace RegressionGames.GenericBots
                 }
                 if (!isParamValid)
                     continue;
-                         
+
                 // store the action inputs
                 var entry = new MonkeyBotActionEntry()
                 {
@@ -177,8 +179,8 @@ namespace RegressionGames.GenericBots
                     _actionsBuf.Add(entry);
                 }
             }
-         
-            // Randomly perform actions from the list 
+
+            // Randomly perform actions from the list
             // This repeatedly selects actions whose inputs do not overlap
             // with the inputs that have already been performed.
             do
@@ -192,7 +194,7 @@ namespace RegressionGames.GenericBots
                         _remainingActionsBuf.Add(action);
                     }
                 }
-         
+
                 if (_remainingActionsBuf.Count > 0)
                 {
                     var action = _remainingActionsBuf[Random.Range(0, _remainingActionsBuf.Count)];
@@ -201,7 +203,7 @@ namespace RegressionGames.GenericBots
                         inp.Perform();
                         didAnyAction = true;
                     }
-         
+                    RGActionRuntimeCoverageAnalysis.RecordActionUsage(action.ActionInstance.BaseAction, action.ActionInstance.TargetObject);
                     action.Performed = true;
                 }
             } while (_remainingActionsBuf.Count > 0);

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/MonkeyBotActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/MonkeyBotActionData.cs
@@ -30,6 +30,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             {
                 var controller = UnityEngine.Object.FindObjectOfType<BotSegmentsPlaybackController>();
                 RGActionManager.StartSession(controller, actionSettings);
+                RGActionRuntimeCoverageAnalysis.StartRecording(segmentNumber);
                 _monkey = new RGMonkeyBotLogic();
                 _monkey.ActionInterval = actionInterval;
             }
@@ -39,6 +40,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
         {
             if (!_isStopped)
             {
+                RGActionRuntimeCoverageAnalysis.SetCurrentSegmentNumber(segmentNumber);
                 bool didAnyAction = _monkey.Update();
                 error = null;
                 return didAnyAction;
@@ -50,6 +52,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
 
         public void AbortAction(int segmentNumber)
         {
+            RGActionRuntimeCoverageAnalysis.StopRecording();
             RGActionManager.StopSession();
             _isStopped = true;
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/MonkeyBotActionData.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/Models/MonkeyBotActionData.cs
@@ -29,7 +29,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             if (!_isStopped)
             {
                 var controller = UnityEngine.Object.FindObjectOfType<BotSegmentsPlaybackController>();
-                RGActionManager.StartSession(controller, actionSettings);
+                RGActionManager.StartSession(segmentNumber, controller, actionSettings);
                 RGActionRuntimeCoverageAnalysis.StartRecording(segmentNumber);
                 _monkey = new RGMonkeyBotLogic();
                 _monkey.ActionInterval = actionInterval;
@@ -41,7 +41,7 @@ namespace RegressionGames.StateRecorder.BotSegments.Models
             if (!_isStopped)
             {
                 RGActionRuntimeCoverageAnalysis.SetCurrentSegmentNumber(segmentNumber);
-                bool didAnyAction = _monkey.Update();
+                bool didAnyAction = _monkey.Update(segmentNumber);
                 error = null;
                 return didAnyAction;
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/RGGameMetadata.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/Models/RGGameMetadata.cs
@@ -2,12 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading;
 using Newtonsoft.Json;
 using RegressionGames.StateRecorder.JsonConverters;
 using UnityEngine;
-using UnityEngine.EventSystems;
-using UnityEngine.InputSystem;
 using UnityEngine.Rendering;
 
 
@@ -15,7 +12,7 @@ namespace RegressionGames.StateRecorder.Models
 {
     [Serializable]
     [JsonConverter(typeof(RGGameMetadataJsonConverter))]
-    public class RGGameMetadata
+    public class RGGameMetadata : IStringBuilderWriteable
     {
         public int apiVersion = SdkApiVersion.VERSION_21;
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -210,8 +210,15 @@ namespace RegressionGames.StateRecorder
                 RGDebug.LogInfo($"Saving action coverage metadata to file: {actionCoverageMetadataPath}");
                 using (StreamWriter sw = new StreamWriter(actionCoverageMetadataPath))
                 {
-                    string actionCoverageMetadataJson = JsonConvert.SerializeObject(actionUsageSummary, Formatting.Indented);
-                    actionCoverageMetadataTask = sw.WriteAsync(actionCoverageMetadataJson);
+                    try
+                    {
+                        string actionCoverageMetadataJson = JsonConvert.SerializeObject(actionUsageSummary, Formatting.Indented);
+                        actionCoverageMetadataTask = sw.WriteAsync(actionCoverageMetadataJson);
+                    }
+                    catch (Exception e)
+                    {
+                        RGDebug.LogException(e, "Exception writing action coverage metadata");
+                    }
                 }
             }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/SdkApiVersion.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/SdkApiVersion.cs
@@ -106,7 +106,13 @@
          */
         public const int VERSION_24 = 24;
 
+
+        /**
+         * <summary> Action analysis results</summary>
+         */
+        public const int VERSION_26 = 26;
+
         // Update this when new features are used in the SDK
-        public const int CURRENT_VERSION = VERSION_24;
+        public const int CURRENT_VERSION = VERSION_26;
     }
 }


### PR DESCRIPTION
- Adds analysis results for monkey bot action usage to bot run output
- Fixes a bug around async file writes on metadata during end recording
- slight performance improvements to metadata file conversions at end of recording

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
