### PR TITLE
[REG-2187] Fix compile issue when NOT using legacy input

### DIFF
--- a/src/gg.regression.unity.bots/Editor/Scripts/RGInstrumentation.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGInstrumentation.cs
@@ -14,9 +14,10 @@ using UnityEditor.Build.Reporting;
 using UnityEditor.Compilation;
 using Assembly = UnityEditor.Compilation.Assembly;
 
+using RegressionGames.StateRecorder.BotSegments;
+
 #if ENABLE_LEGACY_INPUT_MANAGER
 using RegressionGames.RGLegacyInputUtility;
-using RegressionGames.StateRecorder.BotSegments;
 #endif
 
 namespace RegressionGames.Editor


### PR DESCRIPTION
- Fixes a using issue on games not using legacy input system

- Recreated and Tested on BossRoom by updating project settings for input from 'both' to 'new only'
---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
