### PR TITLE
[REG-2195] Ability to easily open data recording location

### DIFF
--- a/src/gg.regression.unity.bots/Editor/Scripts/RGEditorUtils.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGEditorUtils.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using RegressionGames.StateRecorder;
+using UnityEngine;
 
 #if UNITY_EDITOR
 using RegressionGames.StateRecorder.BotSegments;
@@ -67,5 +68,18 @@ namespace RegressionGames.Editor
             }
 #endif
         }
+        
+        /// <summary>
+        /// Opens the recordings folder containing data collected by Regression Games
+        /// </summary>
+        [MenuItem("Regression Games/Open Recordings Folder")]
+        public static void OpenRecordingFolder()
+        {
+            var stateRecordingsDirectory = Application.persistentDataPath + "/RegressionGames/recordings";
+            Directory.CreateDirectory(stateRecordingsDirectory);
+            // Strangely, this is not documented in the Unity API. Forum posts say this works in Windows and Mac.
+            EditorUtility.RevealInFinder(stateRecordingsDirectory);
+        }
+        
     }
 }

--- a/src/gg.regression.unity.bots/Editor/Scripts/RGEditorUtils.cs
+++ b/src/gg.regression.unity.bots/Editor/Scripts/RGEditorUtils.cs
@@ -69,6 +69,7 @@ namespace RegressionGames.Editor
 #endif
         }
         
+#if UNITY_EDITOR
         /// <summary>
         /// Opens the recordings folder containing data collected by Regression Games
         /// </summary>
@@ -80,6 +81,7 @@ namespace RegressionGames.Editor
             // Strangely, this is not documented in the Unity API. Forum posts say this works in Windows and Mac.
             EditorUtility.RevealInFinder(stateRecordingsDirectory);
         }
+#endif
         
     }
 }


### PR DESCRIPTION
A very quick QOL improvement for both us and developers who want to dive deeper into the raw data collected by our systems - simply adds a menu item that will open the folder containing the recordings from our SDK.

<img width="754" alt="Screenshot 2024-12-01 at 4 19 06 PM" src="https://github.com/user-attachments/assets/b15b5dd4-0556-4267-8a9f-ee691d7a5c73">

I only tested this on Mac, but I have been told through my forum reading that this also works on Windows.