### PR TITLE
[REG-2191] Speedup game action analysis

### DIFF
--- a/src/gg.regression.unity.bots/Editor/Scripts/ActionManager/RGActionAnalysis.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/ActionManager/RGActionAnalysis.cs
@@ -1528,7 +1528,7 @@ namespace RegressionGames.ActionManager
                         ++passNum;
                     } while (_unboundActionsNeedResolution);
 
-                    UpdateCodeProgress($"Performing code analysis - complete", CodeAnalysisEndProgress);
+                    UpdateCodeProgress($"Code analysis - complete", CodeAnalysisEndProgress);
                 });
 
                 // do the resource analysis in the foreground

--- a/src/gg.regression.unity.bots/Editor/Scripts/ActionManager/RGActionAnalysis.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/ActionManager/RGActionAnalysis.cs
@@ -1491,11 +1491,12 @@ namespace RegressionGames.ActionManager
                 RunResourceAnalysis();
 
                 // wait for code analysis to complete
-                NotifyProgress("Waiting for code analysis to complete", 0.95f);
+                NotifyProgress("Waiting for code analysis to complete", 0.92f);
 
                 Task.WaitAll(codeTask);
 
-                NotifyProgress("Saving analysis results", 0.98f);
+                NotifyProgress("Computing the unique action set", 0.95f);
+
 
                 // Heuristic: If a syntax node is associated with multiple MousePositionAction, remove the imprecise one that is initially added (NON_UI)
                 foreach (var entry in _rawActionsByNode)
@@ -1528,6 +1529,8 @@ namespace RegressionGames.ActionManager
                         _actions.Add(rawAction);
                     }
                 }
+
+                NotifyProgress("Saving analysis results", 0.98f);
 
                 SaveAnalysisResult();
 

--- a/src/gg.regression.unity.bots/Editor/Scripts/ActionManager/RGActionAnalysis.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/ActionManager/RGActionAnalysis.cs
@@ -1126,7 +1126,7 @@ namespace RegressionGames.ActionManager
             UpdateCodeProgress($"Code analysis (pass {passNum}) - start", startProgress);
 
             List<Task> tasks = new();
-            var completedCount = 0;
+            var completedCount = 0L;
             // ReSharper disable once LoopCanBeConvertedToQuery - task thread indexing
             for (int i = 0, targetAssembliesCount = targetAssemblies.Count; i < targetAssembliesCount; ++i)
             {
@@ -1139,7 +1139,6 @@ namespace RegressionGames.ActionManager
                     var compilation = targetAssemblies[myIndex].Item2;
                     foreach (var syntaxTree in compilation.SyntaxTrees)
                     {
-
                         _currentModel.Value = compilation.GetSemanticModel(syntaxTree);
                         _currentTree.Value = syntaxTree;
                         _assignmentExprs.Value.Clear();
@@ -1148,8 +1147,7 @@ namespace RegressionGames.ActionManager
                         Visit(root);
                     }
 
-                    ++completedCount;
-                    float progress = Mathf.Lerp(startProgress, endProgress, completedCount / (float)targetAssembliesCount);
+                    var progress = Mathf.Lerp(startProgress, endProgress, Interlocked.Increment(ref completedCount) / (float)targetAssembliesCount);
                     UpdateCodeProgress($"Code analysis (pass {passNum}) - Analyzed {targetAssemblies[myIndex].Item1.name}", progress);
                 }));
             }

--- a/src/gg.regression.unity.bots/Editor/Scripts/ActionManager/RGActionAnalysis.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/ActionManager/RGActionAnalysis.cs
@@ -1493,8 +1493,6 @@ namespace RegressionGames.ActionManager
                 // wait for code analysis to complete
                 NotifyProgress("Waiting for code analysis to complete", 0.95f);
 
-                Thread.Sleep(1000);
-
                 Task.WaitAll(codeTask);
 
                 NotifyProgress("Saving analysis results", 0.98f);


### PR DESCRIPTION
- Dramatically shortens the time required to analyze game actions
  - Loads scenes in preview instead of actually modifying the loaded scenes in the editor (this is both for performance and functional to not mess with the user's editor state)
  - Caches type field/property resolutions
  - Reduces 'new' object allocations/gc and prefers re-use
  - Fixes various code style warnings in the analysis file
  - Optimizes the multi loop code analyzer that always ran at least 2 passes to only run >1 passes when necessary
    - Confirmed with Beyond Compare text on a large customer project that before and after results are equivalent
  - Uses multithreading to run resource analysis and code analysis in parallel (also parallelizes parts of code analysis itself)
    - Still provides detailed status/cumulative-progress updates during the multithreaded operations


- I was honestly hoping to get this down to single digit seconds for ALL games so that we could include it as a compile time trigger automatically.  Sadly... that's just not possible for large games as we are limited by Unity's Main Thread access restrictions when doing game resource analysis.


- Bossroom Before (~13 sec)
![RG_ACTION_ANALYSIS_PERF_OLD](https://github.com/user-attachments/assets/aaf8c94d-81dd-49b0-999e-eef0d45df3f5)

- Bossroom After (<4 sec)
![RG_ACTION_ANALYSIS_PERF_MultiThread](https://github.com/user-attachments/assets/2322a446-602d-48e2-9db7-b91fb0a25370)

- Large Customer Project before (~120 sec)
![RG_ACTION_ANALYSIS_PERF_cust_OLD](https://github.com/user-attachments/assets/b70ff0ed-d7fd-483d-b848-a3e39c1fdd24)

- Large Customer Project after (<40 sec)
![RG_ACTION_ANALYSIS_PERF_cust_MultiThread](https://github.com/user-attachments/assets/b069178c-1899-494c-9ef4-7568fdebfd27)



---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
