### PR TITLE
[REG-2193] Fixes issues with capture mouse across different game architectures

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentDirectoryParser.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/BotSegments/BotSegmentDirectoryParser.cs
@@ -68,13 +68,13 @@ namespace StateRecorder.BotSegments
         /**
          * <summary>Sort json files FROM THE SAME DIRECTORY numerically if possible, otherwise Lexicographically</summary>
          */
-        public static IOrderedEnumerable<string> OrderJsonFiles(IEnumerable<string> jsonFiles)
+        public static List<string> OrderJsonFiles(IEnumerable<string> jsonFiles)
         {
             RGDebug.LogInfo($"OrderJsonFiles - Input File List - {string.Join("\n", jsonFiles)}");
             Exception lambdaException = null;
             // sort by numeric value of entries (not string comparison of filenames) .. normalize to front slashes
             jsonFiles = jsonFiles.Where(e=>e.EndsWith(".json")).Select(e =>e = e.Replace('\\', '/'));
-            IOrderedEnumerable<string> entries;
+            List<string> entries;
             try
             {
                 // try to order the files as numbered file names
@@ -103,7 +103,7 @@ namespace StateRecorder.BotSegments
                         lambdaException = le;
                     }
                     return 0;
-                });
+                }).ToList();
                 if (lambdaException != null)
                 {
                     throw lambdaException;
@@ -112,10 +112,10 @@ namespace StateRecorder.BotSegments
             catch (Exception)
             {
                 // if filenames aren't all numbers, order lexicographically
-                entries = jsonFiles.OrderBy(e => e.Substring(0, e.IndexOf('.')));
+                entries = jsonFiles.OrderBy(e => e.Substring(0, e.IndexOf('.'))).ToList();
             }
 
-            RGDebug.LogInfo($"OrderJsonFiles - Output File List - {string.Join("\n", entries)}");
+            RGDebug.LogInfo($"OrderJsonFiles - Output File List [{entries.Count}] - {string.Join(", ", entries)}");
             return entries;
         }
 
@@ -131,7 +131,7 @@ namespace StateRecorder.BotSegments
             {
                 var filesInDirectory = Directory.GetFiles(directoryPath, "*.json", SearchOption.TopDirectoryOnly);
 
-                IOrderedEnumerable<string> entries = OrderJsonFiles(filesInDirectory);
+                var entries = OrderJsonFiles(filesInDirectory);
 
                 foreach (var entry in entries)
                 {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/StringJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/StringJsonConverter.cs
@@ -41,8 +41,8 @@ namespace RegressionGames.StateRecorder.JsonConverters
             //TestCode(); //- useful for testing
         }
 
-        // supports up to 1m char length escaped strings
-        private static readonly ThreadLocal<char[]> _bufferArray = new (() => new char[1_000_000]);
+        // supports up to 30m char length escaped strings .. this seems absolutely excessive, but when unity logs dumps out the listing of every class in every assembly as a single log message, 1m was overflowed.. even for match3 it was 6.45m
+        private static readonly ThreadLocal<char[]> _bufferArray = new (() => new char[30_000_000]);
 
         void ITypedStringBuilderConverter<string>.WriteToStringBuilder(StringBuilder stringBuilder, string val)
         {

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/StringJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/JsonConverters/StringJsonConverter.cs
@@ -70,61 +70,72 @@ namespace RegressionGames.StateRecorder.JsonConverters
 
             var startIndex = 0;
             var endIndex = 0;
-            for (var i = 0; i < inputLength; i++)
+
+            try
             {
-                var ch = input[i];
-                var escapeReplacement = EscapeCharReplacements[ch];
-                if (escapeReplacement == 0)
+                for (var i = 0; i < inputLength; i++)
                 {
-                    // don't need to escape
-                    endIndex = i + 1;
-                }
-                else
-                {
-                    // need to escape or skip.. copy existing range to result
-                    if (startIndex != endIndex)
-                    {
-                        var length = endIndex - startIndex;
-                        input.CopyTo(startIndex, bufferArray, currentNextIndex, length);
-                        currentNextIndex += length;
-                    }
 
-                    // update indexes
-                    endIndex = i + 1;
-                    startIndex = i + 1;
-
-                    if (escapeReplacement == char.MaxValue)
+                    var ch = input[i];
+                    var escapeReplacement = EscapeCharReplacements[ch];
+                    if (escapeReplacement == 0)
                     {
-                        // need to skip
+                        // don't need to escape
+                        endIndex = i + 1;
                     }
                     else
                     {
-                        // need to escape
-                        // write the escaped value to the buffer
-                        bufferArray[currentNextIndex++] = '\\';
-                        bufferArray[currentNextIndex++] = escapeReplacement;
+                        // need to escape or skip.. copy existing range to result
+                        if (startIndex != endIndex)
+                        {
+                            var length = endIndex - startIndex;
+                            input.CopyTo(startIndex, bufferArray, currentNextIndex, length);
+                            currentNextIndex += length;
+                        }
+
+                        // update indexes
+                        endIndex = i + 1;
+                        startIndex = i + 1;
+
+                        if (escapeReplacement == char.MaxValue)
+                        {
+                            // need to skip
+                        }
+                        else
+                        {
+                            // need to escape
+                            // write the escaped value to the buffer
+                            bufferArray[currentNextIndex++] = '\\';
+                            bufferArray[currentNextIndex++] = escapeReplacement;
+                        }
                     }
                 }
-            }
 
-            if (startIndex == 0)
+                if (startIndex == 0)
+                {
+                    // didn't need to escape anything.. bail out early and avoid the extra buffer string copies
+                    stringBuilder.Append("\"").Append(input).Append("\"");
+                    return; // we're done
+                }
+
+                // There MIGHT be room for some further optimization here.. CopyTo and Append both do a memcopy of the string... right now we do the partial
+                // with copyTo and then copy the full string with Append.. if we could find a way to do this with a single memcopy somehow that would be faster
+                if (startIndex != endIndex)
+                {
+                    // got to the end
+                    var length = endIndex - startIndex;
+                    input.CopyTo(startIndex, bufferArray, currentNextIndex, length);
+                    currentNextIndex += length;
+                }
+
+                bufferArray[currentNextIndex++] = '"';
+
+            }
+            catch (ArgumentOutOfRangeException)
             {
-                // didn't need to escape anything.. bail out early and avoid the extra buffer string copies
-                stringBuilder.Append("\"").Append(input).Append("\"");
-                return; // we're done
+                // if we have a buffer overflow because the string is too large (more than 30m chars)
+                RGDebug.LogWarning($"Buffer overflow while escaping json string.  Character indexes beyond {currentNextIndex} have been dropped");
             }
-
-            // There MIGHT be room for some further optimization here.. CopyTo and Append both do a memcopy of the string... right now we do the partial
-            // with copyTo and then copy the full string with Append.. if we could find a way to do this with a single memcopy somehow that would be faster
-            if (startIndex != endIndex)
-            {
-                // got to the end
-                var length = endIndex - startIndex;
-                input.CopyTo(startIndex, bufferArray, currentNextIndex, length);
-                currentNextIndex += length;
-            }
-
-            bufferArray[currentNextIndex++] = '"';
 
             stringBuilder.Append(bufferArray, 0, currentNextIndex);
         }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseEventSender.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseEventSender.cs
@@ -469,7 +469,7 @@ namespace RegressionGames.StateRecorder
             }
 
             // still have some objects we didnt' find in the current state, check previous state
-            // this is used primarly for mouse up event processing
+            // this is used primarily for mouse up event processing
             if (pathsToFind.Count > 0)
             {
                 if (priorTransforms != null)

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseInputActionObserver.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/MouseInputActionObserver.cs
@@ -225,38 +225,23 @@ namespace RegressionGames.StateRecorder
             var vec3Position = new Vector3(position.x, position.y, 0);
             List<ObjectStatus> result = new();
             maxZDepth = 0f;
-            var hitUIElement = false;
             foreach (var recordedGameObjectState in statefulObjects)
             {
                 if (recordedGameObjectState.screenSpaceBounds.HasValue)
                 {
                     if (recordedGameObjectState.screenSpaceBounds.Value.Contains(vec3Position))
                     {
-                        if (!hitUIElement && recordedGameObjectState.worldSpaceBounds != null)
+                        if (recordedGameObjectState.worldSpaceBounds != null)
                         {
                             if (recordedGameObjectState.screenSpaceZOffset > maxZDepth)
                             {
                                 maxZDepth = recordedGameObjectState.screenSpaceZOffset;
                             }
-
-                            result.Add(recordedGameObjectState);
                         }
-                        else
-                        {
-                            maxZDepth = 0f;
-                            hitUIElement = true;
-                            result.Add(recordedGameObjectState);
-                        }
+                        result.Add(recordedGameObjectState);
                     }
                 }
             }
-
-            if (hitUIElement)
-            {
-                // if we hit a UI element, ignore the in game elements
-                result.RemoveAll(a => a.worldSpaceBounds != null);
-            }
-
             return result;
         }
     }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/TransformObjectFinder.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/StateRecorder/TransformObjectFinder.cs
@@ -273,7 +273,6 @@ namespace RegressionGames.StateRecorder
 
                     if (cgEnabled)
                     {
-                        var canvasCamera = canvas.worldCamera == null ? mainCamera : canvas.worldCamera;
                         var isWorldSpace = canvas.renderMode == RenderMode.WorldSpace;
                         RectTransformsList.Clear();
                         theTransform.GetComponentsInChildren(RectTransformsList);
@@ -336,8 +335,9 @@ namespace RegressionGames.StateRecorder
                                 }
                                 else if (canvas.renderMode == RenderMode.ScreenSpaceCamera)
                                 {
-                                    min = mainCamera.WorldToScreenPoint(min);
-                                    max = mainCamera.WorldToScreenPoint(max);
+                                    var cameraToUse = canvas.worldCamera == null ? mainCamera : canvas.worldCamera;
+                                    min = cameraToUse.WorldToScreenPoint(min);
+                                    max = cameraToUse.WorldToScreenPoint(max);
                                 }
                                 else // if (canvas.renderMode == RenderMode.ScreenSpaceOverlay)
                                 {
@@ -346,7 +346,7 @@ namespace RegressionGames.StateRecorder
                             }
 
                             var onCamera = true;
-                            if (isWorldSpace || canvasCamera != mainCamera)
+                            if (isWorldSpace || canvas.renderMode == RenderMode.ScreenSpaceCamera)
                             {
                                 var xLowerLimit = 0;
                                 var xUpperLimit = screenWidth;
@@ -577,8 +577,8 @@ namespace RegressionGames.StateRecorder
             var canvasRenderersLength = canvasRenderers.Length;
             for (var j = 0; j < canvasRenderersLength; j++)
             {
-                var canvasRenderer = canvasRenderers[j];
-                var statefulUiObjectTransform = ((CanvasRenderer)canvasRenderer).transform;
+                var canvasRenderer = (CanvasRenderer)canvasRenderers[j];
+                var statefulUiObjectTransform = canvasRenderer.transform;
                 if (statefulUiObjectTransform != null && statefulUiObjectTransform.GetComponentInParent<RGExcludeFromState>() == null)
                 {
                     var tStatus = TransformStatus.GetOrCreateTransformStatus(statefulUiObjectTransform);


### PR DESCRIPTION
- Fixes (makes less likely) / catches a string json escaping buffer overflow bug during log capture on some games
- Updates mouse observation to record all objects at a point, not just UI objects if a UI object is hit
- Fixes a case where URP with multiple cameras (base + N overlays) wasn't considering the screenSpace correctly for overlay cameras

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
