### PR TITLE
[REG-2222] Support creating and editing segments through the dashboard app 

### DIFF
--- a/src/gg.regression.unity.bots/Runtime/Scripts/ClientDashboard/RGTcpServer.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/ClientDashboard/RGTcpServer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
@@ -313,91 +314,120 @@ namespace RegressionGames.ClientDashboard
         
         /// <summary>
         /// Decode message from client so we can process it
+        /// https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers#exchanging_data_frames
         /// https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_server#decoding_messages
         /// </summary>
         private static string DecodeReceivedMessage(TcpClient client)
         {
-            byte[] bytes = new byte[client.Available];
-            client.GetStream().Read(bytes, 0, bytes.Length);
-            
-            // whether the full message has been sent from the client
-            // currently not used here, but may need to consider partial frames
-            // if we end up accepting large messages from client
-            bool fin = (bytes[0] & 0b10000000) != 0;
-            
-            // must be true, "All messages from the client to the server have this bit set"
-            bool mask = (bytes[1] & 0b10000000) != 0;
-            int opcode = bytes[0] & 0b00001111;
+            var clientStream = client.GetStream();
+            var decodedBytes = new List<byte>();
 
-            if (opcode == 8)
+            while (client.Connected)
             {
-                // this is a close frame
-                if (m_connectedClients.TryGetValue(client, out var clientActions))
+                if (client.Available == 0)
                 {
-                    clientActions.ShouldClose = true;
+                    // we check this condition before calling this method,
+                    // but we may be waiting on a continuation frame here
+                    continue;
                 }
-                return null;
-            }
-            
-            if (opcode != 1)
-            {
-                // not a text message
-                return null;
-            }
-            
-            ulong offset = 2;
-            ulong msglen = bytes[1] & (ulong)0b01111111;
-
-            if (msglen == 126)
-            {
-                // bytes are reversed because websocket will print them in Big-Endian, whereas
-                // BitConverter will want them arranged in little-endian on windows
-                msglen = BitConverter.ToUInt16(new byte[] { bytes[3], bytes[2] }, 0);
-                offset = 4;
-            }
-            else if (msglen == 127)
-            {
-                // To test the below code, we need to manually buffer larger messages — since the NIC's autobuffering
-                // may be too latency-friendly for this code to run (that is, we may have only some of the bytes in this
-                // websocket frame available through client.Available).
-                msglen = BitConverter.ToUInt64(new byte[] {
-                        bytes[9], bytes[8], bytes[7], bytes[6], bytes[5], bytes[4], bytes[3], bytes[2]
-                    }, 0);
-                offset = 10;
-            }
-
-            if (msglen > 0 && mask)
-            {
-                byte[] decoded = new byte[msglen];
-                byte[] masks = new byte[4] { bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3] };
-                offset += 4;
                 
-                if ((int)msglen > bytes.Length)
+                // read the first byte of the message
+                // bit 0 -> fin, whether the full message has been received
+                // bit 1-3 -> reserved, we don't care about this right now
+                // bit 4-7 -> opcode, the type of message
+                var firstByte = (byte)clientStream.ReadByte();
+                bool fin = (firstByte & 0b10000000) != 0;
+                int frameOpcode = firstByte & 0b00001111;
+                
+                switch (frameOpcode)
                 {
-                    var buffer = new List<byte>();
-                    buffer.AddRange(bytes);
-                    while (buffer.Count < (int)msglen)
+                    case 0x0: // Continuation Frame
+                    case 0x1: // Text
+                    case 0x2: // Binary  
+                        break;
+                    case 0x8: // Connection close
                     {
-                        byte[] temp = new byte[client.Available];
-                        client.GetStream().Read(temp, 0, temp.Length);
-                        buffer.AddRange(temp);
+                        if (m_connectedClients.TryGetValue(client, out var clientActions))
+                        {
+                            clientActions.ShouldClose = true;
+                        }
+                        return null;
                     }
-                    
-                    for (ulong i = 0; i < msglen; ++i)
-                    {
-                        decoded[i] = (byte)(buffer.ElementAt((int)offset + (int)i) ^ masks[i % 4]);
-                    }
+                    default:  // Ping/Pong/Reserved
+                        continue;
                 }
-                else
+                
+                // read the second byte of the message
+                // bit 0 -> mask, should be true for client > server messages
+                // bit 1-7 -> payload length
+                var secondByte = (byte)clientStream.ReadByte();
+                bool mask = (secondByte & 0b10000000) != 0;
+                var psuedoLength = secondByte - 128;
+
+                // to get the actual length of the payload, we need to interpret the psuedo length from the header
+                int payloadLength = 0;
+
+                if (psuedoLength > 0 && psuedoLength <= 125)
                 {
-                    for (ulong i = 0; i < msglen; ++i)
-                    {
-                        decoded[i] = (byte)(bytes[offset + i] ^ masks[i % 4]);
-                    }
+                    // if length doesn't exceed 125,
+                    // then this is the actual length of the payload
+                    payloadLength = psuedoLength;
+                }
+                else if (psuedoLength == 126)
+                {
+                    // Actual length will be the next 2 bytes
+                    var lengthBytes = new byte[2];
+                    clientStream.Read(lengthBytes, 0, lengthBytes.Length);
+                    
+                    // bytes are reversed because websocket will print them in Big-Endian, whereas
+                    // BitConverter will want them arranged in little-endian on windows
+                    payloadLength = BitConverter.ToUInt16(new byte[] { lengthBytes[1], lengthBytes[0] }, 0);
+                } 
+                else if (psuedoLength == 127)
+                {
+                    // Actual length will be the next 8 bytes
+                    var lengthBytes = new byte[8];
+                    clientStream.Read(lengthBytes, 0, lengthBytes.Length);
+                    
+                    // bytes are reversed because websocket will print them in Big-Endian, whereas
+                    // BitConverter will want them arranged in little-endian on windows
+                    payloadLength = (int)BitConverter.ToUInt64(new byte[] {
+                        lengthBytes[7], lengthBytes[6], lengthBytes[5], lengthBytes[4],
+                        lengthBytes[3], lengthBytes[2], lengthBytes[1], lengthBytes[0]
+                    }, 0);
                 }
 
-                string decodedMessage = Encoding.UTF8.GetString(decoded);
-                return decodedMessage;
+                // for now we're assuming client-sent messages are masked
+                // determine the masking key from the next 4 bytes
+                // this will be used to decode the message
+                var maskingKey = new byte[4];
+                clientStream.Read(maskingKey, 0, maskingKey.Length);
+                
+                if (payloadLength == 0)
+                {
+                    // no payload, so we're done
+                    return null;
+                }
+                
+                // read the payload
+                // and decode it using the masking key
+                var payload = new byte[payloadLength];
+                clientStream.Read(payload, 0, payloadLength);
+                
+                for (int i = 0; i < payload.Length; ++i)
+                {
+                    decodedBytes.Add((byte)(payload[i] ^ maskingKey[i % 4]));
+                }
+
+                if (!fin)
+                {
+                    // if this isn't the complete message,
+                    // then we need to wait for the continuation frame
+                    continue;
+                }
+                
+                // we have the full message, so return it as a string
+                return Encoding.UTF8.GetString(decodedBytes.ToArray());
             }
 
             return null;

--- a/src/gg.regression.unity.bots/Runtime/Scripts/ClientDashboard/TcpMessage.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/ClientDashboard/TcpMessage.cs
@@ -10,39 +10,6 @@ using RegressionGames.StateRecorder.JsonConverters;
 
 namespace RegressionGames.ClientDashboard
 {
-    public enum TcpMessageType
-    {
-        // =====================
-        // client -> server
-        // =====================
-        
-        Ping,
-        
-        // client requests to play a resource with the given resourcePath
-        PlaySequence,
-        PlaySegment,
-        
-        // stops any currently-running sequence/segments
-        StopReplay,
-        
-        // =====================
-        // server -> client
-        // =====================
-        
-        Pong,
-        
-        // info about the available file-based resources for this game instance
-        AvailableSequences,
-        AvailableSegments,
-        
-        // info about the currently-running sequence (or segment)
-        ActiveSequence,
-        
-        // sent prior to closing Unity windows.
-        // this tells any running client windows to also close.
-        CloseConnection
-    }
-
     public interface ITcpMessageData : IStringBuilderWriteable { }
     
     /// <summary>
@@ -148,6 +115,8 @@ namespace RegressionGames.ClientDashboard
                 IntJsonConverter.WriteToStringBuilder(stringBuilder, currentSegment.apiVersion);
                 
                 // not normally serialized
+                stringBuilder.Append(",\"path\":");
+                StringJsonConverter.WriteToStringBuilder(stringBuilder, currentSegment.path);
                 stringBuilder.Append(",\"resourcePath\":");
                 StringJsonConverter.WriteToStringBuilder(stringBuilder, currentSegment.resourcePath);
                 stringBuilder.Append(",\"type\":");
@@ -177,6 +146,93 @@ namespace RegressionGames.ClientDashboard
     
     [Serializable]
     public class PlayResourceTcpMessageData : ITcpMessageData
+    {
+        public string resourcePath;
+        
+        public void WriteToStringBuilder(StringBuilder stringBuilder)
+        {
+            stringBuilder.Append("{\"resourcePath\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, resourcePath);
+            stringBuilder.Append("}");
+        }
+        
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder(1000);
+            WriteToStringBuilder(sb);
+            return sb.ToString();
+        }
+    }
+    
+    [Serializable]
+    public class RequestResourceContentsTcpMessageData : ITcpMessageData
+    {
+        public string resourcePath;
+        
+        public void WriteToStringBuilder(StringBuilder stringBuilder)
+        {
+            stringBuilder.Append("{\"resourcePath\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, resourcePath);
+            stringBuilder.Append("}");
+        }
+        
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder(1000);
+            WriteToStringBuilder(sb);
+            return sb.ToString();
+        }
+    }
+    
+    [Serializable]
+    public class SendJsonTcpMessageData : ITcpMessageData
+    {
+        /**
+         * The JSON object to send.
+         * This should be a string that has already been serialized using a WriteToStringBuilder implementation
+         */
+        public string jsonContent;
+        
+        public void WriteToStringBuilder(StringBuilder stringBuilder)
+        {
+            stringBuilder.Append("{\"jsonObject\":");
+            stringBuilder.Append(jsonContent); 
+            stringBuilder.Append("}");
+        }
+        
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder(1000);
+            WriteToStringBuilder(sb);
+            return sb.ToString();
+        }
+    }
+
+    [Serializable]
+    public class SaveSegmentListTcpMessageData : ITcpMessageData
+    {
+        public BotSegmentList segmentList;
+        [CanBeNull] public string resourcePath;
+        
+        public void WriteToStringBuilder(StringBuilder stringBuilder)
+        {
+            stringBuilder.Append("{\"segmentList\":");
+            segmentList.WriteToStringBuilder(stringBuilder);
+            stringBuilder.Append(",\"resourcePath\":");
+            StringJsonConverter.WriteToStringBuilder(stringBuilder, resourcePath);
+            stringBuilder.Append("}");
+        }
+        
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder(1000);
+            WriteToStringBuilder(sb);
+            return sb.ToString();
+        }
+    }
+    
+    [Serializable]
+    public class DeleteSegmentTcpMessageData : ITcpMessageData
     {
         public string resourcePath;
         

--- a/src/gg.regression.unity.bots/Runtime/Scripts/ClientDashboard/TcpMessageDataJsonConverter.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/ClientDashboard/TcpMessageDataJsonConverter.cs
@@ -39,6 +39,16 @@ namespace RegressionGames.ClientDashboard
                 case TcpMessageType.PlaySegment:
                     payload = jObject["payload"].ToObject<PlayResourceTcpMessageData>(serializer);
                     break;
+                case TcpMessageType.RequestSequenceJson:
+                case TcpMessageType.RequestSegmentJson:
+                    payload = jObject["payload"].ToObject<RequestResourceContentsTcpMessageData>(serializer);
+                    break;
+                case TcpMessageType.SaveSegment:
+                    payload = jObject["payload"].ToObject<SaveSegmentListTcpMessageData>(serializer);
+                    break;
+                case TcpMessageType.DeleteSegment:
+                    payload = jObject["payload"].ToObject<DeleteSegmentTcpMessageData>(serializer);
+                    break;
                 default:
                     throw new JsonSerializationException($"Unsupported TcpMessage type: '{message.type}'");
             }

--- a/src/gg.regression.unity.bots/Runtime/Scripts/ClientDashboard/TcpMessageType.cs
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/ClientDashboard/TcpMessageType.cs
@@ -1,0 +1,46 @@
+namespace RegressionGames.ClientDashboard
+{
+    public enum TcpMessageType
+    {
+        // =====================
+        // client -> server
+        // =====================
+        
+        Ping,
+        
+        // client requests to play a resource with the given resourcePath
+        PlaySequence,
+        PlaySegment,
+        
+        // stops any currently-running sequence/segments
+        StopReplay,
+        
+        // request JSON contents for a file-based resource
+        RequestSequenceJson,
+        RequestSegmentJson,
+        
+        SaveSegment,
+        DeleteSegment,
+        
+        // =====================
+        // server -> client
+        // =====================
+        
+        Pong,
+        
+        // info about the available file-based resources for this game instance
+        AvailableSequences,
+        AvailableSegments,
+        
+        // info about the currently-running sequence (or segment)
+        ActiveSequence,
+        
+        // send JSON contents for a file-based resource
+        SendSequenceJson,
+        SendSegmentJson,
+        
+        // sent prior to closing Unity windows.
+        // this tells any running client windows to also close.
+        CloseConnection
+    }
+}

--- a/src/gg.regression.unity.bots/Runtime/Scripts/ClientDashboard/TcpMessageType.cs.meta
+++ b/src/gg.regression.unity.bots/Runtime/Scripts/ClientDashboard/TcpMessageType.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1f292d14db764738aaa5d7865ab4f116
+timeCreated: 1734370041


### PR DESCRIPTION
## What has been done
* Added TCP message types for the client to request a specific segment and overwrite the contents of a specific segment using its `resourcePath`
* Helper methods added to `BotSegment` to facilitate reading + writing segment files
* Reworked TCPServer logic to properly handle fragmented messages

## Out of scope
* Creating new BotSequences and viewing/editing the contents of BotSequences
* server ack on segment save -> I want to do this but ran out of time before the holiday break

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
