### PR TITLE
[REG-2044] Save/Load recording zips to default persistent path

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ReplayToolbarManager.cs
@@ -171,7 +171,7 @@ namespace RegressionGames.StateRecorder
             yield return FileBrowser.WaitForLoadDialog(
                 FileBrowser.PickMode.Files,
                 false,
-                null,
+                ScreenRecorder.stateRecordingsDirectory,
                 "bot_segments.zip",
                 "Select Replay Zip File",
                 "Load Replay"

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -136,7 +136,7 @@ namespace RegressionGames.StateRecorder
 
             if (string.IsNullOrEmpty(stateRecordingsDirectory))
             {
-                stateRecordingsDirectory = Application.temporaryCachePath+ "/RegressionGames/recordings";
+                stateRecordingsDirectory = Application.persistentDataPath + "/RegressionGames/recordings";
                 Directory.CreateDirectory(stateRecordingsDirectory);
             }
 

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/ScreenRecorder.cs
@@ -61,8 +61,8 @@ namespace RegressionGames.StateRecorder
         [Tooltip("Minimum FPS at which to capture frames if you desire more granularity in recordings.  Key frames may still be recorded more frequently than this. <= 0 will only record key frames")]
         public int recordingMinFPS;
 
-        [Tooltip("Directory to save state recordings in.  This directory will be created if it does not exist.  If not specific, this will default to 'unity_videos' in your user profile path for your operating system.")]
-        public string stateRecordingsDirectory = "";
+        [NonSerialized] // not changeable in the editor anymore
+        public static string stateRecordingsDirectory;
 
         [Tooltip("Minimize the amount of criteria in bot segment recordings.  This limits the endCriteria in recorded bot segments to only include objects with count deltas and objects that were under click locations.")]
         public bool minimizeRecordingCriteria = true;
@@ -136,7 +136,8 @@ namespace RegressionGames.StateRecorder
 
             if (string.IsNullOrEmpty(stateRecordingsDirectory))
             {
-                stateRecordingsDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) + "/unity_videos";
+                stateRecordingsDirectory = Application.temporaryCachePath+ "/RegressionGames/recordings";
+                Directory.CreateDirectory(stateRecordingsDirectory);
             }
 
             // keep this thing alive across scenes
@@ -564,13 +565,13 @@ namespace RegressionGames.StateRecorder
                 var prefix = _isReplay ? "replay" : "recording";
                 var pf = _currentSessionId.Substring(Math.Max(0, _currentSessionId.Length - 6));
                 var postfix = referenceSessionId != null ? pf + "_" + referenceSessionId.Substring(Math.Max(0, referenceSessionId.Length - 6)) : pf;
-                var dateTimeString =  DateTime.Now.ToString("MM-dd-yyyy_HH.mm");
+                var dateTimeString =  DateTime.Now.ToString("MM-dd-yyyy_HH.mm.ss");
 
                 // find the first index number we haven't used yet
                 do
                 {
                     _currentGameplaySessionDirectoryPrefix =
-                        $"{stateRecordingsDirectory}/{Application.productName}/{prefix}_{dateTimeString}_{postfix}";
+                        $"{stateRecordingsDirectory}/{prefix}_{dateTimeString}_{postfix}";
                 } while (Directory.Exists(_currentGameplaySessionDirectoryPrefix));
 
                 Directory.CreateDirectory(_currentGameplaySessionDirectoryPrefix);


### PR DESCRIPTION
- One of the next steps in moving towards the eventual removal of loading recordings from a zip file
- Saves the recording/replay data correctly to Unity's persistent path for the application
- Sets the default file path for the replay zip file loader to go to this new path
- Adds seconds to the name of the recording folders to remove ambiguity when doing multiple small recordings quickly

See doc update https://github.com/Regression-Games/RegressionDocs/pull/104

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
