### PR TITLE
[REG-2194] Improved SDK UI on mobile

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlayCanvas.prefab
+++ b/src/gg.regression.unity.bots/Runtime/Prefabs/RGOverlayCanvas.prefab
@@ -31,7 +31,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1094668923711103164}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -107,7 +106,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6927235806806861544}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -186,7 +184,6 @@ RectTransform:
   - {fileID: 8867301982941913259}
   - {fileID: 1873950661224102372}
   m_Father: {fileID: 8117107699251341521}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -275,7 +272,6 @@ RectTransform:
   - {fileID: 8117107699251341521}
   - {fileID: 5070724337647967428}
   m_Father: {fileID: 1094668923711103164}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -381,7 +377,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2586173674173139519}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -419,7 +414,8 @@ MonoBehaviour:
   m_text: Segments
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
-  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -520,7 +516,6 @@ RectTransform:
   m_Children:
   - {fileID: 2517803416891369262}
   m_Father: {fileID: 504710645255300407}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -670,7 +665,6 @@ RectTransform:
   - {fileID: 7561077974882775834}
   - {fileID: 1824198797412453037}
   m_Father: {fileID: 5224021696837641672}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -747,7 +741,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7599706311069070457}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -833,7 +826,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -986,7 +978,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1139,7 +1130,6 @@ RectTransform:
   m_Children:
   - {fileID: 266832984541047860}
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1272,7 +1262,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1310,7 +1299,8 @@ MonoBehaviour:
   m_text: Gameplay Session Uploading ...
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
-  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1427,7 +1417,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1579,7 +1568,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1094668923711103164}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -1713,7 +1701,6 @@ RectTransform:
   m_Children:
   - {fileID: 5483322438096022206}
   m_Father: {fileID: 7599706311069070457}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -1797,7 +1784,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8461864424661141685}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -1835,7 +1821,8 @@ MonoBehaviour:
   m_text: Sequences
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
-  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1933,7 +1920,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1971,7 +1957,8 @@ MonoBehaviour:
   m_text: Replay Data Loading ...
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
-  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -2086,7 +2073,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2163,7 +2149,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5630640976557725279}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2245,7 +2230,8 @@ MonoBehaviour:
     This Box Grows Updwards'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
-  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -2344,7 +2330,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2496,7 +2481,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1094668923711103164}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -2628,7 +2612,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2666,7 +2649,8 @@ MonoBehaviour:
   m_text: 21
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
-  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -2763,7 +2747,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6927235806806861544}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2839,7 +2822,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6927235806806861544}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2917,7 +2899,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3070,7 +3051,6 @@ RectTransform:
   m_Children:
   - {fileID: 7599706311069070457}
   m_Father: {fileID: 7561077974882775834}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3160,7 +3140,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2943620597921803164}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3254,7 +3233,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 9177377740776242902}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3332,7 +3310,6 @@ RectTransform:
   - {fileID: 2586173674173139519}
   - {fileID: 473555547563468943}
   m_Father: {fileID: 1094668923711103164}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -3393,7 +3370,6 @@ RectTransform:
   - {fileID: 1094668923711103164}
   - {fileID: 8701351736407767869}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -3417,7 +3393,9 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
   m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 29999
   m_TargetDisplay: 0
@@ -3479,7 +3457,8 @@ MonoBehaviour:
   gameObjectsDropdown: {fileID: 0}
   behaviorsDropdown: {fileID: 0}
   activeBotRoot: {fileID: 0}
-  rgBotEntry: {fileID: 7128609913998066405, guid: bf084db059b1b48858cdb9ab14e8e53d, type: 3}
+  rgBotEntry: {fileID: 7128609913998066405, guid: bf084db059b1b48858cdb9ab14e8e53d,
+    type: 3}
 --- !u!114 &6602689997961244080
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3494,10 +3473,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   sequencesPanel: {fileID: 3545653956877431460}
   segmentsPanel: {fileID: 1972991633119368260}
-  sequenceCardPrefab: {fileID: 4199513441948227604, guid: 1286929087b3c4db0aa7ebfeba68731c, type: 3}
-  segmentCardPrefab: {fileID: 4199513441948227604, guid: 33bc06c2f7ebd144d8e50252f54768c9, type: 3}
+  sequenceCardPrefab: {fileID: 4199513441948227604, guid: 1286929087b3c4db0aa7ebfeba68731c,
+    type: 3}
+  segmentCardPrefab: {fileID: 4199513441948227604, guid: 33bc06c2f7ebd144d8e50252f54768c9,
+    type: 3}
   sequenceEditor: {fileID: 1768688999565580427}
   deleteSequenceDialog: {fileID: 5563740331335366267}
+  recordingToolbar: {fileID: 9073394237553129601}
+  reloadButton: {fileID: 6051290809586765412}
 --- !u!114 &3883112371070943306
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3511,7 +3494,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   recordingMinFPS: 0
-  stateRecordingsDirectory: 
   minimizeRecordingCriteria: 1
   minimizeRecordingMouseMovements: 0
 --- !u!114 &4232611005985544413
@@ -3639,7 +3621,6 @@ RectTransform:
   m_Children:
   - {fileID: 985415874430226196}
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3716,7 +3697,6 @@ RectTransform:
   - {fileID: 5061430410649258493}
   - {fileID: 5716806768315515097}
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3756,7 +3736,6 @@ RectTransform:
   m_Children:
   - {fileID: 9177377740776242902}
   m_Father: {fileID: 7561077974882775834}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3882,7 +3861,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1090041802443136416}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4015,7 +3993,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 504710645255300407}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -4053,7 +4030,8 @@ MonoBehaviour:
   m_text: This overlay will close when starting a Sequence or Segment
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
-  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6, type: 2}
+  m_sharedMaterial: {fileID: 8592267718606122159, guid: 7fc1e1edc788747d3b207177e40103d6,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -4154,7 +4132,6 @@ RectTransform:
   m_Children:
   - {fileID: 7703921365364316530}
   m_Father: {fileID: 504710645255300407}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -4312,11 +4289,10 @@ RectTransform:
   - {fileID: 5789129086972528656}
   - {fileID: 6927235806806861544}
   m_Father: {fileID: 5224021696837641672}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -5, y: 10}
+  m_AnchoredPosition: {x: -10, y: 10}
   m_SizeDelta: {x: 310, y: 70}
   m_Pivot: {x: 1, y: 0}
 --- !u!114 &1784025199367272708
@@ -4403,7 +4379,6 @@ RectTransform:
   m_Children:
   - {fileID: 2717452967654519485}
   m_Father: {fileID: 5070724337647967428}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -4415,6 +4390,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 1094668923711103164}
     m_Modifications:
     - target: {fileID: 4489364121807382, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
@@ -4429,3784 +4405,4731 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -65
       objectReference: {fileID: 0}
-    - target: {fileID: 30115021444014790, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 30115021444014790, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 30115021444014790, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 30115021444014790, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 30115021444014790, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 30115021444014790, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 125
       objectReference: {fileID: 0}
-    - target: {fileID: 30115021444014790, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 30115021444014790, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -337
       objectReference: {fileID: 0}
-    - target: {fileID: 77335370782478927, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 77335370782478927, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 77335370782478927, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 77335370782478927, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 77335370782478927, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 77335370782478927, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 77335370782478927, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 77335370782478927, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 84115045780104405, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 84115045780104405, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 84115045780104405, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 84115045780104405, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 84115045780104405, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 84115045780104405, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 117.5
       objectReference: {fileID: 0}
-    - target: {fileID: 84115045780104405, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 84115045780104405, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -6
       objectReference: {fileID: 0}
-    - target: {fileID: 87384171957796238, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 87384171957796238, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 87384171957796238, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 87384171957796238, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 87384171957796238, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 87384171957796238, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 126
       objectReference: {fileID: 0}
-    - target: {fileID: 87384171957796238, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 87384171957796238, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 98339627337143294, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 98339627337143294, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 98339627337143294, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 98339627337143294, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 98339627337143294, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 98339627337143294, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 126
       objectReference: {fileID: 0}
-    - target: {fileID: 98339627337143294, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 98339627337143294, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 129190860956398542, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 129190860956398542, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 129190860956398542, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 129190860956398542, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 129190860956398542, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 129190860956398542, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 225
       objectReference: {fileID: 0}
-    - target: {fileID: 129190860956398542, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 129190860956398542, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 558
       objectReference: {fileID: 0}
-    - target: {fileID: 129190860956398542, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 129190860956398542, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 120.5
       objectReference: {fileID: 0}
-    - target: {fileID: 129190860956398542, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 129190860956398542, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -287
       objectReference: {fileID: 0}
-    - target: {fileID: 203463490328798921, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 203463490328798921, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 203463490328798921, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 203463490328798921, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 203463490328798921, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 203463490328798921, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -192
       objectReference: {fileID: 0}
-    - target: {fileID: 204130718417855833, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 204130718417855833, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 55
       objectReference: {fileID: 0}
-    - target: {fileID: 247955018416004435, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 247955018416004435, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 247955018416004435, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 247955018416004435, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 247955018416004435, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 247955018416004435, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 257590620066606733, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 257590620066606733, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 257590620066606733, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 257590620066606733, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 257590620066606733, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 257590620066606733, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 257590620066606733, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 257590620066606733, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 260321299304885537, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 260321299304885537, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 260321299304885537, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 260321299304885537, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 260321299304885537, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 260321299304885537, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 260321299304885537, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 260321299304885537, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -81
       objectReference: {fileID: 0}
-    - target: {fileID: 267687603784806310, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 267687603784806310, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 267687603784806310, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 267687603784806310, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 267687603784806310, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 267687603784806310, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -134
       objectReference: {fileID: 0}
-    - target: {fileID: 331245472229601596, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 331245472229601596, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 331245472229601596, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 331245472229601596, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 331245472229601596, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 331245472229601596, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -290
       objectReference: {fileID: 0}
-    - target: {fileID: 352213818025109303, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 352213818025109303, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 352213818025109303, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 352213818025109303, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 352213818025109303, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 352213818025109303, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 126
       objectReference: {fileID: 0}
-    - target: {fileID: 352213818025109303, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 352213818025109303, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 444379137753862658, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 444379137753862658, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 444379137753862658, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 444379137753862658, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 444379137753862658, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 444379137753862658, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 444379137753862658, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 444379137753862658, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 485213735607278569, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 485213735607278569, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 485213735607278569, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 485213735607278569, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 485213735607278569, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 485213735607278569, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 485213735607278569, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 485213735607278569, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 512626182302087506, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 512626182302087506, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 512626182302087506, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 512626182302087506, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 512626182302087506, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 512626182302087506, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -437
       objectReference: {fileID: 0}
-    - target: {fileID: 521480107203449191, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 521480107203449191, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 521480107203449191, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 521480107203449191, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 521480107203449191, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 521480107203449191, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 123.5
       objectReference: {fileID: 0}
-    - target: {fileID: 521480107203449191, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 521480107203449191, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -21
       objectReference: {fileID: 0}
-    - target: {fileID: 569917710567418167, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 569917710567418167, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 569917710567418167, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 569917710567418167, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 569917710567418167, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 569917710567418167, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 181
       objectReference: {fileID: 0}
-    - target: {fileID: 569917710567418167, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 569917710567418167, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 583609011113767133, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 583609011113767133, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 583609011113767133, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 583609011113767133, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 583609011113767133, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 583609011113767133, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 583609011113767133, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 583609011113767133, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 661130840400282561, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 661130840400282561, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 661130840400282561, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 661130840400282561, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 661130840400282561, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 661130840400282561, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 683127955022078699, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 683127955022078699, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 683127955022078699, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 683127955022078699, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 683127955022078699, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 683127955022078699, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 704607385059654815, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 704607385059654815, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 704607385059654815, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 704607385059654815, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 704607385059654815, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 704607385059654815, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 123.5
       objectReference: {fileID: 0}
-    - target: {fileID: 704607385059654815, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 704607385059654815, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -21
       objectReference: {fileID: 0}
-    - target: {fileID: 763208329488630369, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 763208329488630369, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 763208329488630369, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 763208329488630369, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 763208329488630369, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 763208329488630369, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -200
       objectReference: {fileID: 0}
-    - target: {fileID: 777774228845721264, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 777774228845721264, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 777774228845721264, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 777774228845721264, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 777774228845721264, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 777774228845721264, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 780856496766251266, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 780856496766251266, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 780856496766251266, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 780856496766251266, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 780856496766251266, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 780856496766251266, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 125
       objectReference: {fileID: 0}
-    - target: {fileID: 780856496766251266, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 780856496766251266, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -383
       objectReference: {fileID: 0}
-    - target: {fileID: 794040545167376962, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 794040545167376962, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 794040545167376962, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 794040545167376962, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 794040545167376962, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 794040545167376962, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 126
       objectReference: {fileID: 0}
-    - target: {fileID: 794040545167376962, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 794040545167376962, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 844610140676645786, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 844610140676645786, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 560
       objectReference: {fileID: 0}
-    - target: {fileID: 906312436672542037, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 906312436672542037, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 906312436672542037, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 906312436672542037, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 906312436672542037, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 906312436672542037, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 12
       objectReference: {fileID: 0}
-    - target: {fileID: 906312436672542037, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 906312436672542037, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 933406499206390999, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 933406499206390999, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 933406499206390999, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 933406499206390999, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 933406499206390999, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 933406499206390999, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -388
       objectReference: {fileID: 0}
-    - target: {fileID: 951996313412098073, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 951996313412098073, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 951996313412098073, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 951996313412098073, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 951996313412098073, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 951996313412098073, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 2.5
       objectReference: {fileID: 0}
-    - target: {fileID: 951996313412098073, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 951996313412098073, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1005393149062427372, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1005393149062427372, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1005393149062427372, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1005393149062427372, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1005393149062427372, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1005393149062427372, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 1015058812686985689, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1015058812686985689, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1015058812686985689, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1015058812686985689, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1015058812686985689, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1015058812686985689, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -410
       objectReference: {fileID: 0}
-    - target: {fileID: 1022650866000776515, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1022650866000776515, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1022650866000776515, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1022650866000776515, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1022650866000776515, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1022650866000776515, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 123.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1022650866000776515, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1022650866000776515, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -21
       objectReference: {fileID: 0}
-    - target: {fileID: 1136352430772565462, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1136352430772565462, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1136352430772565462, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1136352430772565462, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1136352430772565462, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1136352430772565462, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -388
       objectReference: {fileID: 0}
-    - target: {fileID: 1220159243891585983, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1220159243891585983, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1220159243891585983, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1220159243891585983, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1220159243891585983, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1220159243891585983, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 1220159243891585983, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1220159243891585983, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 1241122122446674274, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1241122122446674274, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1241122122446674274, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1241122122446674274, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1241122122446674274, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1241122122446674274, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 125
       objectReference: {fileID: 0}
-    - target: {fileID: 1241122122446674274, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1241122122446674274, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -107
       objectReference: {fileID: 0}
-    - target: {fileID: 1306213549485166284, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1306213549485166284, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1306213549485166284, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1306213549485166284, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1306213549485166284, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1306213549485166284, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 1306213549485166284, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1306213549485166284, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 1318347851240235196, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1318347851240235196, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1318347851240235196, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1318347851240235196, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1318347851240235196, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1318347851240235196, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 1318347851240235196, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1318347851240235196, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 1328285981023653757, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1328285981023653757, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1328285981023653757, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1328285981023653757, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1328285981023653757, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1328285981023653757, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 1328285981023653757, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1328285981023653757, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 1385629104356653617, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1385629104356653617, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1385629104356653617, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1385629104356653617, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1385629104356653617, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1385629104356653617, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -94
       objectReference: {fileID: 0}
-    - target: {fileID: 1386804125913104074, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1386804125913104074, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1386804125913104074, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1386804125913104074, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1386804125913104074, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1386804125913104074, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1483096259220272133, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1483096259220272133, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1483096259220272133, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1483096259220272133, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1483096259220272133, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1483096259220272133, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 12
       objectReference: {fileID: 0}
-    - target: {fileID: 1483096259220272133, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1483096259220272133, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 1537703756642258736, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1537703756642258736, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1537703756642258736, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1537703756642258736, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1537703756642258736, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1537703756642258736, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 1537703756642258736, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1537703756642258736, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 1558739268129681263, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1558739268129681263, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1558739268129681263, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1558739268129681263, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1558739268129681263, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1558739268129681263, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 112.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1558739268129681263, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1558739268129681263, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -246
       objectReference: {fileID: 0}
-    - target: {fileID: 1568965991232751323, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1568965991232751323, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1568965991232751323, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1568965991232751323, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1568965991232751323, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1568965991232751323, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 1568965991232751323, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1568965991232751323, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 1585385324866452366, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1585385324866452366, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1585385324866452366, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1585385324866452366, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1585385324866452366, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1585385324866452366, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 117.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1585385324866452366, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1585385324866452366, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -6
       objectReference: {fileID: 0}
-    - target: {fileID: 1585818349289657569, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1585818349289657569, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1585818349289657569, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1585818349289657569, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1585818349289657569, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1585818349289657569, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -42.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1701962130057935365, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1701962130057935365, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1701962130057935365, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1701962130057935365, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1701962130057935365, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1701962130057935365, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 1701962130057935365, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1701962130057935365, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 1712481366825139454, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1712481366825139454, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1712481366825139454, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1712481366825139454, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1712481366825139454, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1712481366825139454, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 1732535618533063130, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1732535618533063130, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1732535618533063130, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1732535618533063130, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1732535618533063130, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1732535618533063130, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 112.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1732535618533063130, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1732535618533063130, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -400.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1763505295149916016, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1763505295149916016, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1763505295149916016, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1763505295149916016, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1763505295149916016, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1763505295149916016, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 1763505295149916016, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1763505295149916016, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 1765439803952212468, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1765439803952212468, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1765439803952212468, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1765439803952212468, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1765439803952212468, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1765439803952212468, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1853996611892664125, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1853996611892664125, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1853996611892664125, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1853996611892664125, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1853996611892664125, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1853996611892664125, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 1973878864165531119, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1973878864165531119, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1973878864165531119, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1973878864165531119, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1973878864165531119, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1973878864165531119, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 1973878864165531119, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 1973878864165531119, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 2117598518535369365, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2117598518535369365, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2117598518535369365, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2117598518535369365, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2117598518535369365, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2117598518535369365, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -143
       objectReference: {fileID: 0}
-    - target: {fileID: 2143089256640224570, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2143089256640224570, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2143089256640224570, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2143089256640224570, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2143089256640224570, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2143089256640224570, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -30
       objectReference: {fileID: 0}
-    - target: {fileID: 2170721818604894310, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2170721818604894310, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2170721818604894310, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2170721818604894310, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2170721818604894310, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2170721818604894310, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 2228079383664856222, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2228079383664856222, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2228079383664856222, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2228079383664856222, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2228079383664856222, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2228079383664856222, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -437
       objectReference: {fileID: 0}
-    - target: {fileID: 2233152366543563662, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2233152366543563662, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: overlayContainer
       value: 
       objectReference: {fileID: 7029756735420670719}
-    - target: {fileID: 2251814040980116169, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2251814040980116169, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2251814040980116169, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2251814040980116169, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2251814040980116169, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2251814040980116169, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 2258853675713098347, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2258853675713098347, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2258853675713098347, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2258853675713098347, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2258853675713098347, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2258853675713098347, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2258853675713098347, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2258853675713098347, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -38
       objectReference: {fileID: 0}
-    - target: {fileID: 2267489858870464546, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2267489858870464546, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2267489858870464546, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2267489858870464546, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2267489858870464546, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2267489858870464546, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 125
       objectReference: {fileID: 0}
-    - target: {fileID: 2267489858870464546, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2267489858870464546, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -429
       objectReference: {fileID: 0}
-    - target: {fileID: 2300806456631978087, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2300806456631978087, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2300806456631978087, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2300806456631978087, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2300806456631978087, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2300806456631978087, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 181
       objectReference: {fileID: 0}
-    - target: {fileID: 2300806456631978087, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2300806456631978087, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 2303754332799187804, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2303754332799187804, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2303754332799187804, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2303754332799187804, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2303754332799187804, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2303754332799187804, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 2326912770822280407, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2326912770822280407, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2326912770822280407, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2326912770822280407, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2326912770822280407, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2326912770822280407, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -45
       objectReference: {fileID: 0}
-    - target: {fileID: 2367708116977737020, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2367708116977737020, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2367708116977737020, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2367708116977737020, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2367708116977737020, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2367708116977737020, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -486
       objectReference: {fileID: 0}
-    - target: {fileID: 2385158097636075017, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2385158097636075017, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2385158097636075017, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2385158097636075017, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2385158097636075017, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2385158097636075017, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -203
       objectReference: {fileID: 0}
-    - target: {fileID: 2444398308664522348, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2444398308664522348, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2444398308664522348, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2444398308664522348, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2444398308664522348, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2444398308664522348, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 2444398308664522348, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2444398308664522348, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 2455122730164643849, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2455122730164643849, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2455122730164643849, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2455122730164643849, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2455122730164643849, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2455122730164643849, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -404
       objectReference: {fileID: 0}
-    - target: {fileID: 2456675895653890512, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2456675895653890512, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2456675895653890512, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2456675895653890512, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2456675895653890512, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2456675895653890512, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 2479754433963900418, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2479754433963900418, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2479754433963900418, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2479754433963900418, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2479754433963900418, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2479754433963900418, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 2479754433963900418, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2479754433963900418, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 2582212326657905103, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2582212326657905103, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2582212326657905103, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2582212326657905103, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2582212326657905103, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2582212326657905103, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 2604155301919894007, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2604155301919894007, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2604155301919894007, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2604155301919894007, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2604155301919894007, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2604155301919894007, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 2604155301919894007, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2604155301919894007, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 2634833424808815480, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2634833424808815480, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2634833424808815480, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2634833424808815480, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2634833424808815480, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2634833424808815480, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 20.5
       objectReference: {fileID: 0}
-    - target: {fileID: 2634833424808815480, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2634833424808815480, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -20
       objectReference: {fileID: 0}
-    - target: {fileID: 2685849558146343064, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2685849558146343064, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2685849558146343064, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2685849558146343064, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2685849558146343064, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2685849558146343064, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 181
       objectReference: {fileID: 0}
-    - target: {fileID: 2685849558146343064, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2685849558146343064, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 2789543203456985149, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2789543203456985149, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2789543203456985149, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2789543203456985149, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2789543203456985149, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2789543203456985149, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 2789543203456985149, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2789543203456985149, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 2809958688114271528, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2809958688114271528, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2809958688114271528, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2809958688114271528, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2809958688114271528, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2809958688114271528, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 181
       objectReference: {fileID: 0}
-    - target: {fileID: 2809958688114271528, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2809958688114271528, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 2821720489114375163, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2821720489114375163, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2821720489114375163, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2821720489114375163, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2821720489114375163, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2821720489114375163, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 2858755361231068352, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2858755361231068352, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2858755361231068352, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2858755361231068352, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2858755361231068352, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2858755361231068352, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -166
       objectReference: {fileID: 0}
-    - target: {fileID: 2866394882537468592, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2866394882537468592, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2866394882537468592, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2866394882537468592, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2866394882537468592, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2866394882537468592, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -234
       objectReference: {fileID: 0}
-    - target: {fileID: 2896101278252355382, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2896101278252355382, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2896101278252355382, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2896101278252355382, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2896101278252355382, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2896101278252355382, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 2896101278252355382, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2896101278252355382, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 2947393856728721127, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2947393856728721127, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2947393856728721127, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2947393856728721127, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2947393856728721127, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2947393856728721127, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 181
       objectReference: {fileID: 0}
-    - target: {fileID: 2947393856728721127, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2947393856728721127, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 2949844792206942361, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2949844792206942361, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2949844792206942361, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2949844792206942361, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2949844792206942361, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2949844792206942361, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 2949844792206942361, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2949844792206942361, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 2969045366243343080, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2969045366243343080, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2969045366243343080, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2969045366243343080, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2969045366243343080, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2969045366243343080, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 2969045366243343080, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 2969045366243343080, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 3018154975732926576, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3018154975732926576, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3018154975732926576, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3018154975732926576, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3018154975732926576, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3018154975732926576, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 123.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3018154975732926576, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3018154975732926576, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -21
       objectReference: {fileID: 0}
-    - target: {fileID: 3027872231084616681, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3027872231084616681, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3027872231084616681, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3027872231084616681, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3027872231084616681, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3027872231084616681, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 3027872231084616681, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3027872231084616681, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 3029193201226372439, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3029193201226372439, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3029193201226372439, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3029193201226372439, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3029193201226372439, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3029193201226372439, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -42.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3122723130810400760, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3122723130810400760, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3122723130810400760, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3122723130810400760, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3122723130810400760, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3122723130810400760, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3127599251048193682, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3127599251048193682, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3127599251048193682, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3127599251048193682, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3127599251048193682, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3127599251048193682, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 3127599251048193682, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3127599251048193682, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 3165674883933869677, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3165674883933869677, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3165674883933869677, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3165674883933869677, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3165674883933869677, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3165674883933869677, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 3199381384026623327, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3199381384026623327, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3199381384026623327, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3199381384026623327, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3199381384026623327, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3199381384026623327, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 126
       objectReference: {fileID: 0}
-    - target: {fileID: 3199381384026623327, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3199381384026623327, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 3212811395144484037, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3212811395144484037, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3212811395144484037, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3212811395144484037, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3212811395144484037, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3212811395144484037, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 3218860630197044214, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3218860630197044214, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3218860630197044214, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3218860630197044214, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3218860630197044214, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3218860630197044214, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 125
       objectReference: {fileID: 0}
-    - target: {fileID: 3218860630197044214, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3218860630197044214, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -61
       objectReference: {fileID: 0}
-    - target: {fileID: 3291164635857811980, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3291164635857811980, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3291164635857811980, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3291164635857811980, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3291164635857811980, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3291164635857811980, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3311823783812664700, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3311823783812664700, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3311823783812664700, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3311823783812664700, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3311823783812664700, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3311823783812664700, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -370
       objectReference: {fileID: 0}
-    - target: {fileID: 3380071134174822371, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3380071134174822371, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3380071134174822371, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3380071134174822371, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3380071134174822371, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3380071134174822371, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -192
       objectReference: {fileID: 0}
-    - target: {fileID: 3427790084538253474, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3427790084538253474, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3427790084538253474, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3427790084538253474, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3427790084538253474, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3427790084538253474, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 123.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3427790084538253474, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3427790084538253474, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -21
       objectReference: {fileID: 0}
-    - target: {fileID: 3511611198738013431, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3511611198738013431, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3511611198738013431, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3511611198738013431, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3511611198738013431, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3511611198738013431, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 125
       objectReference: {fileID: 0}
-    - target: {fileID: 3511611198738013431, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3511611198738013431, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -291
       objectReference: {fileID: 0}
-    - target: {fileID: 3536485242179543856, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3536485242179543856, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3536485242179543856, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3536485242179543856, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3536485242179543856, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3536485242179543856, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 3536485242179543856, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3536485242179543856, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 3558662070718837907, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3558662070718837907, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3558662070718837907, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3558662070718837907, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3558662070718837907, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3558662070718837907, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 117.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3558662070718837907, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3558662070718837907, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -6
       objectReference: {fileID: 0}
-    - target: {fileID: 3617771236235289097, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3617771236235289097, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3617771236235289097, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3617771236235289097, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3617771236235289097, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3617771236235289097, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3617771236235289097, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3617771236235289097, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3643968847881988958, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3643968847881988958, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3643968847881988958, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3643968847881988958, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3643968847881988958, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3643968847881988958, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 3643968847881988958, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3643968847881988958, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 3678061572166905370, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3678061572166905370, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3678061572166905370, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3678061572166905370, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3678061572166905370, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3678061572166905370, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 125
       objectReference: {fileID: 0}
-    - target: {fileID: 3678061572166905370, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3678061572166905370, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -199
       objectReference: {fileID: 0}
-    - target: {fileID: 3687363723740831427, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3687363723740831427, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3687363723740831427, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3687363723740831427, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3687363723740831427, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3687363723740831427, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 1017
       objectReference: {fileID: 0}
-    - target: {fileID: 3687363723740831427, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3687363723740831427, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 577
       objectReference: {fileID: 0}
-    - target: {fileID: 3687363723740831427, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3687363723740831427, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 524.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3687363723740831427, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3687363723740831427, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -304.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3791481730052276291, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3791481730052276291, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3791481730052276291, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3791481730052276291, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3791481730052276291, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3791481730052276291, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -339
       objectReference: {fileID: 0}
-    - target: {fileID: 3819287859360718370, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3819287859360718370, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3819287859360718370, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3819287859360718370, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3819287859360718370, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3819287859360718370, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 350
       objectReference: {fileID: 0}
-    - target: {fileID: 3819287859360718370, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3819287859360718370, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -38
       objectReference: {fileID: 0}
-    - target: {fileID: 3855995637649192986, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3855995637649192986, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3855995637649192986, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3855995637649192986, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3855995637649192986, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3855995637649192986, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 12
       objectReference: {fileID: 0}
-    - target: {fileID: 3855995637649192986, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3855995637649192986, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 3876394009550353679, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3876394009550353679, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3876394009550353679, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3876394009550353679, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3876394009550353679, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3876394009550353679, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 3876394009550353679, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3876394009550353679, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 3900092926629035137, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3900092926629035137, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3900092926629035137, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3900092926629035137, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3900092926629035137, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3900092926629035137, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -339
       objectReference: {fileID: 0}
-    - target: {fileID: 3907937977386941866, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3907937977386941866, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3907937977386941866, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3907937977386941866, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3907937977386941866, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3907937977386941866, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 12
       objectReference: {fileID: 0}
-    - target: {fileID: 3907937977386941866, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3907937977386941866, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 3912712235540535504, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3912712235540535504, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 276.14
       objectReference: {fileID: 0}
-    - target: {fileID: 3912712235540535504, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3912712235540535504, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 43.21
       objectReference: {fileID: 0}
-    - target: {fileID: 3989648726170367173, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3989648726170367173, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3989648726170367173, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3989648726170367173, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3989648726170367173, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3989648726170367173, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 3989648726170367173, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3989648726170367173, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 3992090404843696226, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3992090404843696226, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3992090404843696226, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3992090404843696226, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3992090404843696226, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 3992090404843696226, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 4042465043493813398, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4042465043493813398, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_Name
       value: Sequence Editor
       objectReference: {fileID: 0}
-    - target: {fileID: 4042465043493813398, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4042465043493813398, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4042741396440515488, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4042741396440515488, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4042741396440515488, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4042741396440515488, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4042741396440515488, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4042741396440515488, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 4042741396440515488, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4042741396440515488, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 4077022293691431972, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4077022293691431972, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4077022293691431972, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4077022293691431972, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4077022293691431972, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4077022293691431972, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.11532384
       objectReference: {fileID: 0}
-    - target: {fileID: 4116029253153515353, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4116029253153515353, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4116029253153515353, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4116029253153515353, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4116029253153515353, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4116029253153515353, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -341
       objectReference: {fileID: 0}
-    - target: {fileID: 4141320251370026715, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4141320251370026715, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4141320251370026715, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4141320251370026715, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4141320251370026715, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4141320251370026715, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 4141320251370026715, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4141320251370026715, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_RootOrder
       value: 5
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4172012668602294237, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4172012668602294237, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4172012668602294237, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4172012668602294237, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4172012668602294237, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4172012668602294237, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4200149898977339354, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4200149898977339354, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4200149898977339354, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4200149898977339354, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4200149898977339354, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4200149898977339354, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 4200149898977339354, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4200149898977339354, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 4226592279210574713, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4226592279210574713, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4226592279210574713, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4226592279210574713, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4226592279210574713, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4226592279210574713, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4226592279210574713, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4226592279210574713, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4268085035395573039, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4268085035395573039, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4268085035395573039, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4268085035395573039, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4268085035395573039, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4268085035395573039, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 117.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4268085035395573039, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4268085035395573039, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -6
       objectReference: {fileID: 0}
-    - target: {fileID: 4273003277522735620, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4273003277522735620, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4273003277522735620, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4273003277522735620, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4273003277522735620, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4273003277522735620, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 126
       objectReference: {fileID: 0}
-    - target: {fileID: 4273003277522735620, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4273003277522735620, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 4274026643118787423, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4274026643118787423, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4274026643118787423, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4274026643118787423, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4274026643118787423, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4274026643118787423, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 117.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4274026643118787423, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4274026643118787423, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -6
       objectReference: {fileID: 0}
-    - target: {fileID: 4292547435812371883, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4292547435812371883, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4292547435812371883, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4292547435812371883, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4292547435812371883, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4292547435812371883, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 4292547435812371883, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4292547435812371883, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 4295020119809080277, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4295020119809080277, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4295020119809080277, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4295020119809080277, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4295020119809080277, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4295020119809080277, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 12
       objectReference: {fileID: 0}
-    - target: {fileID: 4295020119809080277, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4295020119809080277, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 4390486264951443393, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4390486264951443393, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4390486264951443393, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4390486264951443393, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4390486264951443393, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4390486264951443393, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 123.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4390486264951443393, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4390486264951443393, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -21
       objectReference: {fileID: 0}
-    - target: {fileID: 4412091861332618992, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4412091861332618992, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4412091861332618992, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4412091861332618992, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4412091861332618992, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4412091861332618992, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4426156168036536282, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4426156168036536282, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4426156168036536282, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4426156168036536282, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4426156168036536282, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4426156168036536282, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 4505085611890266598, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4505085611890266598, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4505085611890266598, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4505085611890266598, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4505085611890266598, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4505085611890266598, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 117.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4505085611890266598, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4505085611890266598, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -6
       objectReference: {fileID: 0}
-    - target: {fileID: 4529809092500216705, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4529809092500216705, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4529809092500216705, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4529809092500216705, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4529809092500216705, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4529809092500216705, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 4545258759768844252, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4545258759768844252, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4545258759768844252, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4545258759768844252, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4545258759768844252, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4545258759768844252, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 64.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4545258759768844252, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4545258759768844252, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -20
       objectReference: {fileID: 0}
-    - target: {fileID: 4547432178857562221, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4547432178857562221, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4547432178857562221, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4547432178857562221, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4547432178857562221, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4547432178857562221, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 4547432178857562221, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4547432178857562221, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 4690513678931962887, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4690513678931962887, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4690513678931962887, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4690513678931962887, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4690513678931962887, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4690513678931962887, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 4728737844615621475, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4728737844615621475, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4728737844615621475, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4728737844615621475, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4728737844615621475, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4728737844615621475, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -42.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4766828743738240723, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4766828743738240723, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4766828743738240723, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4766828743738240723, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4766828743738240723, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4766828743738240723, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -42.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4775895431174469971, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4775895431174469971, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4775895431174469971, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4775895431174469971, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4775895431174469971, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4775895431174469971, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 176
       objectReference: {fileID: 0}
-    - target: {fileID: 4775895431174469971, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4775895431174469971, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -321
       objectReference: {fileID: 0}
-    - target: {fileID: 4819063596728966182, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4819063596728966182, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4819063596728966182, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4819063596728966182, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4819063596728966182, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4819063596728966182, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -45
       objectReference: {fileID: 0}
-    - target: {fileID: 4846702226123712444, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4846702226123712444, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4846702226123712444, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4846702226123712444, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4846702226123712444, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4846702226123712444, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4864112806864870766, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4864112806864870766, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4864112806864870766, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4864112806864870766, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4864112806864870766, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4864112806864870766, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 117.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4864112806864870766, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4864112806864870766, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -6
       objectReference: {fileID: 0}
-    - target: {fileID: 4871179589147381957, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4871179589147381957, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4871179589147381957, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4871179589147381957, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4871179589147381957, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4871179589147381957, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 4919363145526898586, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4919363145526898586, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4919363145526898586, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4919363145526898586, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4919363145526898586, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4919363145526898586, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 4919363145526898586, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4919363145526898586, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 4950859946163183492, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4950859946163183492, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4950859946163183492, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4950859946163183492, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4950859946163183492, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4950859946163183492, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 4950859946163183492, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4950859946163183492, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 4974501804509130825, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4974501804509130825, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4974501804509130825, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4974501804509130825, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4974501804509130825, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 4974501804509130825, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5040543715760412092, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5040543715760412092, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5040543715760412092, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5040543715760412092, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5040543715760412092, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5040543715760412092, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 117.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5040543715760412092, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5040543715760412092, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -6
       objectReference: {fileID: 0}
-    - target: {fileID: 5083754474524375079, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5083754474524375079, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5083754474524375079, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5083754474524375079, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5083754474524375079, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5083754474524375079, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5166697826147890227, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5166697826147890227, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5166697826147890227, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5166697826147890227, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5166697826147890227, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5166697826147890227, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 352
       objectReference: {fileID: 0}
-    - target: {fileID: 5166697826147890227, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5166697826147890227, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 561
       objectReference: {fileID: 0}
-    - target: {fileID: 5166697826147890227, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5166697826147890227, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 825
       objectReference: {fileID: 0}
-    - target: {fileID: 5166697826147890227, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5166697826147890227, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -288.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5176041274309925380, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5176041274309925380, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5176041274309925380, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5176041274309925380, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5176041274309925380, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5176041274309925380, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 48
       objectReference: {fileID: 0}
-    - target: {fileID: 5176041274309925380, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5176041274309925380, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -20
       objectReference: {fileID: 0}
-    - target: {fileID: 5254254121217106846, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5254254121217106846, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5254254121217106846, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5254254121217106846, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5254254121217106846, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5254254121217106846, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -535
       objectReference: {fileID: 0}
-    - target: {fileID: 5270904493479099785, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5270904493479099785, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5270904493479099785, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5270904493479099785, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5270904493479099785, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5270904493479099785, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 5270904493479099785, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5270904493479099785, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 5339952742944465712, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5339952742944465712, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5339952742944465712, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5339952742944465712, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5339952742944465712, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5339952742944465712, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -64
       objectReference: {fileID: 0}
-    - target: {fileID: 5386016517325636194, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5386016517325636194, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5386016517325636194, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5386016517325636194, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5386016517325636194, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5386016517325636194, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 5386016517325636194, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5386016517325636194, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 5390158124389872711, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5390158124389872711, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5390158124389872711, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5390158124389872711, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5390158124389872711, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5390158124389872711, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 5390158124389872711, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5390158124389872711, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 5429965128184412101, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5429965128184412101, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5429965128184412101, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5429965128184412101, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5429965128184412101, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5429965128184412101, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -535
       objectReference: {fileID: 0}
-    - target: {fileID: 5491863396796674483, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5491863396796674483, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5491863396796674483, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5491863396796674483, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5491863396796674483, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5491863396796674483, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 5491863396796674483, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5491863396796674483, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 5519463783089244957, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5519463783089244957, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5519463783089244957, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5519463783089244957, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5519463783089244957, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5519463783089244957, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 5568861853753603006, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5568861853753603006, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5568861853753603006, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5568861853753603006, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5568861853753603006, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5568861853753603006, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 5568861853753603006, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5568861853753603006, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 5576592467085567394, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5576592467085567394, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5576592467085567394, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5576592467085567394, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5576592467085567394, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5576592467085567394, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5577984834215615260, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5577984834215615260, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5577984834215615260, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5577984834215615260, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5577984834215615260, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5577984834215615260, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 181
       objectReference: {fileID: 0}
-    - target: {fileID: 5577984834215615260, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5577984834215615260, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 5618542852586048676, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5618542852586048676, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5618542852586048676, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5618542852586048676, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5618542852586048676, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5618542852586048676, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 5618542852586048676, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5618542852586048676, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 5644430396891624611, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5644430396891624611, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5644430396891624611, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5644430396891624611, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5644430396891624611, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5644430396891624611, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5686548939280700271, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5686548939280700271, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5686548939280700271, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5686548939280700271, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5686548939280700271, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5686548939280700271, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 125
       objectReference: {fileID: 0}
-    - target: {fileID: 5686548939280700271, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5686548939280700271, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -245
       objectReference: {fileID: 0}
-    - target: {fileID: 5730302301586565292, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5730302301586565292, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5730302301586565292, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5730302301586565292, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5730302301586565292, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5730302301586565292, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -42.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5850751717701770817, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5850751717701770817, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5850751717701770817, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5850751717701770817, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5850751717701770817, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5850751717701770817, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 123.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5850751717701770817, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5850751717701770817, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -21
       objectReference: {fileID: 0}
-    - target: {fileID: 5861759957892968497, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5861759957892968497, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5861759957892968497, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5861759957892968497, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5861759957892968497, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5861759957892968497, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 123.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5861759957892968497, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5861759957892968497, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -21
       objectReference: {fileID: 0}
-    - target: {fileID: 5956739885965720388, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5956739885965720388, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5956739885965720388, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5956739885965720388, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5956739885965720388, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5956739885965720388, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5957912699959869375, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5957912699959869375, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5957912699959869375, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5957912699959869375, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5957912699959869375, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 5957912699959869375, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -143
       objectReference: {fileID: 0}
-    - target: {fileID: 6097813947988134477, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6097813947988134477, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6097813947988134477, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6097813947988134477, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6097813947988134477, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6097813947988134477, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 6117902980420797688, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6117902980420797688, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6117902980420797688, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6117902980420797688, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6117902980420797688, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6117902980420797688, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 123.5
       objectReference: {fileID: 0}
-    - target: {fileID: 6117902980420797688, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6117902980420797688, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -21
       objectReference: {fileID: 0}
-    - target: {fileID: 6120488409171767962, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6120488409171767962, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: overlayContainer
       value: 
       objectReference: {fileID: 7029756735420670719}
-    - target: {fileID: 6151292713048977784, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6151292713048977784, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6151292713048977784, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6151292713048977784, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6151292713048977784, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6151292713048977784, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 6182557230287648915, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6182557230287648915, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6182557230287648915, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6182557230287648915, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6182557230287648915, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6182557230287648915, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 6236444078902467295, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6236444078902467295, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6236444078902467295, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6236444078902467295, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6236444078902467295, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6236444078902467295, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 117.5
       objectReference: {fileID: 0}
-    - target: {fileID: 6236444078902467295, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6236444078902467295, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -6
       objectReference: {fileID: 0}
-    - target: {fileID: 6285005982554436264, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6285005982554436264, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6285005982554436264, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6285005982554436264, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6285005982554436264, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6285005982554436264, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 126
       objectReference: {fileID: 0}
-    - target: {fileID: 6285005982554436264, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6285005982554436264, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 6310066907093996948, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6310066907093996948, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6310066907093996948, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6310066907093996948, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6310066907093996948, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6310066907093996948, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -479
       objectReference: {fileID: 0}
-    - target: {fileID: 6325650855192150710, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6325650855192150710, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6325650855192150710, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6325650855192150710, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6325650855192150710, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6325650855192150710, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 6325650855192150710, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6325650855192150710, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 6396495503706644968, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6396495503706644968, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6396495503706644968, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6396495503706644968, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6396495503706644968, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6396495503706644968, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.10280377
       objectReference: {fileID: 0}
-    - target: {fileID: 6417685734736914561, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6417685734736914561, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6417685734736914561, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6417685734736914561, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6417685734736914561, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6417685734736914561, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -633
       objectReference: {fileID: 0}
-    - target: {fileID: 6441420351778335827, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6441420351778335827, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6441420351778335827, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6441420351778335827, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6441420351778335827, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6441420351778335827, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -132
       objectReference: {fileID: 0}
-    - target: {fileID: 6462794463485520245, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6462794463485520245, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6462794463485520245, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6462794463485520245, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6462794463485520245, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6462794463485520245, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 6462794463485520245, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6462794463485520245, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 6468079940336033616, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6468079940336033616, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6468079940336033616, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6468079940336033616, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6468079940336033616, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6468079940336033616, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 126
       objectReference: {fileID: 0}
-    - target: {fileID: 6468079940336033616, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6468079940336033616, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 6474244363453279179, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6474244363453279179, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6474244363453279179, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6474244363453279179, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6474244363453279179, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6474244363453279179, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 352
       objectReference: {fileID: 0}
-    - target: {fileID: 6474244363453279179, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6474244363453279179, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 462
       objectReference: {fileID: 0}
-    - target: {fileID: 6474244363453279179, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6474244363453279179, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 441
       objectReference: {fileID: 0}
-    - target: {fileID: 6474244363453279179, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6474244363453279179, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -239
       objectReference: {fileID: 0}
-    - target: {fileID: 6511016102994059451, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6511016102994059451, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6511016102994059451, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6511016102994059451, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6511016102994059451, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6511016102994059451, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 6511016102994059451, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6511016102994059451, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 6557389948899713421, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6557389948899713421, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6557389948899713421, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6557389948899713421, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6557389948899713421, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6557389948899713421, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 123.5
       objectReference: {fileID: 0}
-    - target: {fileID: 6557389948899713421, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6557389948899713421, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -21
       objectReference: {fileID: 0}
-    - target: {fileID: 6588323240625918887, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6588323240625918887, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6588323240625918887, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6588323240625918887, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6588323240625918887, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6588323240625918887, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 6697716499446789088, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6697716499446789088, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6697716499446789088, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6697716499446789088, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6697716499446789088, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6697716499446789088, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 6779393761168049710, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6779393761168049710, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6779393761168049710, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6779393761168049710, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6779393761168049710, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6779393761168049710, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 12
       objectReference: {fileID: 0}
-    - target: {fileID: 6779393761168049710, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6779393761168049710, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 6788427989059055244, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6788427989059055244, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6788427989059055244, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6788427989059055244, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6788427989059055244, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6788427989059055244, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 126
       objectReference: {fileID: 0}
-    - target: {fileID: 6788427989059055244, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6788427989059055244, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 6802895412626651689, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6802895412626651689, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6802895412626651689, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6802895412626651689, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6802895412626651689, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6802895412626651689, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -290
       objectReference: {fileID: 0}
-    - target: {fileID: 6810805923639480726, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6810805923639480726, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6810805923639480726, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6810805923639480726, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6810805923639480726, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6810805923639480726, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 6810805923639480726, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6810805923639480726, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 6852177013983798401, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6852177013983798401, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6852177013983798401, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6852177013983798401, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6852177013983798401, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6852177013983798401, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -98
       objectReference: {fileID: 0}
-    - target: {fileID: 6866513587730574465, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6866513587730574465, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6866513587730574465, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6866513587730574465, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6866513587730574465, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6866513587730574465, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 6866513587730574465, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6866513587730574465, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 6880254950007033323, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6880254950007033323, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6880254950007033323, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6880254950007033323, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6880254950007033323, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6880254950007033323, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 6956339239428777852, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6956339239428777852, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6956339239428777852, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6956339239428777852, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6956339239428777852, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 6956339239428777852, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -42.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7010944589376363593, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7010944589376363593, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7010944589376363593, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7010944589376363593, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7010944589376363593, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7010944589376363593, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7024732067703882376, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7024732067703882376, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7024732067703882376, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7024732067703882376, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7024732067703882376, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7024732067703882376, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 247.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7024732067703882376, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7024732067703882376, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -6.749999
       objectReference: {fileID: 0}
-    - target: {fileID: 7051216308554388898, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7051216308554388898, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7051216308554388898, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7051216308554388898, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7051216308554388898, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7051216308554388898, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7069825668023797656, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7069825668023797656, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7069825668023797656, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7069825668023797656, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7069825668023797656, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7069825668023797656, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 12
       objectReference: {fileID: 0}
-    - target: {fileID: 7069825668023797656, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7069825668023797656, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 7080720688030013249, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7080720688030013249, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_RaycastTarget
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7080720688030013249, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7080720688030013249, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_UseSpriteMesh
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7080720688030013249, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7080720688030013249, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_PreserveAspect
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7081335814271635642, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7081335814271635642, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7081335814271635642, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7081335814271635642, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7081335814271635642, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7081335814271635642, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -241
       objectReference: {fileID: 0}
-    - target: {fileID: 7164347239034604592, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7164347239034604592, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 1049
       objectReference: {fileID: 0}
-    - target: {fileID: 7164347239034604592, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7164347239034604592, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 609
       objectReference: {fileID: 0}
-    - target: {fileID: 7180193048215726465, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7180193048215726465, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7180193048215726465, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7180193048215726465, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7180193048215726465, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7180193048215726465, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 117.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7180193048215726465, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7180193048215726465, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -6
       objectReference: {fileID: 0}
-    - target: {fileID: 7210765804473045784, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7210765804473045784, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7210765804473045784, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7210765804473045784, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7210765804473045784, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7210765804473045784, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 7210765804473045784, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7210765804473045784, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 7229192940109731933, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7229192940109731933, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7229192940109731933, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7229192940109731933, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7229192940109731933, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7229192940109731933, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 117.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7229192940109731933, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7229192940109731933, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -6
       objectReference: {fileID: 0}
-    - target: {fileID: 7403002483852777077, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7403002483852777077, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7403002483852777077, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7403002483852777077, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7403002483852777077, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7403002483852777077, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 7431518413187657139, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7431518413187657139, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7431518413187657139, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7431518413187657139, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7431518413187657139, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7431518413187657139, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 7431518413187657139, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7431518413187657139, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 7558510768859012817, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7558510768859012817, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7558510768859012817, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7558510768859012817, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7558510768859012817, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7558510768859012817, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 7652598395964180341, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7652598395964180341, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7652598395964180341, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7652598395964180341, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7652598395964180341, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7652598395964180341, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 125
       objectReference: {fileID: 0}
-    - target: {fileID: 7652598395964180341, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7652598395964180341, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -153
       objectReference: {fileID: 0}
-    - target: {fileID: 7681766743012783757, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7681766743012783757, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7681766743012783757, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7681766743012783757, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7681766743012783757, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7681766743012783757, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 7681766743012783757, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7681766743012783757, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 7693851504597581453, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7693851504597581453, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7693851504597581453, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7693851504597581453, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7693851504597581453, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7693851504597581453, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -241
       objectReference: {fileID: 0}
-    - target: {fileID: 7730632265507893707, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7730632265507893707, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7730632265507893707, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7730632265507893707, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7730632265507893707, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7730632265507893707, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 123.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7730632265507893707, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7730632265507893707, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -21
       objectReference: {fileID: 0}
-    - target: {fileID: 7741049735351951578, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7741049735351951578, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7741049735351951578, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7741049735351951578, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7741049735351951578, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7741049735351951578, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 7753494466888832034, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7753494466888832034, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7753494466888832034, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7753494466888832034, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7753494466888832034, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7753494466888832034, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -272
       objectReference: {fileID: 0}
-    - target: {fileID: 7774463935147190309, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7774463935147190309, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7774463935147190309, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7774463935147190309, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7774463935147190309, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7774463935147190309, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 7774463935147190309, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7774463935147190309, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 7799312910598814585, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7799312910598814585, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7799312910598814585, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7799312910598814585, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7799312910598814585, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7799312910598814585, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -584
       objectReference: {fileID: 0}
-    - target: {fileID: 7824541253030743126, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7824541253030743126, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7824541253030743126, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7824541253030743126, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7824541253030743126, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7824541253030743126, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 176
       objectReference: {fileID: 0}
-    - target: {fileID: 7824541253030743126, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7824541253030743126, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -20
       objectReference: {fileID: 0}
-    - target: {fileID: 7826411434696489613, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7826411434696489613, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7826411434696489613, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7826411434696489613, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7826411434696489613, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7826411434696489613, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 7826411434696489613, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7826411434696489613, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 7847602860803915359, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7847602860803915359, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7847602860803915359, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7847602860803915359, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7847602860803915359, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7847602860803915359, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 7847602860803915359, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7847602860803915359, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 7848185623830490126, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7848185623830490126, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7848185623830490126, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7848185623830490126, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7848185623830490126, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7848185623830490126, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 126
       objectReference: {fileID: 0}
-    - target: {fileID: 7848185623830490126, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7848185623830490126, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 7880952190095000697, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7880952190095000697, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7880952190095000697, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7880952190095000697, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7880952190095000697, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7880952190095000697, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 117.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7880952190095000697, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7880952190095000697, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -6
       objectReference: {fileID: 0}
-    - target: {fileID: 7902151618787621115, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7902151618787621115, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7902151618787621115, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7902151618787621115, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7902151618787621115, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7902151618787621115, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 7902151618787621115, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7902151618787621115, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 7934170242872945824, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7934170242872945824, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7934170242872945824, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7934170242872945824, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7934170242872945824, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7934170242872945824, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 7934170242872945824, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7934170242872945824, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 7980773051223131924, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7980773051223131924, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7980773051223131924, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7980773051223131924, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7980773051223131924, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7980773051223131924, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 260.14
       objectReference: {fileID: 0}
-    - target: {fileID: 7980773051223131924, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7980773051223131924, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 27.21
       objectReference: {fileID: 0}
-    - target: {fileID: 7980773051223131924, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7980773051223131924, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 138.07
       objectReference: {fileID: 0}
-    - target: {fileID: 7980773051223131924, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 7980773051223131924, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -21.605
       objectReference: {fileID: 0}
-    - target: {fileID: 8004919701782828230, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8004919701782828230, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8004919701782828230, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8004919701782828230, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8004919701782828230, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8004919701782828230, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8004919701782828230, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8004919701782828230, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 81
       objectReference: {fileID: 0}
-    - target: {fileID: 8032246627525164694, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8032246627525164694, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8032246627525164694, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8032246627525164694, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8032246627525164694, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8032246627525164694, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8151185325810277752, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8151185325810277752, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8151185325810277752, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8151185325810277752, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8151185325810277752, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8151185325810277752, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 8169764946748676778, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8169764946748676778, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8169764946748676778, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8169764946748676778, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8169764946748676778, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8169764946748676778, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 181
       objectReference: {fileID: 0}
-    - target: {fileID: 8169764946748676778, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8169764946748676778, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 8199324428626115990, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8199324428626115990, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8199324428626115990, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8199324428626115990, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8199324428626115990, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8199324428626115990, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -268
       objectReference: {fileID: 0}
-    - target: {fileID: 8258254911629808918, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8258254911629808918, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8258254911629808918, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8258254911629808918, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8258254911629808918, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8258254911629808918, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 8385644836376080513, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8385644836376080513, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8385644836376080513, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8385644836376080513, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8385644836376080513, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8385644836376080513, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 8385644836376080513, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8385644836376080513, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 8424853825852650310, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8424853825852650310, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 73
       objectReference: {fileID: 0}
-    - target: {fileID: 8434720392888418614, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8434720392888418614, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8434720392888418614, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8434720392888418614, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8434720392888418614, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8434720392888418614, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8469567553629357650, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8469567553629357650, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8469567553629357650, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8469567553629357650, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8469567553629357650, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8469567553629357650, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 8516594591135269858, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8516594591135269858, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8516594591135269858, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8516594591135269858, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8516594591135269858, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8516594591135269858, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 8598736363425155725, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8598736363425155725, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8598736363425155725, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8598736363425155725, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8598736363425155725, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8598736363425155725, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 8605266563269758506, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8605266563269758506, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8605266563269758506, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8605266563269758506, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8605266563269758506, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8605266563269758506, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 8605266563269758506, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8605266563269758506, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 8615316628600618484, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8615316628600618484, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8615316628600618484, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8615316628600618484, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8615316628600618484, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8615316628600618484, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -32.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8680088375614889640, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8680088375614889640, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8680088375614889640, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8680088375614889640, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8680088375614889640, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8680088375614889640, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -486
       objectReference: {fileID: 0}
-    - target: {fileID: 8687227926982764076, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8687227926982764076, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8687227926982764076, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8687227926982764076, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8687227926982764076, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8687227926982764076, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -42.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8690175769329235223, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8690175769329235223, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8690175769329235223, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8690175769329235223, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8690175769329235223, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8690175769329235223, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 8690175769329235223, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8690175769329235223, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 8702184620453700018, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8702184620453700018, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8702184620453700018, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8702184620453700018, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8702184620453700018, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8702184620453700018, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -302
       objectReference: {fileID: 0}
-    - target: {fileID: 8737356546176888317, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8737356546176888317, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8737356546176888317, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8737356546176888317, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8737356546176888317, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8737356546176888317, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 224
       objectReference: {fileID: 0}
-    - target: {fileID: 8737356546176888317, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8737356546176888317, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 38
       objectReference: {fileID: 0}
-    - target: {fileID: 8737356546176888317, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8737356546176888317, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 112.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8737356546176888317, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8737356546176888317, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -539
       objectReference: {fileID: 0}
-    - target: {fileID: 8751093968873392275, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8751093968873392275, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8751093968873392275, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8751093968873392275, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8751093968873392275, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8751093968873392275, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 8783949143639092159, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8783949143639092159, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8783949143639092159, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8783949143639092159, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8783949143639092159, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8783949143639092159, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 126
       objectReference: {fileID: 0}
-    - target: {fileID: 8783949143639092159, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8783949143639092159, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 8809924185605691794, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8809924185605691794, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8809924185605691794, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8809924185605691794, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8809924185605691794, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8809924185605691794, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 8844462517833474130, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8844462517833474130, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_CullTransparentMesh
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8903677218956871069, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8903677218956871069, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8903677218956871069, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8903677218956871069, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8903677218956871069, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8903677218956871069, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 8958337316916194088, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8958337316916194088, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8958337316916194088, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8958337316916194088, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8958337316916194088, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8958337316916194088, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 64.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8958337316916194088, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8958337316916194088, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -20
       objectReference: {fileID: 0}
-    - target: {fileID: 8962731343690624656, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8962731343690624656, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8962731343690624656, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8962731343690624656, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8962731343690624656, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8962731343690624656, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 123.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8962731343690624656, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8962731343690624656, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -21
       objectReference: {fileID: 0}
-    - target: {fileID: 8983220153540063109, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8983220153540063109, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8983220153540063109, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8983220153540063109, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8983220153540063109, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 8983220153540063109, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -94
       objectReference: {fileID: 0}
-    - target: {fileID: 9035928253452349842, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9035928253452349842, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9035928253452349842, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9035928253452349842, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9035928253452349842, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9035928253452349842, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 9035928253452349842, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9035928253452349842, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 9041086693106963600, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9041086693106963600, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9041086693106963600, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9041086693106963600, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9041086693106963600, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9041086693106963600, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 20.5
       objectReference: {fileID: 0}
-    - target: {fileID: 9041086693106963600, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9041086693106963600, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -20
       objectReference: {fileID: 0}
-    - target: {fileID: 9066302257242451626, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9066302257242451626, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9066302257242451626, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9066302257242451626, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9066302257242451626, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9066302257242451626, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 250
       objectReference: {fileID: 0}
-    - target: {fileID: 9066302257242451626, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9066302257242451626, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 125
       objectReference: {fileID: 0}
-    - target: {fileID: 9066302257242451626, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9066302257242451626, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 9122132885086162329, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9122132885086162329, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_Value
       value: 1.0000008
       objectReference: {fileID: 0}
-    - target: {fileID: 9124126768738734240, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9124126768738734240, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_Size
       value: 0.89719623
       objectReference: {fileID: 0}
-    - target: {fileID: 9124126768738734240, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9124126768738734240, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_Value
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9140002754767807945, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9140002754767807945, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9140002754767807945, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9140002754767807945, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9140002754767807945, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9140002754767807945, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 9140002754767807945, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9140002754767807945, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 9165447478334623854, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9165447478334623854, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9165447478334623854, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9165447478334623854, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9165447478334623854, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9165447478334623854, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -336
       objectReference: {fileID: 0}
-    - target: {fileID: 9193408330584138605, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9193408330584138605, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9193408330584138605, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9193408330584138605, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9193408330584138605, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9193408330584138605, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 126
       objectReference: {fileID: 0}
-    - target: {fileID: 9193408330584138605, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9193408330584138605, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 9193991082770542908, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9193991082770542908, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9193991082770542908, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9193991082770542908, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9193991082770542908, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9193991082770542908, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 9193991082770542908, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9193991082770542908, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 9214710806144903103, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9214710806144903103, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9214710806144903103, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9214710806144903103, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9214710806144903103, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9214710806144903103, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 177
       objectReference: {fileID: 0}
-    - target: {fileID: 9214710806144903103, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+    - target: {fileID: 9214710806144903103, guid: 04ac259d13a0945ac87ddc5cac56785e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
 --- !u!1 &1768688999565580427 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 4042465043493813398, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+  m_CorrespondingSourceObject: {fileID: 4042465043493813398, guid: 04ac259d13a0945ac87ddc5cac56785e,
+    type: 3}
   m_PrefabInstance: {fileID: 2346971118752932893}
   m_PrefabAsset: {fileID: 0}
 --- !u!224 &1824198797412453037 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e, type: 3}
+  m_CorrespondingSourceObject: {fileID: 4162107705649557168, guid: 04ac259d13a0945ac87ddc5cac56785e,
+    type: 3}
   m_PrefabInstance: {fileID: 2346971118752932893}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2808644653837158682
@@ -8214,314 +9137,394 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 5224021696837641672}
     m_Modifications:
-    - target: {fileID: 210366935220034040, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 210366935220034040, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 210366935220034040, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 210366935220034040, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 210366935220034040, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 210366935220034040, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 457.37
       objectReference: {fileID: 0}
-    - target: {fileID: 513760574875140303, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 513760574875140303, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 513760574875140303, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 513760574875140303, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 513760574875140303, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 513760574875140303, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 323.13
       objectReference: {fileID: 0}
-    - target: {fileID: 513760574875140303, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 513760574875140303, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 473.37
       objectReference: {fileID: 0}
-    - target: {fileID: 1362750833803285249, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 1362750833803285249, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 133.37
       objectReference: {fileID: 0}
-    - target: {fileID: 2653587487447981162, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 2653587487447981162, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2653587487447981162, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 2653587487447981162, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2653587487447981162, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 2653587487447981162, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 796.5
       objectReference: {fileID: 0}
-    - target: {fileID: 2653587487447981162, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 2653587487447981162, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 30
       objectReference: {fileID: 0}
-    - target: {fileID: 2653587487447981162, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 2653587487447981162, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 398.25
       objectReference: {fileID: 0}
-    - target: {fileID: 2653587487447981162, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 2653587487447981162, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 2967997487976718605, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 2967997487976718605, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: overlayContainer
       value: 
       objectReference: {fileID: 7029756735420670719}
-    - target: {fileID: 4942844073237141754, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 4942844073237141754, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4942844073237141754, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 4942844073237141754, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4942844073237141754, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 4942844073237141754, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 93.37
       objectReference: {fileID: 0}
-    - target: {fileID: 4942844073237141754, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 4942844073237141754, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 78.685
       objectReference: {fileID: 0}
-    - target: {fileID: 4942844073237141754, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 4942844073237141754, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -20
       objectReference: {fileID: 0}
-    - target: {fileID: 5020629288057838675, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 5020629288057838675, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 828.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5020629288057838675, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 5020629288057838675, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 154.11
       objectReference: {fileID: 0}
-    - target: {fileID: 6448674239935938532, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6448674239935938532, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6448674239935938532, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6448674239935938532, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6448674239935938532, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6448674239935938532, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 20.5
       objectReference: {fileID: 0}
-    - target: {fileID: 6448674239935938532, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6448674239935938532, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -20
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6974553987836872862, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6974553987836872862, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6974553987836872862, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6974553987836872862, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6974553987836872862, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6974553987836872862, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 796.5
       objectReference: {fileID: 0}
-    - target: {fileID: 6974553987836872862, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6974553987836872862, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 82.11
       objectReference: {fileID: 0}
-    - target: {fileID: 6974553987836872862, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6974553987836872862, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 414.25
       objectReference: {fileID: 0}
-    - target: {fileID: 6974553987836872862, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 6974553987836872862, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -57.055
       objectReference: {fileID: 0}
-    - target: {fileID: 7572337814382127804, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 7572337814382127804, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7572337814382127804, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 7572337814382127804, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7572337814382127804, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 7572337814382127804, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 64.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7572337814382127804, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 7572337814382127804, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -20
       objectReference: {fileID: 0}
-    - target: {fileID: 7750639364715422709, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 7750639364715422709, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7750639364715422709, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 7750639364715422709, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7750639364715422709, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 7750639364715422709, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 484.25
       objectReference: {fileID: 0}
-    - target: {fileID: 7750639364715422709, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 7750639364715422709, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 20.11
       objectReference: {fileID: 0}
-    - target: {fileID: 7750639364715422709, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 7750639364715422709, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 156.125
       objectReference: {fileID: 0}
-    - target: {fileID: 7750639364715422709, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 7750639364715422709, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -46
       objectReference: {fileID: 0}
-    - target: {fileID: 7767635361911652193, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 7767635361911652193, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_Name
       value: DeleteSequenceDialog
       objectReference: {fileID: 0}
-    - target: {fileID: 7767635361911652193, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 7767635361911652193, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8355597630735644262, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 8355597630735644262, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8355597630735644262, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 8355597630735644262, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8355597630735644262, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 8355597630735644262, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 346
       objectReference: {fileID: 0}
-    - target: {fileID: 8355597630735644262, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 8355597630735644262, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -118.11
       objectReference: {fileID: 0}
-    - target: {fileID: 8559602234941710125, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 8559602234941710125, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8559602234941710125, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 8559602234941710125, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8559602234941710125, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 8559602234941710125, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 18
       objectReference: {fileID: 0}
-    - target: {fileID: 8559602234941710125, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 8559602234941710125, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -20
       objectReference: {fileID: 0}
-    - target: {fileID: 9089944729806318628, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+    - target: {fileID: 9089944729806318628, guid: b173f524aed5741e7bf7718478ebfae9,
+        type: 3}
       propertyPath: overlayContainer
       value: 
       objectReference: {fileID: 7029756735420670719}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
 --- !u!1 &5563740331335366267 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 7767635361911652193, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+  m_CorrespondingSourceObject: {fileID: 7767635361911652193, guid: b173f524aed5741e7bf7718478ebfae9,
+    type: 3}
   m_PrefabInstance: {fileID: 2808644653837158682}
   m_PrefabAsset: {fileID: 0}
 --- !u!224 &8701351736407767869 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9, type: 3}
+  m_CorrespondingSourceObject: {fileID: 6790062799219569191, guid: b173f524aed5741e7bf7718478ebfae9,
+    type: 3}
   m_PrefabInstance: {fileID: 2808644653837158682}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8127591394754714046
@@ -8529,129 +9532,167 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 8867301982941913259}
     m_Modifications:
-    - target: {fileID: 4199513441948227604, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4199513441948227604, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_Name
       value: CreateSequenceCard
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 200
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 100
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 100
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9035366199221417254, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 9035366199221417254, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9035366199221417254, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 9035366199221417254, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9035366199221417254, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 9035366199221417254, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 1644905056975458796}
-    - target: {fileID: 9035366199221417254, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 9035366199221417254, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 9035366199221417254, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 9035366199221417254, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: OnClick
       objectReference: {fileID: 0}
-    - target: {fileID: 9035366199221417254, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 9035366199221417254, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
       value: RGCreateNewSequenceButton, RegressionGames
       objectReference: {fileID: 0}
-    - target: {fileID: 9035366199221417254, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+    - target: {fileID: 9035366199221417254, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 4854958758869477337, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1644905056975458796}
   m_SourcePrefab: {fileID: 100100000, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
 --- !u!1 &3723146531997908583 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 4854958758869477337, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+  m_CorrespondingSourceObject: {fileID: 4854958758869477337, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+    type: 3}
   m_PrefabInstance: {fileID: 8127591394754714046}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &1644905056975458796
@@ -8669,6 +9710,7 @@ MonoBehaviour:
   overlayContainer: {fileID: 7029756735420670719}
 --- !u!224 &5483322438096022206 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e, type: 3}
+  m_CorrespondingSourceObject: {fileID: 4383038157323776768, guid: 2a80ebd7f472840da84a654a4fa3d09e,
+    type: 3}
   m_PrefabInstance: {fileID: 8127591394754714046}
   m_PrefabAsset: {fileID: 0}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceEntry.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceEntry.cs
@@ -102,6 +102,25 @@ public class RGSequenceEntry : MonoBehaviour
         {
             recordingDot.SetActive(false);
         }
+
+        if (RGUtils.IsMobile())
+        {
+            SetMobileView();
+        }
+    }
+
+    /**
+     * <summary>
+     * When this component is viewed on a mobile device:
+     * - Allow playing the Sequence
+     * - Disable editing, copying, or deleting the Sequence
+     * </summary>
+     */
+    public void SetMobileView()
+    {
+        RGSequenceEditor.SetButtonEnabled(false, editButton);
+        RGSequenceEditor.SetButtonEnabled(false, copyButton);
+        RGSequenceEditor.SetButtonEnabled(false, deleteButton);
     }
 
     /**

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
@@ -175,10 +175,6 @@ public class RGSequenceManager : MonoBehaviour
     public void SetPortraitView()
     {
         GetComponent<CanvasScaler>().referenceResolution = new Vector2(800, 600);
-        
-        // the create sequence button is always the first child in the sequences panel
-        var createSequenceButton = sequencesPanel.transform.GetChild(0);
-        createSequenceButton.gameObject.SetActive(false);
     }
 
     /**

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
@@ -172,7 +172,9 @@ public class RGSequenceManager : MonoBehaviour
      */
     public void UpscaleUI()
     {
-        GetComponent<CanvasScaler>().referenceResolution = new Vector2(800, 600);
+        var scaler = GetComponent<CanvasScaler>();
+        var currentResolution = scaler.referenceResolution;
+        scaler.referenceResolution = new Vector2(currentResolution.x * 0.6f, currentResolution.y * 0.6f);
     }
 
     /**

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
@@ -169,7 +169,6 @@ public class RGSequenceManager : MonoBehaviour
      * <summary>
      * When the screen is in a portrait orientation:
      * - Scale the entire canvas so that all components are larger
-     * - Hide the create Sequence button
      * </summary>
      */
     public void SetPortraitView()

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
@@ -6,6 +6,7 @@ using JetBrains.Annotations;
 using RegressionGames;
 using RegressionGames.StateRecorder;
 using UnityEngine;
+using UnityEngine.UI;
 // ReSharper disable once RedundantUsingDirective - used in #if #else - do not remove
 using RegressionGames.StateRecorder.BotSegments.Models;
 // ReSharper disable once RedundantUsingDirective - used in #if #else - do not remove
@@ -33,6 +34,8 @@ public class RGSequenceManager : MonoBehaviour
     public GameObject sequenceEditor;
 
     public GameObject deleteSequenceDialog;
+    
+    public Button reloadButton;
     
     private static RGSequenceManager _this;
 
@@ -91,6 +94,11 @@ public class RGSequenceManager : MonoBehaviour
 
     public void Start()
     {
+        if (RGUtils.IsMobile())
+        {
+            SetMobileView();
+        }
+        
         _replayToolbarManager = FindObjectOfType<ReplayToolbarManager>();
 
         // load our assets and show the Sequences tab content
@@ -133,6 +141,24 @@ public class RGSequenceManager : MonoBehaviour
         BotSequence.DeleteSequenceAtPath(path);
 
         LoadSequences();
+    }
+
+    /**
+     * <summary>
+     * When this component is viewed on a mobile device:
+     * - Scale the entire canvas so that all components are larger
+     * - Disable the reload Sequence/Segment button
+     * - Hide the create Sequence button
+     * </summary>
+     */
+    public void SetMobileView()
+    {
+        GetComponent<CanvasScaler>().referenceResolution = new Vector2(800, 600);
+        reloadButton.gameObject.SetActive(false);
+        
+        // the create sequence button is always the first child in the sequences panel
+        var createSequenceButton = sequencesPanel.transform.GetChild(0);
+        createSequenceButton.gameObject.SetActive(false);
     }
 
     /**

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
@@ -98,6 +98,10 @@ public class RGSequenceManager : MonoBehaviour
         {
             SetMobileView();
         }
+        else if (RGUtils.IsPortraitView())
+        {
+            SetPortraitView();
+        }
         
         _replayToolbarManager = FindObjectOfType<ReplayToolbarManager>();
 
@@ -155,6 +159,22 @@ public class RGSequenceManager : MonoBehaviour
     {
         GetComponent<CanvasScaler>().referenceResolution = new Vector2(800, 600);
         reloadButton.gameObject.SetActive(false);
+        
+        // the create sequence button is always the first child in the sequences panel
+        var createSequenceButton = sequencesPanel.transform.GetChild(0);
+        createSequenceButton.gameObject.SetActive(false);
+    }
+
+    /**
+     * <summary>
+     * When the screen is in a portrait orientation:
+     * - Scale the entire canvas so that all components are larger
+     * - Hide the create Sequence button
+     * </summary>
+     */
+    public void SetPortraitView()
+    {
+        GetComponent<CanvasScaler>().referenceResolution = new Vector2(800, 600);
         
         // the create sequence button is always the first child in the sequences panel
         var createSequenceButton = sequencesPanel.transform.GetChild(0);

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGOverlay/RGSequenceManager.cs
@@ -100,7 +100,7 @@ public class RGSequenceManager : MonoBehaviour
         }
         else if (RGUtils.IsPortraitView())
         {
-            SetPortraitView();
+            UpscaleUI();
         }
         
         _replayToolbarManager = FindObjectOfType<ReplayToolbarManager>();
@@ -157,7 +157,7 @@ public class RGSequenceManager : MonoBehaviour
      */
     public void SetMobileView()
     {
-        GetComponent<CanvasScaler>().referenceResolution = new Vector2(800, 600);
+        UpscaleUI();
         reloadButton.gameObject.SetActive(false);
         
         // the create sequence button is always the first child in the sequences panel
@@ -167,11 +167,10 @@ public class RGSequenceManager : MonoBehaviour
 
     /**
      * <summary>
-     * When the screen is in a portrait orientation:
-     * - Scale the entire canvas so that all components are larger
+     * Scale the entire canvas so that all components are larger
      * </summary>
      */
-    public void SetPortraitView()
+    public void UpscaleUI()
     {
         GetComponent<CanvasScaler>().referenceResolution = new Vector2(800, 600);
     }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGUtils.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGUtils.cs
@@ -15,6 +15,14 @@ namespace RegressionGames
 {
     public static class RGUtils
     {
+        // <summary>
+        // Determines if the game is currently running on an Android or Apple mobile device
+        // </summary>
+        public static bool IsMobile()
+        {
+            return Application.platform == RuntimePlatform.Android || Application.platform == RuntimePlatform.IPhonePlayer;
+        }
+        
         public static bool IsCSharpPrimitive(string typeName)
         {
             HashSet<string> primitiveTypes = new HashSet<string>

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGUtils.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGUtils.cs
@@ -16,11 +16,24 @@ namespace RegressionGames
     public static class RGUtils
     {
         // <summary>
-        // Determines if the game is currently running on an Android or Apple mobile device
+        // Determines if the game is currently running on a mobile device, or is running in the Unity Device Simulator
         // </summary>
         public static bool IsMobile()
         {
-            return Application.platform == RuntimePlatform.Android || Application.platform == RuntimePlatform.IPhonePlayer;
+            return Application.platform == RuntimePlatform.Android
+                   || Application.platform == RuntimePlatform.IPhonePlayer
+#if UNITY_EDITOR
+                   || !UnityEngine.Device.Application.isEditor
+#endif
+            ;
+        }
+        
+        // <summary>
+        // Determines if the game's viewport is in a 'portrait' orientation. (ie: height > width)
+        // </summary>
+        public static bool IsPortraitView()
+        {
+            return Screen.height > Screen.width;
         }
         
         public static bool IsCSharpPrimitive(string typeName)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/RGUtils.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/RGUtils.cs
@@ -23,7 +23,7 @@ namespace RegressionGames
             return Application.platform == RuntimePlatform.Android
                    || Application.platform == RuntimePlatform.IPhonePlayer
 #if UNITY_EDITOR
-                   || !UnityEngine.Device.Application.isEditor
+                   || !UnityEngine.Device.Application.isEditor // game is running in Unity Device Simulator
 #endif
             ;
         }


### PR DESCRIPTION
In an effort to improve our demos to potential clients building mobile games, I've made the UI a bit larger when running on a mobile device. This is definitely not a comprehensive solution, but it is a small win.  

## What has been done
- We can detect when a game is running on a mobile device, or in the Unity Device Simulator
- When on mobile or using the Unity Device Simulator:
  - Scale everything in our UI to be larger 
  - Disable the edit, copy, and delete actions for Sequences
  - Hide the 'create sequence button'. Creating or editing Sequences on mobile is too cramped
- When the Unity viewport is in a portrait orientation:
  - Scale everything in our UI to be larger 

## Screenshots
These were taken on my old OnePlus 7. Tested with both our [Match3Example](https://github.com/Regression-Games/Match3Example) game, and the [Vampire Survivors Clone](https://github.com/matthiasbroske/VampireSurvivorsClone) I was testing out recently

![Screenshot_2024-11-25-16-19-09-95_433f1a8e1986f46fa5f9eab6651a65c2](https://github.com/user-attachments/assets/85d26b0e-dc4f-4927-87d7-473ad10f6478)
![Screenshot_2024-11-25-16-12-56-27_2c16d6eb5a2ead1fd6ae640023a34bb5](https://github.com/user-attachments/assets/f5c6cbf5-2d7e-4d43-8d97-1fa5b663f8e9)
![Screenshot_2024-11-25-16-21-17-14_433f1a8e1986f46fa5f9eab6651a65c2](https://github.com/user-attachments/assets/075f7039-3c49-4703-afb0-5db1262e1a94)
