### PR TITLE
[FIX] Avoid index out of bounds error when escaping chars

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/StringJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/StringJsonConverter.cs
@@ -13,8 +13,8 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
         private static readonly ThreadLocal<StringBuilder> _stringBuilder = new(() => new(5_000));
 
-        // some games use obscure chars like 'TM' which is #8xxx in the table.. don't let us get index out of bounds on something silly
-        private static readonly char[] EscapeCharReplacements = new char[32_768];
+        // non-Latin chars, and obscure cases like 'TM', don't need to be escaped, but let's avoid index out of bounds errors
+        private static readonly char[] EscapeCharReplacements = new char[char.MaxValue];
 
         static StringJsonConverter()
         {


### PR DESCRIPTION
## What is the problem?
- When attempting to record gameplay in this [Vampire Survivors Clone](https://matthiasbroske.github.io/vampire-survivors.html), an error occurs that prevents the recording from happening

## What is the solution?
- When writing our game state to JSON during gameplay recording, we get an index out of bounds error when checking if individual chars in the game state need to be escaped
- This game uses Mandarin characters, even when you use the English language setting, and these Mandarin characters were causing the index out of bounds error
- We solve this error by being able to check if a char needs to be escaped, and handling any standard Unicode character (ie: codes \u0000 to \uFFFF)
  - The `char.MaxValue` == `\uFFFF`

## LOOM-ing
https://www.loom.com/share/e4302d036acf448f9a1bc3ae3ce42393